### PR TITLE
Add newsletter signup with Kit content upgrades

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -3,6 +3,7 @@ import { deny, getSegmentParams } from "@timber-js/app/server";
 import type { Metadata } from "@timber-js/app/server";
 import type React from "react";
 import { metadataFromFrontmatter } from "../mdx-metadata";
+import { NewsletterSignup } from "../../components/newsletter-signup";
 import { RelatedArticles } from "../../components/related-articles";
 
 // Vite glob: all MDX in pages/, compiled as ES modules via @mdx-js/rollup (RSC-compatible)
@@ -69,6 +70,7 @@ export default async function Page() {
                 </time>
             )}
             <MDXContent />
+            <NewsletterSignup formKey={page.content_upgrade ?? undefined} />
             <RelatedArticles url={articleUrl} />
         </article>
     );

--- a/app/actions/subscribe.ts
+++ b/app/actions/subscribe.ts
@@ -1,0 +1,85 @@
+'use server';
+
+import { createActionClient, ActionError } from '@timber-js/app/server';
+import { z } from 'zod';
+import { getNewsletterForm } from '../../lib/newsletter-forms';
+
+const action = createActionClient();
+
+const KIT_API = 'https://api.kit.com/v4';
+
+async function kitPost(path: string, body: Record<string, unknown>) {
+    const apiKey = process.env.CONVERTKIT_APIKEY_V4;
+    if (!apiKey) {
+        console.error('CONVERTKIT_APIKEY_V4 is not set');
+        throw new ActionError('KIT_ERROR');
+    }
+
+    const response = await fetch(`${KIT_API}${path}`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json; charset="utf-8"',
+            'X-Kit-Api-Key': apiKey,
+        },
+        body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+        console.error(`Kit API ${path} failed: ${response.status} ${response.statusText}`);
+        throw new ActionError('KIT_ERROR');
+    }
+
+    return response;
+}
+
+// Bots fill hidden fields and submit literal "null" values; humans can't —
+// the honeypot is invisible and both real fields are required in the UI.
+// Missing/absent fields never reach the action body: schema validation
+// rejects them first, so nothing gets subscribed on those either.
+function isBot(input: { email: string; first_name: string; website?: string }) {
+    if (input.website) return true;
+    if (input.email.trim().toLowerCase() === 'null') return true;
+    if (input.first_name.trim().toLowerCase() === 'null') return true;
+    return false;
+}
+
+export const subscribe = action
+    .schema(
+        z.object({
+            email: z.email("That doesn't look like an email address"),
+            first_name: z.string().trim().min(1, 'What should I call you?'),
+            // Honeypot — hidden from humans, bots fill it
+            website: z.string().optional(),
+            // Which Kit form to use; resolved server-side so form IDs stay ours
+            form_key: z.string().optional(),
+        })
+    )
+    .action(async ({ input }) => {
+        // Pretend success so bots can't tell they were filtered
+        if (isBot(input)) {
+            return { subscribed: true };
+        }
+
+        const form = getNewsletterForm(input.form_key);
+
+        // Same two-step Kit v4 flow as the old site (src/api/subscribe-ck.js
+        // on master): create an inactive subscriber, then attach them to the
+        // form. The form subscription sends the confirmation email and
+        // triggers that form's automation.
+        await kitPost('/subscribers', {
+            email_address: input.email,
+            first_name: input.first_name,
+            state: 'inactive',
+            fields: {
+                'Last name': '',
+                Birthday: '1970-01-01',
+                Source: 'swizec.com',
+            },
+        });
+
+        await kitPost(`/forms/${form.formId}/subscribers`, {
+            email_address: input.email,
+        });
+
+        return { subscribed: true };
+    });

--- a/app/styles.css
+++ b/app/styles.css
@@ -109,3 +109,80 @@ code.shiki {
   max-width: 100%;
   height: auto;
 }
