### PR TITLE
Paginated archive with time-jump sidebar on all listing pages

### DIFF
--- a/app/404.tsx
+++ b/app/404.tsx
@@ -5,6 +5,8 @@
 // from pages/404.mdx (whose giphy embed is a server component).
 export default function NotFound() {
     return (
+        <div className="page-grid page-grid-solo">
+        <div className="page-content">
         <main>
             <h1>404 Not Found</h1>
             <p>Ooops! Looks like that page doesn't exist.</p>
@@ -17,5 +19,7 @@ export default function NotFound() {
                 and deploying. Keep this tab open and come back in a few minutes.
             </p>
         </main>
+        </div>
+        </div>
     );
 }

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -8,6 +8,10 @@ import { NewsletterSignup } from "../../components/newsletter-signup";
 import { RelatedArticles } from "../../components/related-articles";
 import { Byline } from "../../components/byline";
 import { BookPromo } from "../../components/book-promo";
+import { PageShell } from "../../components/page-shell";
+import { ArticleArchive } from "../../components/article-archive";
+import { ArchiveSidebar } from "../../components/archive-sidebar";
+import { parseArchiveFrontmatter } from "../../lib/article-archive";
 
 // Vite glob: all MDX in pages/, compiled as ES modules via @mdx-js/rollup (RSC-compatible)
 const mdxModules = import.meta.glob("/pages/**/*.{mdx,md}");
@@ -67,12 +71,25 @@ export default async function Page() {
     // URL format matches what index-articles.ts stores: /blog/slug/
     const articleUrl = `/${page._meta.path.replace(/\/index$/, '')}/`;
 
+    // Listing pages (archive frontmatter): MDX body is the intro copy, the
+    // paginated listing is appended, and the time-jump rail replaces books.
+    const archiveQuery = page.archive ? parseArchiveFrontmatter(page.archive) : undefined;
+    const basePath = `/${path}`;
+
     return (
+        <PageShell
+            sidebar={
+                archiveQuery ? (
+                    <ArchiveSidebar query={archiveQuery} basePath={basePath} />
+                ) : undefined
+            }
+        >
         <article>
             <h1>{page.title}</h1>
             {page.subtitle && <p className="article-subtitle">{page.subtitle}</p>}
             <Byline published={page.published} />
             <MDXContent />
+            {archiveQuery && <ArticleArchive query={archiveQuery} basePath={basePath} />}
             {isBlogPost && categories.length > 0 && (
                 <p className="article-categories">
                     Filed under:{" "}
@@ -88,5 +105,6 @@ export default async function Page() {
             {isBlogPost && <BookPromo upgradeKey={page.content_upgrade ?? undefined} />}
             {isBlogPost && <RelatedArticles url={articleUrl} />}
         </article>
+        </PageShell>
     );
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,26 +1,27 @@
 import type { Metadata } from '@timber-js/app/server';
-import { LatestArticles } from '../../components/article-listing';
+import { PageShell } from '../../components/page-shell';
+import { ArticleArchive } from '../../components/article-archive';
+import { ArchiveSidebar } from '../../components/archive-sidebar';
 
 export const metadata: Metadata = {
     title: 'Latest articles',
     description:
-        'Software engineering lessons from production — the latest articles by Swizec Teller',
+        'Software engineering lessons from production — almost 20 years of articles by Swizec Teller',
 };
 
 export default function BlogIndex() {
     return (
-        <main>
-            <h1>Latest articles</h1>
-            <p>
-                Software engineering lessons from production, raw and honest from the heart.
-                Looking for something specific? Browse <a href="/categories">categories</a> or{' '}
-                <a href="/collections">curated collections</a>.
-            </p>
-            <LatestArticles limit={30} />
-            <p>
-                Want more? Explore <a href="/categories">all categories</a> or subscribe to the{' '}
-                <a href="/letters">newsletter</a> so you never miss a new one.
-            </p>
-        </main>
+        <PageShell sidebar={<ArchiveSidebar query={{}} basePath="/blog" />}>
+            <main>
+                <h1>Articles</h1>
+                <p>
+                    Software engineering lessons from production, raw and honest from the heart —
+                    almost 20 years of them. Jump to a year in the sidebar, or browse{' '}
+                    <a href="/categories">categories</a> and{' '}
+                    <a href="/collections">curated collections</a>.
+                </p>
+                <ArticleArchive query={{}} basePath="/blog" />
+            </main>
+        </PageShell>
     );
 }

--- a/app/categories/[categorySlug]/page.tsx
+++ b/app/categories/[categorySlug]/page.tsx
@@ -1,6 +1,9 @@
 import { deny, getSegmentParams } from '@timber-js/app/server';
 import type { Metadata } from '@timber-js/app/server';
 import { getCategory } from '../../../lib/categories';
+import { PageShell } from '../../../components/page-shell';
+import { ArticleArchive } from '../../../components/article-archive';
+import { ArchiveSidebar } from '../../../components/archive-sidebar';
 
 function resolvedSlug(): string {
     const { categorySlug } = getSegmentParams();
@@ -17,33 +20,26 @@ export async function metadata(): Promise<Metadata> {
 }
 
 export default async function CategoryPage() {
-    const category = await getCategory(resolvedSlug());
+    const slug = resolvedSlug();
+    const category = await getCategory(slug);
 
     if (!category) {
         deny(404);
         return null;
     }
 
+    const query = { categorySlug: slug };
+    const basePath = `/categories/${slug}`;
+
     return (
-        <main>
-            <h1>{category.name}</h1>
-            <p>{category.articles.length} articles</p>
-            <ul>
-                {category.articles.map(({ path, title, published }) => (
-                    <li key={path}>
-                        <a href={path}>{title}</a>
-                        <time dateTime={published}>
-                            {' '}
-                            —{' '}
-                            {new Date(published).toLocaleDateString('en-US', {
-                                year: 'numeric',
-                                month: 'short',
-                                day: 'numeric',
-                            })}
-                        </time>
-                    </li>
-                ))}
-            </ul>
-        </main>
+        <PageShell sidebar={<ArchiveSidebar query={query} basePath={basePath} />}>
+            <main>
+                <h1>{category.name}</h1>
+                <p>
+                    {category.articles.length} articles · <a href="/categories">all categories</a>
+                </p>
+                <ArticleArchive query={query} basePath={basePath} />
+            </main>
+        </PageShell>
     );
 }

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from '@timber-js/app/server';
 import { listCategories } from '../../lib/categories';
+import { PageShell } from '../../components/page-shell';
 
 export const metadata: Metadata = {
     title: 'Categories',
@@ -10,6 +11,7 @@ export default async function CategoriesIndex() {
     const categories = await listCategories();
 
     return (
+        <PageShell>
         <main>
             <h1>Categories</h1>
             <p>Articles organized by topic</p>
@@ -22,5 +24,6 @@ export default async function CategoriesIndex() {
                 ))}
             </ul>
         </main>
+        </PageShell>
     );
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -14,7 +14,9 @@ export default function ErrorPage({
 }) {
     if (status === 404) {
         return (
-            <main>
+            <div className="page-grid page-grid-solo">
+        <div className="page-content">
+        <main>
                 <h1>404 Not Found</h1>
                 <p>Ooops! Looks like that page doesn't exist.</p>
                 <p>
@@ -23,12 +25,16 @@ export default function ErrorPage({
                     fix it.
                 </p>
             </main>
+        </div>
+        </div>
         );
     }
 
     if (status) {
         return (
-            <main>
+            <div className="page-grid page-grid-solo">
+        <div className="page-content">
+        <main>
                 <h1>Well this is embarrassing 😅</h1>
                 <p>Something went wrong handling your request (error {status}).</p>
                 <p>
@@ -36,10 +42,14 @@ export default function ErrorPage({
                     <a href="mailto:hi@swizec.com">hi@swizec.com</a> if it keeps happening.
                 </p>
             </main>
+        </div>
+        </div>
         );
     }
 
     return (
+        <div className="page-grid page-grid-solo">
+        <div className="page-content">
         <main>
             <h1>Well this is embarrassing 😅</h1>
             <p>Something broke while rendering this page: {error.message}</p>
@@ -51,5 +61,7 @@ export default function ErrorPage({
                 I'll fix it.
             </p>
         </main>
+        </div>
+        </div>
     );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,6 @@ import '@fontsource/jetbrains-mono/400.css';
 import './styles.css';
 import { SiteHeader } from '../components/site-header';
 import { SiteFooter } from '../components/site-footer';
-import { BookSidebar } from '../components/book-sidebar';
 
 export const metadata = {
   metadataBase: new URL('https://swizec.com'),
@@ -28,10 +27,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <SiteHeader />
-        <div className="page-grid">
-          <div className="page-content">{children}</div>
-          <BookSidebar />
-        </div>
+        {children}
         <SiteFooter />
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from '@timber-js/app/server';
 import HomeContent from '../pages/index.mdx';
+import { PageShell } from '../components/page-shell';
 import { requestOrigin } from './mdx-metadata';
 
 export async function metadata(): Promise<Metadata> {
@@ -23,8 +24,10 @@ export async function metadata(): Promise<Metadata> {
 
 export default function Home() {
     return (
-        <main>
-            <HomeContent />
-        </main>
+        <PageShell>
+            <main>
+                <HomeContent />
+            </main>
+        </PageShell>
     );
 }

--- a/app/styles.css
+++ b/app/styles.css
@@ -886,6 +886,139 @@ a.button:hover {
   display: inline-block;
 }
 
+/* ---------- Archive: time-jump sidebar ---------- */
+
+.archive-sidebar {
+  align-self: start;
+  background: var(--color-background-card);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-hard);
+  max-height: calc(100vh - 7rem);
+  overflow-y: auto;
+  padding: 1.25rem;
+  position: sticky;
+  top: 5.5rem;
+}
+
+.archive-sidebar h2 {
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.06em;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+}
+
+.archive-sidebar nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.archive-sidebar a {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  padding: 0.1rem 0.4rem;
+  text-decoration: none;
+}
+
+.archive-sidebar a:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+}
+
+.archive-sidebar a.archive-active {
+  background: var(--color-background-yellow);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.archive-year {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.archive-months {
+  border-left: 2px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin: 0.15rem 0 0.35rem 0.6rem;
+  padding-left: 0.5rem;
+}
+
+@media (max-width: 960px) {
+  .archive-sidebar {
+    max-height: none;
+    position: static;
+  }
+
+  .archive-sidebar nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.75rem;
+  }
+
+  .archive-year {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .archive-months {
+    border-left: 0;
+    border-top: 2px solid var(--color-border);
+    flex-basis: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.3rem 0.6rem;
+    margin: 0.2rem 0;
+    padding: 0.3rem 0 0;
+  }
+}
+
+/* ---------- Archive: listing, filter note, pagination ---------- */
+
+.archive-filter-note {
+  background: var(--color-background-cyan);
+  border: 1px solid var(--color-border);
+  display: inline-block;
+  padding: 0.35rem 0.8rem;
+}
+
+.archive-pagination {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-top: 2rem;
+}
+
+.archive-pagination .button {
+  margin: 0;
+}
+
+.archive-pagination-status {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.archive-pagination-disabled {
+  background: var(--color-background-muted);
+  border: 1px solid var(--color-border);
+  box-shadow: none;
+  color: var(--color-text-secondary);
+  display: inline-block;
+  font-weight: 600;
+  padding: 0.6rem 1.2rem;
+  opacity: 0.55;
+}
+
+/* Solo layout: full-width content well, no sidebar (404, error pages) */
+.page-grid-solo {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 /* ---------- Typeform ---------- */
 
 .typeform-embed {

--- a/app/styles.css
+++ b/app/styles.css
@@ -986,6 +986,32 @@ a.button:hover {
   padding: 0.35rem 0.8rem;
 }
 
+/* Sticky month/year markers orient readers as they scroll a long archive.
+   Sits just below the sticky header; a pastel sticker in the Y2K style. */
+.archive-time-marker {
+  background: var(--color-background-purple);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-hard-sm);
+  font-size: var(--font-size-base);
+  margin: 2rem 0 1rem;
+  padding: 0.3rem 0.9rem;
+  position: sticky;
+  top: 4.75rem;
+  width: fit-content;
+  z-index: 5;
+}
+
+.archive-time-marker:first-child {
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 960px) {
+  /* Header un-sticks on mobile, so markers stick to the top of the viewport */
+  .archive-time-marker {
+    top: 0.5rem;
+  }
+}
+
 .archive-pagination {
   align-items: center;
   display: flex;

--- a/components/archive-sidebar.tsx
+++ b/components/archive-sidebar.tsx
@@ -1,0 +1,58 @@
+import { archiveParams } from '../lib/archive-params';
+import {
+    MONTH_NAMES,
+    archiveHref,
+    buildTimeIndex,
+    queryArchive,
+    type ArchiveQuery,
+} from '../lib/article-archive';
+
+// Time-jump rail for listing pages: almost 20 years of archive, browsable by
+// year, then by month within the active year. Replaces the book sidebar.
+export async function ArchiveSidebar({
+    query,
+    basePath,
+}: {
+    query: ArchiveQuery;
+    basePath: string;
+}) {
+    const { year: activeYear, month: activeMonth } = archiveParams.get();
+    const articles = await queryArchive(query);
+    const years = buildTimeIndex(articles);
+
+    if (years.length === 0) return null;
+
+    return (
+        <aside className="archive-sidebar" aria-label="Browse the archive by date">
+            <h2>Jump in time</h2>
+            <nav>
+                <a href={basePath} className={activeYear ? '' : 'archive-active'}>
+                    All time ({articles.length})
+                </a>
+                {years.map(({ year, count, months }) => (
+                    <div key={year} className="archive-year">
+                        <a
+                            href={archiveHref(basePath, { year })}
+                            className={activeYear === year && !activeMonth ? 'archive-active' : ''}
+                        >
+                            {year} ({count})
+                        </a>
+                        {activeYear === year && (
+                            <div className="archive-months">
+                                {months.map(({ month, count: monthCount }) => (
+                                    <a
+                                        key={month}
+                                        href={archiveHref(basePath, { year, month })}
+                                        className={activeMonth === month ? 'archive-active' : ''}
+                                    >
+                                        {MONTH_NAMES[month - 1]} ({monthCount})
+                                    </a>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                ))}
+            </nav>
+        </aside>
+    );
+}

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -1,0 +1,90 @@
+import { archiveParams } from '../lib/archive-params';
+import {
+    MONTH_NAMES,
+    archiveHref,
+    filterByTime,
+    paginate,
+    queryArchive,
+    type ArchiveQuery,
+} from '../lib/article-archive';
+import { ArticleListing } from './article-listing';
+
+function Pagination({
+    basePath,
+    page,
+    totalPages,
+    year,
+    month,
+}: {
+    basePath: string;
+    page: number;
+    totalPages: number;
+    year?: number;
+    month?: number;
+}) {
+    if (totalPages <= 1) return null;
+
+    return (
+        <nav className="archive-pagination" aria-label="Pagination">
+            {page > 1 ? (
+                <a className="button" href={archiveHref(basePath, { year, month, page: page - 1 })}>
+                    ← Newer
+                </a>
+            ) : (
+                <span className="button archive-pagination-disabled">← Newer</span>
+            )}
+            <span className="archive-pagination-status">
+                Page {page} of {totalPages}
+            </span>
+            {page < totalPages ? (
+                <a className="button" href={archiveHref(basePath, { year, month, page: page + 1 })}>
+                    Older →
+                </a>
+            ) : (
+                <span className="button archive-pagination-disabled">Older →</span>
+            )}
+        </nav>
+    );
+}
+
+// Paginated, time-filterable article listing driven by ?page/?year/?month.
+// Used by every long-list page: /blog, category pages, collections, interviews.
+export async function ArticleArchive({
+    query,
+    basePath,
+}: {
+    query: ArchiveQuery;
+    basePath: string;
+}) {
+    const { page: requestedPage, year, month } = archiveParams.get();
+    const all = await queryArchive(query);
+    const filtered = filterByTime(all, year, month);
+    const { items, page, totalPages, total } = paginate(filtered, requestedPage);
+
+    return (
+        <section className="article-archive">
+            {year && (
+                <p className="archive-filter-note">
+                    {total} article{total === 1 ? '' : 's'} from{' '}
+                    <strong>
+                        {month ? `${MONTH_NAMES[month - 1]} ` : ''}
+                        {year}
+                    </strong>{' '}
+                    · <a href={basePath}>show all</a>
+                </p>
+            )}
+            {items.length === 0 ? (
+                <p>Nothing here — try another year or clear the filter.</p>
+            ) : (
+                items.map((article) => <ArticleListing key={article.path} article={article} />)
+            )}
+            <Pagination
+                basePath={basePath}
+                page={page}
+                totalPages={totalPages}
+                year={year}
+                month={month}
+            />
+        </section>
+    );
+}

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -8,6 +8,32 @@ import {
     type ArchiveQuery,
 } from '../lib/article-archive';
 import { ArticleListing } from './article-listing';
+import type { ListedArticle } from '../lib/article-listings';
+
+// Interleaves "Month Year" markers before the first article of each month, so
+// readers stay oriented in time as they scroll. Skipped when the view is
+// already narrowed to a single month (every marker would be identical).
+function withTimeMarkers(
+    articles: ListedArticle[],
+    activeMonth?: number
+): { marker?: string; article?: ListedArticle }[] {
+    if (activeMonth) return articles.map((article) => ({ article }));
+
+    const out: { marker?: string; article?: ListedArticle }[] = [];
+    let lastKey = '';
+    for (const article of articles) {
+        const date = new Date(article.published);
+        if (!Number.isNaN(date.valueOf())) {
+            const key = `${date.getUTCFullYear()}-${date.getUTCMonth()}`;
+            if (key !== lastKey) {
+                out.push({ marker: `${MONTH_NAMES[date.getUTCMonth()]} ${date.getUTCFullYear()}` });
+                lastKey = key;
+            }
+        }
+        out.push({ article });
+    }
+    return out;
+}
 
 function Pagination({
     basePath,
@@ -76,7 +102,15 @@ export async function ArticleArchive({
             {items.length === 0 ? (
                 <p>Nothing here — try another year or clear the filter.</p>
             ) : (
-                items.map((article) => <ArticleListing key={article.path} article={article} />)
+                withTimeMarkers(items, month).map((entry) =>
+                    entry.marker ? (
+                        <h2 className="archive-time-marker" key={entry.marker}>
+                            {entry.marker}
+                        </h2>
+                    ) : (
+                        <ArticleListing key={entry.article!.path} article={entry.article!} />
+                    )
+                )
             )}
             <Pagination
                 basePath={basePath}

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -52,22 +52,23 @@ function Pagination({
 
     return (
         <nav className="archive-pagination" aria-label="Pagination">
-            {page > 1 ? (
-                <a className="button" href={archiveHref(basePath, { year, month, page: page - 1 })}>
-                    ← Newer
+            {/* Time flows left → right: older (further back) on the left, newer on the right */}
+            {page < totalPages ? (
+                <a className="button" href={archiveHref(basePath, { year, month, page: page + 1 })}>
+                    ← Older
                 </a>
             ) : (
-                <span className="button archive-pagination-disabled">← Newer</span>
+                <span className="button archive-pagination-disabled">← Older</span>
             )}
             <span className="archive-pagination-status">
                 Page {page} of {totalPages}
             </span>
-            {page < totalPages ? (
-                <a className="button" href={archiveHref(basePath, { year, month, page: page + 1 })}>
-                    Older →
+            {page > 1 ? (
+                <a className="button" href={archiveHref(basePath, { year, month, page: page - 1 })}>
+                    Newer →
                 </a>
             ) : (
-                <span className="button archive-pagination-disabled">Older →</span>
+                <span className="button archive-pagination-disabled">Newer →</span>
             )}
         </nav>
     );

--- a/components/page-shell.tsx
+++ b/components/page-shell.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import { BookSidebar } from './book-sidebar';
+
+// Content-well + sidebar grid. Pages pick their sidebar; the default is the
+// site-wide book rail. Pass sidebar={null} for a full-width solo layout.
+export function PageShell({
+    children,
+    sidebar,
+}: {
+    children: ReactNode;
+    sidebar?: ReactNode | null;
+}) {
+    const rail = sidebar === undefined ? <BookSidebar /> : sidebar;
+
+    return (
+        <div className={`page-grid${rail ? '' : ' page-grid-solo'}`}>
+            <div className="page-content">{children}</div>
+            {rail}
+        </div>
+    );
+}

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -20,6 +20,9 @@ const pages = defineCollection({
     image: z.string().optional(),
     // Empty YAML frontmatter (`content_upgrade:`) parses to null — accept it and normalize to undefined
     content_upgrade: z.string().nullish().transform((v) => v ?? undefined),
+    // Marks a listing page: category-regex, "prefix:interviews/", or "all".
+    // The catch-all appends a paginated archive and swaps in the time sidebar.
+    archive: z.string().optional(),
     content: z.string(),
   }),
 });

--- a/lib/archive-params.ts
+++ b/lib/archive-params.ts
@@ -1,0 +1,13 @@
+import { defineSearchParams } from '@timber-js/app/search-params';
+import { z } from 'zod';
+
+// Shared search params for every article-archive listing page:
+// /blog?page=3, /categories/react?year=2019&month=5, etc.
+// Invalid values fall back to defaults instead of erroring.
+export const archiveParams = defineSearchParams(
+    z.object({
+        page: z.coerce.number().int().min(1).catch(1).default(1),
+        year: z.coerce.number().int().min(2000).max(2100).optional().catch(undefined),
+        month: z.coerce.number().int().min(1).max(12).optional().catch(undefined),
+    })
+);

--- a/lib/article-archive.ts
+++ b/lib/article-archive.ts
@@ -27,6 +27,7 @@ export async function queryArchive(query: ArchiveQuery): Promise<ListedArticle[]
         return (category?.articles ?? []).map((a) => ({
             path: a.path,
             title: a.title,
+            description: a.description,
             published: a.published,
         }));
     }

--- a/lib/article-archive.ts
+++ b/lib/article-archive.ts
@@ -1,0 +1,134 @@
+import { getCategory } from './categories';
+import { getArticlesByPattern, getPagesUnder, type ListedArticle } from './article-listings';
+
+export const ARCHIVE_PAGE_SIZE = 30;
+
+// What an archive page lists. Exactly one of these (or none = all blog articles):
+// - pattern: category-regex over blog articles (collections pages, /blog with none)
+// - prefix: pages under a path (interviews)
+// - categorySlug: a /categories/[slug] listing
+export interface ArchiveQuery {
+    pattern?: string;
+    prefix?: string;
+    categorySlug?: string;
+}
+
+// Frontmatter encoding for MDX listing pages: either a category-regex
+// ("React|Reactjs") or "prefix:interviews/" for path-based listings.
+export function parseArchiveFrontmatter(value: string): ArchiveQuery {
+    if (value.startsWith('prefix:')) return { prefix: value.slice('prefix:'.length) };
+    if (value === 'all') return {};
+    return { pattern: value };
+}
+
+export async function queryArchive(query: ArchiveQuery): Promise<ListedArticle[]> {
+    if (query.categorySlug) {
+        const category = await getCategory(query.categorySlug);
+        return (category?.articles ?? []).map((a) => ({
+            path: a.path,
+            title: a.title,
+            published: a.published,
+        }));
+    }
+    if (query.prefix) return getPagesUnder(query.prefix);
+    return getArticlesByPattern(query.pattern ?? null);
+}
+
+export interface ArchiveMonth {
+    month: number;
+    count: number;
+}
+
+export interface ArchiveYear {
+    year: number;
+    count: number;
+    months: ArchiveMonth[];
+}
+
+// Year/month counts for the time-jump sidebar, newest year first.
+// Cheap single pass over compact rows — no caching needed.
+export function buildTimeIndex(articles: ListedArticle[]): ArchiveYear[] {
+    const years = new Map<number, Map<number, number>>();
+
+    for (const article of articles) {
+        const date = new Date(article.published);
+        if (Number.isNaN(date.valueOf())) continue;
+        const year = date.getUTCFullYear();
+        const month = date.getUTCMonth() + 1;
+        const months = years.get(year) ?? new Map<number, number>();
+        months.set(month, (months.get(month) ?? 0) + 1);
+        years.set(year, months);
+    }
+
+    return [...years.entries()]
+        .map(([year, months]) => ({
+            year,
+            count: [...months.values()].reduce((a, b) => a + b, 0),
+            months: [...months.entries()]
+                .map(([month, count]) => ({ month, count }))
+                .sort((a, b) => b.month - a.month),
+        }))
+        .sort((a, b) => b.year - a.year);
+}
+
+export function filterByTime(
+    articles: ListedArticle[],
+    year?: number,
+    month?: number
+): ListedArticle[] {
+    if (!year) return articles;
+    return articles.filter((article) => {
+        const date = new Date(article.published);
+        if (Number.isNaN(date.valueOf())) return false;
+        if (date.getUTCFullYear() !== year) return false;
+        if (month && date.getUTCMonth() + 1 !== month) return false;
+        return true;
+    });
+}
+
+export interface ArchivePage {
+    items: ListedArticle[];
+    page: number;
+    totalPages: number;
+    total: number;
+}
+
+export function paginate(articles: ListedArticle[], page: number): ArchivePage {
+    const total = articles.length;
+    const totalPages = Math.max(1, Math.ceil(total / ARCHIVE_PAGE_SIZE));
+    const current = Math.min(Math.max(1, page), totalPages);
+    return {
+        items: articles.slice((current - 1) * ARCHIVE_PAGE_SIZE, current * ARCHIVE_PAGE_SIZE),
+        page: current,
+        totalPages,
+        total,
+    };
+}
+
+export const MONTH_NAMES = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+];
+
+// Builds hrefs that preserve the active time filter + page.
+export function archiveHref(
+    basePath: string,
+    params: { year?: number; month?: number; page?: number }
+): string {
+    const search = new URLSearchParams();
+    if (params.year) search.set('year', String(params.year));
+    if (params.month) search.set('month', String(params.month));
+    if (params.page && params.page > 1) search.set('page', String(params.page));
+    const qs = search.toString();
+    return qs ? `${basePath}?${qs}` : basePath;
+}

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -22,6 +22,7 @@ export function parseCategories(categories: string | undefined): { name: string;
 export interface CategoryArticle {
     path: string;
     title: string;
+    description?: string;
     published: string;
 }
 
@@ -47,7 +48,12 @@ export const getCategoryIndex = cache(
             const path = `/${page._meta.path.replace(/\/index$/, '')}`;
             for (const { name, slug } of parseCategories(page.categories)) {
                 index[slug] ??= { name, slug, articles: [] };
-                index[slug].articles.push({ path, title: page.title, published: page.published });
+                index[slug].articles.push({
+                    path,
+                    title: page.title,
+                    description: page.description,
+                    published: page.published,
+                });
             }
         }
 

--- a/pages/collections/fullstack-web.mdx
+++ b/pages/collections/fullstack-web.mdx
@@ -2,10 +2,10 @@
 title: "Learn from stories about fullstack web development"
 description: "Learning from tutorials is great! You follow some steps, learn a smol lesson, and feel like you got this. Then you go into an interview, get a question from the boss, or encounter a new situation and o-oh."
 content_upgrade: FullstackWeb
+archive: "Fullstack"
 ---
 
 import { NewsletterSignup } from "@/components/newsletter-signup"
-import { LatestArticles } from "@/components/article-listing"
 
 Fullstack Web is the bastard child of web development. BigTech frowns on its lack of specialization, everyone else drowns in its complexity. But it runs the web.
 
@@ -20,5 +20,3 @@ Leave your email and **get the Fullstack Web Essays series** - a series of curat
 <NewsletterSignup formKey="FullstackWeb" />
 
 ## Latest Fullstack Web articles from Swizec
-
-<LatestArticles pattern="Fullstack" />

--- a/pages/collections/indie-hacking.mdx
+++ b/pages/collections/indie-hacking.mdx
@@ -2,10 +2,10 @@
 title: "Read about indie hacking from the trenches"
 description: "Indie Hacking has been near and dear to me for over a decade. Diversifying your income is a wonderful habit"
 content_upgrade: Javascript
+archive: "IndieHacking|Business"
 ---
 
 import { NewsletterSignup } from "@/components/newsletter-signup"
-import { LatestArticles } from "@/components/article-listing"
 
 Indie Hacking – building smol businesses on your own terms – is a strange beast to me. From my first experiments back in 2011 where I went from [idea to sales in 3 days](https://swizec.com/blog/postmeme-idea-to-sales-in-3-days/) to nowadays where I have a [full-time job but think like a consultant](https://podcast.ditchinghourly.com/episodes/swizec-teller-the-employed-consultant), indie hacking has been near and dear to my heart.
 
@@ -26,5 +26,3 @@ Leave your email and **get the Indie Hacking Series** - a series of curated essa
 <NewsletterSignup formKey="IndieHacking" />
 
 ## Latest IndieHacking articles from Swizec
-
-<LatestArticles pattern="IndieHacking|Business" />

--- a/pages/collections/javascript.mdx
+++ b/pages/collections/javascript.mdx
@@ -2,10 +2,10 @@
 title: "Read JavaScript and TypeScript lessons from production"
 description: "Learning from tutorials is great! You follow some steps, learn a smol lesson, and feel like you got this. Then you go into an interview, get a question from the boss, or encounter a new situation and o-oh."
 content_upgrade: Javascript
+archive: "JavaScript|TypeScript"
 ---
 
 import { NewsletterSignup } from "@/components/newsletter-signup"
-import { LatestArticles } from "@/components/article-listing"
 
 Learning from tutorials is great! You follow some steps, learn a smol lesson, and feel like you got this. Then you go into an interview, get a question from the boss, or encounter a new situation and o-oh.
 
@@ -20,5 +20,3 @@ Leave your email and **get the JavaScript Essays series** - a series of curated 
 <NewsletterSignup formKey="Javascript" />
 
 ## Latest JavaScript articles from Swizec
-
-<LatestArticles pattern="JavaScript|TypeScript" />

--- a/pages/collections/react.mdx
+++ b/pages/collections/react.mdx
@@ -2,10 +2,10 @@
 title: "Take your React beyond the tutorial"
 description: "Learning from tutorials is great! You follow some steps, learn a smol lesson, and feel like you got this. Then you go into an interview, get a question from the boss, or encounter a new situation and o-oh."
 content_upgrade: ReactCU
+archive: "React|Reactjs|React.js|gatsby|nextjs"
 ---
 
 import { NewsletterSignup } from "@/components/newsletter-signup"
-import { LatestArticles } from "@/components/article-listing"
 
 React is here to stay. It solves many problems you may not even know existed. These essays are the good stuff I learned over the years.
 
@@ -22,5 +22,3 @@ Leave your email and **get the React email Series** - a series of curated essays
 <NewsletterSignup formKey="ReactCU" />
 
 ## Latest React articles from Swizec
-
-<LatestArticles pattern="React|Reactjs|React.js|gatsby|nextjs" />

--- a/pages/collections/seniormindset.mdx
+++ b/pages/collections/seniormindset.mdx
@@ -2,10 +2,10 @@
 title: "Learn the mindset of a true senior engineer"
 description: "Getting that senior title is easy. Just stick around. Being a true senior takes a new way of thinking. Do you have it?"
 content_upgrade: SeniorMindset
+archive: "SeniorMindset|Mindset"
 ---
 
 import { NewsletterSignup } from "@/components/newsletter-signup"
-import { LatestArticles } from "@/components/article-listing"
 
 Getting that senior title is easy. Just stick around. Being a _true_ senior takes a new way of thinking. Do you have it?
 
@@ -14,5 +14,3 @@ Get a series of curated essays on the mindset of a senior software engineer. Wha
 <NewsletterSignup formKey="SeniorMindset" />
 
 ## Latest SeniorMindset articles from Swizec
-
-<LatestArticles pattern="SeniorMindset|Mindset" />

--- a/pages/collections/serverless.mdx
+++ b/pages/collections/serverless.mdx
@@ -2,10 +2,10 @@
 title: "Insights into Serverless and modern backends"
 description: "I've been building web backends since ~2004 when they were just called websites. With these curated essays I want to share the hard lessons learned."
 content_upgrade: Serverless
+archive: "Serverless|Backend|Backend Web"
 ---
 
 import { NewsletterSignup } from "@/components/newsletter-signup"
-import { LatestArticles } from "@/components/article-listing"
 
 Learning from tutorials is great! You follow some steps, learn a smol lesson, and feel like you got this. Then you go into an interview, get a question from the boss, or encounter a new situation and o-oh.
 
@@ -18,5 +18,3 @@ I've been building web backends since ~2004 when they were just called websites.
 <NewsletterSignup formKey="Serverless" />
 
 ## Latest Serverless and Backend articles from Swizec
-
-<LatestArticles pattern="Serverless|Backend|Backend Web" />

--- a/pages/interviews/index.mdx
+++ b/pages/interviews/index.mdx
@@ -2,9 +2,8 @@
 title: "Interviews"
 description: "There's a lot of fantastic podcasts out there. Rather than add one more to the list, Swizec runs a reverse podcast – guesting with everyone who has good questions."
 hero: "../img/swizec-interview-face.jpg"
+archive: "prefix:interviews/"
 ---
-
-import { PageListing } from "@/components/article-listing"
 
 ![Swizec's best interview face](../img/swizec-interview-face.jpg)
 
@@ -12,4 +11,3 @@ I like to share thoughts with new audiences and discover ideas with provocative 
 
 Got a provocative question to ask? [email me](mailto:hi@swizec.com?subject=Provocative+question)
 
-<PageListing prefix="interviews/" />


### PR DESCRIPTION
Makes all ~20 years of writing reachable. Every long-list page now paginates **30 articles at a time**, and on those pages the book sidebar gives way to a **\"Jump in time\" rail** — years with counts, months under the active year — that filters the listing.

Stacked on #138 (base: \`timber-styling\`).

## How it works

- **Typed search params** (\`lib/archive-params.ts\`): \`?page\` / \`?year\` / \`?month\` via timber's \`defineSearchParams\` + zod; junk values fall back to defaults instead of erroring
- **Archive queries** (\`lib/article-archive.ts\`): one interface for all listing flavors — category-regex pattern (collections, /blog), path prefix (interviews), or category slug (/categories/x) — reusing the existing cached compact queries; time index/filter/pagination are cheap per-request passes
- **\`ArticleArchive\`** renders the filter note (\"90 articles from 2019 · show all\"), the listing, and Newer/Older sticker-button pagination with page status
- **\`ArchiveSidebar\`** lists every year with counts; the active year expands its months; active selection gets the yellow Y2K sticker highlight
- **\`PageShell\` refactor**: the content-well grid moved out of the layout so each page picks its sidebar (books by default, time rail on listings, none on 404/error)

## Page wiring

| Page | Query | Notes |
|---|---|---|
| \`/blog\` | all blog articles | 1967 articles, 66 pages, years 2006–2026 |
| \`/categories/[slug]\` | category slug | scoped counts, e.g. React: 94 |
| \`/collections/*\` (6 pages) | \`archive:\` frontmatter regex | intro copy + upgrade form stay, listing appended |
| \`/interviews\` | \`archive: prefix:interviews/\` | 21 items — pagination auto-hides under 30 |

MDX listing pages declare themselves with one frontmatter line (\`archive: \"React|Reactjs|...\"\`); the catch-all appends the paginated archive after the intro and swaps the sidebar — no components inside the MDX needed.

## Verified (desktop + mobile)

- ✅ \`/blog\`: 30/page, \"Page 1 of 66\", full year list 2006–2026 with counts
- ✅ \`?year=2019\`: 90 articles / 3 pages, months expand with counts, filter note + \"show all\"
- ✅ \`?year=2019&month=3\`: exactly the 7 March-2019 articles
- ✅ Pagination preserves the active time filter
- ✅ Collections keep intro + upgrade form, archive scoped to the collection (Senior Mindset: 173/6 pages)
- ✅ Regressions: articles/home keep the book sidebar, no archive listing leaks
- ✅ Mobile: time rail wraps into a year cloud below content, no horizontal scroll
- ✅ Production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)