### PR TITLE
Add redirect proxy for legacy URLs

### DIFF
--- a/app/proxy.ts
+++ b/app/proxy.ts
@@ -1,0 +1,49 @@
+import { allPages } from 'content-collections';
+// Single source of truth for static redirects: the legacy Netlify `_redirects`
+// file, inlined as a string at build time by Vite. Format is "<from>  <to>" per
+// line (extra whitespace and blank lines are ignored).
+import redirectsFile from '../static/_redirects?raw';
+
+// Collapse "/x" and "/x/" to one key so either form matches. Root is left alone.
+function normalize(path: string): string {
+    return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
+// Built once per cold start; every request is then a single Map lookup, no async.
+const redirectMap = new Map<string, string>();
+
+for (const line of redirectsFile.split('\n')) {
+    const [from, to] = line.trim().split(/\s+/);
+    if (from && to) redirectMap.set(normalize(from), to);
+}
+
+// redirect_from frontmatter → canonical article path. Static entries win on
+// collision, so only fill in keys the static file didn't already claim.
+for (const page of allPages) {
+    if (!page.redirect_from?.length) continue;
+    const canonical = `/${page._meta.path.replace(/\/index$/, '')}`;
+    for (const from of page.redirect_from) {
+        const key = normalize(from.startsWith('/') ? from : `/${from}`);
+        if (!redirectMap.has(key)) redirectMap.set(key, canonical);
+    }
+}
+
+export default async function proxy(req: Request, next: () => Promise<Response>) {
+    const url = new URL(req.url);
+    let path = url.pathname;
+    // pathname is percent-encoded; map keys use literal characters (incl. emoji),
+    // so decode before lookup. Fall back to the raw path on malformed input.
+    try {
+        path = decodeURIComponent(path);
+    } catch {
+        /* keep the raw pathname */
+    }
+
+    const target = redirectMap.get(normalize(path));
+    if (target) {
+        const dest = target.startsWith('http') ? target : new URL(target, url.origin).href;
+        return Response.redirect(dest, 301);
+    }
+
+    return next();
+}


### PR DESCRIPTION
## Summary

- Adds `app/proxy.ts` — TimberJS global middleware that runs on every request before routing
- Handles 301 redirects for all legacy URLs so 15 years of links stay alive
- Two sources of redirects, both handled at startup with zero per-request cost:
  1. **Static redirects** (49 entries from `static/_redirects`): external redirects to reactfordataviz.com, serverlesshandbook.dev, scalingfastbook.com, plus internal slug fixes
  2. **Frontmatter redirects** (1507 blog posts): `redirect_from` arrays in MDX frontmatter loaded via content-collections at module init time
- Trailing-slash variants registered automatically for both sources
- Returns HTTP 301 (permanent) for all matches

## How it works

`allPages` from content-collections is a build-time bundle — at cold start, the proxy builds a `Map<string, string>` once and every request is just a `Map.get()` lookup with no async work.


---
_Generated by [Claude Code](https://claude.ai/code/session_018xgWPeghNLM7kKYKUTH92L)_