+
+/* Newsletter signup */
+.newsletter-signup {
+  border: 2px solid #f0a500;
+  border-radius: 10px;
+  margin: 2.5rem 0;
+  padding: 1.5rem;
+}
+
+.newsletter-signup h3 {
+  margin-top: 0;
+}
+
+.newsletter-signup form {
+  align-items: stretch;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.newsletter-signup input[type='text'],
+.newsletter-signup input[type='email'] {
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  flex: 1 1 180px;
+  font-size: 1rem;
+  padding: 0.6rem 0.8rem;
+}
+
+.newsletter-signup button {
+  background: #f0a500;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  flex: 0 1 auto;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.6rem 1.2rem;
+}
+
+.newsletter-signup button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+/* Honeypot: moved off-screen, not display:none, so naive bots still fill it */
+.newsletter-signup-honeypot {
+  height: 1px;
+  left: -9999px;
+  overflow: hidden;
+  position: absolute;
+  width: 1px;
+}
+
+.newsletter-signup-error {
+  color: #b00020;
+  flex-basis: 100%;
+  margin: 0;
+}
+
+.newsletter-signup-spinner {
+  animation: newsletter-spin 0.6s linear infinite;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  border-right-color: transparent;
+  display: inline-block;
+  height: 0.9em;
+  margin-right: 0.4em;
+  vertical-align: -0.1em;
+  width: 0.9em;
+}
+
+@keyframes newsletter-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/components/newsletter-signup.tsx
+++ b/components/newsletter-signup.tsx
@@ -22,9 +22,9 @@ export function NewsletterSignup({ formKey }: NewsletterSignupProps) {
             <aside className="newsletter-signup newsletter-signup-success">
                 <h3>One more step — confirm your email 💌</h3>
                 <p>
-                    I just sent a confirmation link to your inbox. Click it and you're in! Nothing
-                    arriving? Check your spam or promotions folder — or email{' '}
-                    <a href="mailto:swizec@swizec.com">swizec@swizec.com</a> and I'll sort you out.
+                    I just sent a confirmation link to your inbox. Click that and you're in! Don't
+                    see an email? Check your spam or promotions folder – or email{' '}
+                    <a href="mailto:hi@swizec.com">hi@swizec.com</a> and I'll sort you out.
                 </p>
             </aside>
         );
@@ -91,7 +91,7 @@ export function NewsletterSignup({ formKey }: NewsletterSignupProps) {
                     <p role="alert" className="newsletter-signup-error">
                         Ouch — the subscription didn't go through. That's my email service
                         hiccuping, not you. Give it another try in a few seconds, or email{' '}
-                        <a href="mailto:swizec@swizec.com">swizec@swizec.com</a> and I'll add you by
+                        <a href="mailto:hi@swizec.com">hi@swizec.com</a> and I'll add you by
                         hand.
                     </p>
                 )}

--- a/components/newsletter-signup.tsx
+++ b/components/newsletter-signup.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useActionState } from '@timber-js/app/client';
+import { subscribe } from '../app/actions/subscribe';
+import { getNewsletterForm } from '../lib/newsletter-forms';
+
+interface NewsletterSignupProps {
+    /** content_upgrade frontmatter value; omit for the default newsletter */
+    formKey?: string;
+}
+
+export function NewsletterSignup({ formKey }: NewsletterSignupProps) {
+    const form = getNewsletterForm(formKey);
+    const [state, action, pending, errors] = useActionState(subscribe, null);
+
+    const subscribed = Boolean(
+        state && 'data' in state && (state.data as { subscribed?: boolean } | undefined)?.subscribed
+    );
+
+    if (subscribed) {
+        return (
+            <aside className="newsletter-signup newsletter-signup-success">
+                <h3>One more step — confirm your email 💌</h3>
+                <p>
+                    I just sent a confirmation link to your inbox. Click it and you're in! Nothing
+                    arriving? Check your spam or promotions folder — or email{' '}
+                    <a href="mailto:swizec@swizec.com">swizec@swizec.com</a> and I'll sort you out.
+                </p>
+            </aside>
+        );
+    }
+
+    const firstNameError = errors.getFieldError('first_name');
+    const emailError = errors.getFieldError('email');
+
+    return (
+        <aside className="newsletter-signup">
+            <h3>{form.headline}</h3>
+            <p>{form.description}</p>
+            <form action={action}>
+                {formKey ? <input type="hidden" name="form_key" value={formKey} /> : null}
+
+                {/* Honeypot: invisible to humans, bots fill it and get silently dropped */}
+                <div className="newsletter-signup-honeypot" aria-hidden="true">
+                    <label>
+                        Website
+                        <input type="text" name="website" tabIndex={-1} autoComplete="off" />
+                    </label>
+                </div>
+
+                <input
+                    name="first_name"
+                    type="text"
+                    placeholder="First name"
+                    aria-label="First name"
+                    required
+                    autoComplete="given-name"
+                    disabled={pending}
+                />
+                <input
+                    name="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    aria-label="Email address"
+                    required
+                    autoComplete="email"
+                    disabled={pending}
+                />
+                <button type="submit" disabled={pending}>
+                    {pending ? (
+                        <>
+                            <span className="newsletter-signup-spinner" aria-hidden="true" />
+                            Subscribing…
+                        </>
+                    ) : (
+                        form.submitText
+                    )}
+                </button>
+
+                {firstNameError && (
+                    <p role="alert" className="newsletter-signup-error">
+                        {firstNameError}
+                    </p>
+                )}
+                {emailError && (
+                    <p role="alert" className="newsletter-signup-error">
+                        {emailError}
+                    </p>
+                )}
+                {errors.serverError && (
+                    <p role="alert" className="newsletter-signup-error">
+                        Ouch — the subscription didn't go through. That's my email service
+                        hiccuping, not you. Give it another try in a few seconds, or email{' '}
+                        <a href="mailto:swizec@swizec.com">swizec@swizec.com</a> and I'll add you by
+                        hand.
+                    </p>
+                )}
+            </form>
+        </aside>
+    );
+}

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -17,6 +17,8 @@ const pages = defineCollection({
     redirect_from: z.array(z.string()).optional(),
     hero: z.string().optional(),
     image: z.string().optional(),
+    // Empty YAML frontmatter (`content_upgrade:`) parses to null — accept it and normalize to undefined
+    content_upgrade: z.string().nullish().transform((v) => v ?? undefined),
     content: z.string(),
   }),
 });

--- a/lib/newsletter-forms.ts
+++ b/lib/newsletter-forms.ts
@@ -1,0 +1,87 @@
+export interface NewsletterForm {
+    formId: string;
+    headline: string;
+    description: string;
+    submitText: string;
+}
+
+// Kit (ConvertKit) form IDs live on the Kit side and each one triggers its
+// own automation — don't change them. IDs match gatsby-config.js on master.
+export const DEFAULT_FORM: NewsletterForm = {
+    formId: '826419',
+    headline: 'Learned something new? Read more Software Engineering Lessons from Production',
+    description:
+        'I write articles with real insight into the career and skills of a modern software engineer. "Raw and honest from the heart!" as one reader described them. Fueled by lessons learned over 20 years of building production code for side-projects, small businesses, and hyper growth startups. Both successful and not.',
+    submitText: 'Subscribe 💌',
+};
+
+// Keyed by lowercased content_upgrade frontmatter value. Lookup is
+// case-insensitive because frontmatter spells these inconsistently
+// (Javascript vs JavaScript, FullstackWeb vs fullstackWeb).
+const FORMS: Record<string, NewsletterForm> = {
+    seniormindset: {
+        formId: '1712642',
+        headline: 'The Senior Engineer Mindset email crash course',
+        description:
+            'Get promoted, earn a bigger salary, work for top companies. A new take on being a senior engineer, straight to your inbox.',
+        submitText: 'Get email crash course 💌',
+    },
+    scalingfast: {
+        formId: '8571155',
+        headline: 'Scaling Fast — free chapter',
+        description:
+            'Curious how great teams ship fast without burning out? Get a free chapter of Scaling Fast, my book on engineering leadership at hypergrowth startups.',
+        submitText: 'Send it to me! 💌',
+    },
+    serverlesshandbook: {
+        formId: '2103715',
+        headline: 'Serverless Handbook — free chapter',
+        description:
+            'Dip your toes in backend web development with a free chapter of the Serverless Handbook, written for frontend engineers.',
+        submitText: 'Send it to me! 💌',
+    },
+    reactcu: {
+        formId: '2753675',
+        headline: 'Get Curated React Essays',
+        description: 'The best React essays, curated and sent straight to your inbox.',
+        submitText: 'Send them to me! 💌',
+    },
+    javascript: {
+        formId: '2507452',
+        headline: 'Get Curated JavaScript Essays',
+        description: 'The best JavaScript essays, curated and sent straight to your inbox.',
+        submitText: 'Send them to me! 💌',
+    },
+    fullstackweb: {
+        formId: '2507619',
+        headline: 'Get Curated Fullstack Web Essays',
+        description: 'Real insight into modern fullstack web development, straight to your inbox.',
+        submitText: 'Send them to me! 💌',
+    },
+    serverless: {
+        formId: '2849380',
+        headline: 'Get Curated Serverless Essays',
+        description: 'The best serverless and backend engineering essays, curated for your inbox.',
+        submitText: 'Send them to me! 💌',
+    },
+    indiehacking: {
+        formId: '2753667',
+        headline: 'Get Curated Indie Hacking Essays',
+        description: 'The best indie hacking and side-business essays, curated for your inbox.',
+        submitText: 'Send them to me! 💌',
+    },
+    computerscience: {
+        formId: '2720965',
+        headline: 'Get Curated Computer Science Essays',
+        description: 'Computer science fundamentals applied to everyday software engineering, in your inbox.',
+        submitText: 'Send them to me! 💌',
+    },
+};
+
+export function getNewsletterForm(key: string | null | undefined): NewsletterForm {
+    if (!key) return DEFAULT_FORM;
+    // Strip accidental quotes from frontmatter, normalize casing
+    const normalized = key.trim().replace(/^"|"$/g, '').toLowerCase();
+    if (!normalized) return DEFAULT_FORM;
+    return FORMS[normalized] ?? DEFAULT_FORM;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,11 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["app", "*.config.ts", ".content-collections/generated"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,4 +39,11 @@ const pagesColocatedAssets = {
 
 export default defineConfig({
   plugins: [pagesColocatedAssets, timber()],
+  resolve: {
+    // Lets MDX pages import components without counting ../ hops:
+    // import { NewsletterSignup } from '@/components/newsletter-signup'
+    alias: {
+      '@': new URL('.', import.meta.url).pathname,
+    },
+  },
 });


### PR DESCRIPTION
Rebuilt newsletter signup, replacing #130. Built on Timber's form patterns end to end: \`createActionClient\` with a zod schema on the server, \`useActionState\` 4-tuple on the client, works without JS via form POST + flash re-render.

## How it works

**Every article** gets a signup form after the content (\`app/[...slug]/page.tsx\`). Articles with a \`content_upgrade\` frontmatter field get that upgrade's Kit form + custom copy; everything else gets the default newsletter form.

**Any MDX page** can embed a form with one import (new \`@/\` Vite alias, no \`../\` counting):

\`\`\`mdx
import { NewsletterSignup } from "@/components/newsletter-signup"

<NewsletterSignup />                      {/* default newsletter */}
<NewsletterSignup formKey="ScalingFast" /> {/* specific content upgrade */}
\`\`\`

## Form registry (\`lib/newsletter-forms.ts\`)

Maps \`content_upgrade\` values → Kit form IDs (copied from master's gatsby-config) + per-upgrade headline/description/CTA. Lookup is case-insensitive because frontmatter spells these inconsistently (\`Javascript\`/\`JavaScript\`, \`FullstackWeb\`/\`fullstackWeb\`). Form IDs stay server-controlled — the form posts only a \`form_key\` string.

## Bot filtering (\`app/actions/subscribe.ts\`)

- **Honeypot**: off-screen \`website\` field. Filled → pretend success, never call Kit.
- **\`"null"\` values**: literal \`null\` in name/email → same silent drop.
- **Missing fields**: rejected by zod before the action body runs — nothing subscribed.

Real submissions use master's exact two-step Kit v4 flow (\`src/api/subscribe-ck.js\`): create inactive subscriber → attach to form, which sends the confirmation email and triggers that form's automation. Uses the same \`CONVERTKIT_APIKEY_V4\` env var (already set on Vercel).

## UX states

- **Pending**: CSS spinner in the button + disabled inputs
- **Success**: "confirm your email" guidance with a fallback contact
- **Validation errors**: inline, friendly copy
- **Server error**: recoverable message (retry or email me)

## Verified locally

- ✅ SeniorMindset article renders upgrade copy + correct hidden form_key
- ✅ Article without upgrade renders default form
- ✅ Empty submit (required stripped) → inline zod errors
- ✅ Honeypot filled → success UI, **zero** Kit API calls in server log
- ✅ \`first_name: "null"\` → success UI, zero Kit calls
- ✅ All 1965 documents validate (nullish \`content_upgrade\` schema)

## Test plan on preview

- [ ] Subscribe with a real email on an article without upgrade → confirmation email from default form
- [ ] Subscribe on a SeniorMindset article → crash-course automation fires
- [ ] Check Kit dashboard: subscriber created inactive, then confirmed after email click

🤖 Generated with [Claude Code](https://claude.com/claude-code)