### PR TITLE
Use timber <Link> for internal navigation

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -11,6 +11,7 @@ import { BookPromo } from "../../components/book-promo";
 import { PageShell } from "../../components/page-shell";
 import { ArticleArchive } from "../../components/article-archive";
 import { ArchiveSidebar } from "../../components/archive-sidebar";
+import { SmartLink } from "../../components/link";
 import { parseArchiveFrontmatter } from "../../lib/article-archive";
 
 // Vite glob: all MDX in pages/, compiled as ES modules via @mdx-js/rollup (RSC-compatible)
@@ -95,7 +96,7 @@ export default async function Page() {
                     Filed under:{" "}
                     {categories.map(({ name, slug }, i) => (
                         <span key={slug}>
-                            <a href={`/categories/${slug}`}>{name}</a>
+                            <SmartLink href={`/categories/${slug}`}>{name}</SmartLink>
                             {i < categories.length - 1 && ", "}
                         </span>
                     ))}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from '@timber-js/app/server';
 import { PageShell } from '../../components/page-shell';
 import { ArticleArchive } from '../../components/article-archive';
 import { ArchiveSidebar } from '../../components/archive-sidebar';
+import { SmartLink } from '../../components/link';
 
 export const metadata: Metadata = {
     title: 'Latest articles',
@@ -17,8 +18,8 @@ export default function BlogIndex() {
                 <p>
                     Software engineering lessons from production, raw and honest from the heart —
                     almost 20 years of them. Jump to a year in the sidebar, or browse{' '}
-                    <a href="/categories">categories</a> and{' '}
-                    <a href="/collections">curated collections</a>.
+                    <SmartLink href="/categories">categories</SmartLink> and{' '}
+                    <SmartLink href="/collections">curated collections</SmartLink>.
                 </p>
                 <ArticleArchive query={{}} basePath="/blog" />
             </main>

--- a/app/categories/[categorySlug]/page.tsx
+++ b/app/categories/[categorySlug]/page.tsx
@@ -4,6 +4,7 @@ import { getCategory } from '../../../lib/categories';
 import { PageShell } from '../../../components/page-shell';
 import { ArticleArchive } from '../../../components/article-archive';
 import { ArchiveSidebar } from '../../../components/archive-sidebar';
+import { SmartLink } from '../../../components/link';
 
 function resolvedSlug(): string {
     const { categorySlug } = getSegmentParams();
@@ -36,7 +37,8 @@ export default async function CategoryPage() {
             <main>
                 <h1>{category.name}</h1>
                 <p>
-                    {category.articles.length} articles · <a href="/categories">all categories</a>
+                    {category.articles.length} articles ·{' '}
+                    <SmartLink href="/categories">all categories</SmartLink>
                 </p>
                 <ArticleArchive query={query} basePath={basePath} />
             </main>

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from '@timber-js/app/server';
 import { listCategories } from '../../lib/categories';
 import { PageShell } from '../../components/page-shell';
+import { SmartLink } from '../../components/link';
 
 export const metadata: Metadata = {
     title: 'Categories',
@@ -18,7 +19,7 @@ export default async function CategoriesIndex() {
             <ul>
                 {categories.map(({ slug, name, count }) => (
                     <li key={slug}>
-                        <a href={`/categories/${slug}`}>{name}</a>
+                        <SmartLink href={`/categories/${slug}`}>{name}</SmartLink>
                         {' '}({count})
                     </li>
                 ))}

--- a/app/styles.css
+++ b/app/styles.css
@@ -189,8 +189,12 @@ main h3 {
   margin: 2rem auto 0.5rem;
 }
 
-article a,
-main a {
+/* Prose links are underlined so they're obviously links. Scoped to text
+   blocks so it doesn't touch chrome links (byline, listing titles, chips,
+   buttons, book cards) that live in divs/headings and style themselves. */
+article :is(p, li, blockquote, td, dd) a,
+main :is(p, li, blockquote, td, dd) a {
+  text-decoration: underline;
   text-decoration-thickness: 1.5px;
   text-underline-offset: 3px;
 }

--- a/components/archive-sidebar.tsx
+++ b/components/archive-sidebar.tsx
@@ -5,6 +5,7 @@ import {
     queryArchive,
     type ArchiveQuery,
 } from '../lib/article-archive';
+import { SmartLink } from './link';
 
 // Time-jump rail for listing pages: almost 20 years of archive, browsable by
 // year, then by month within the active year. Replaces the book sidebar.
@@ -25,27 +26,27 @@ export async function ArchiveSidebar({
         <aside className="archive-sidebar" aria-label="Browse the archive by date">
             <h2>Jump in time</h2>
             <nav>
-                <a href={basePath} className={activeYear ? '' : 'archive-active'}>
+                <SmartLink href={basePath} className={activeYear ? '' : 'archive-active'}>
                     All time ({articles.length})
-                </a>
+                </SmartLink>
                 {years.map(({ year, count, months }) => (
                     <div key={year} className="archive-year">
-                        <a
+                        <SmartLink
                             href={archiveParams.href(basePath, { year })}
                             className={activeYear === year && !activeMonth ? 'archive-active' : ''}
                         >
                             {year} ({count})
-                        </a>
+                        </SmartLink>
                         {activeYear === year && (
                             <div className="archive-months">
                                 {months.map(({ month, count: monthCount }) => (
-                                    <a
+                                    <SmartLink
                                         key={month}
                                         href={archiveParams.href(basePath, { year, month })}
                                         className={activeMonth === month ? 'archive-active' : ''}
                                     >
                                         {MONTH_NAMES[month - 1]} ({monthCount})
-                                    </a>
+                                    </SmartLink>
                                 ))}
                             </div>
                         )}

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -7,6 +7,7 @@ import {
     type ArchiveQuery,
 } from '../lib/article-archive';
 import { ArticleListing } from './article-listing';
+import { SmartLink } from './link';
 import type { ListedArticle } from '../lib/article-listings';
 
 // Interleaves "Month Year" markers before the first article of each month, so
@@ -53,9 +54,9 @@ function Pagination({
         <nav className="archive-pagination" aria-label="Pagination">
             {/* Time flows left → right: older (further back) on the left, newer on the right */}
             {page < totalPages ? (
-                <a className="button" href={archiveParams.href(basePath, { year, month, page: page + 1 })}>
+                <SmartLink className="button" href={archiveParams.href(basePath, { year, month, page: page + 1 })}>
                     ← Older
-                </a>
+                </SmartLink>
             ) : (
                 <span className="button archive-pagination-disabled">← Older</span>
             )}
@@ -63,9 +64,9 @@ function Pagination({
                 Page {page} of {totalPages}
             </span>
             {page > 1 ? (
-                <a className="button" href={archiveParams.href(basePath, { year, month, page: page - 1 })}>
+                <SmartLink className="button" href={archiveParams.href(basePath, { year, month, page: page - 1 })}>
                     Newer →
-                </a>
+                </SmartLink>
             ) : (
                 <span className="button archive-pagination-disabled">Newer →</span>
             )}
@@ -96,7 +97,7 @@ export async function ArticleArchive({
                         {month ? `${MONTH_NAMES[month - 1]} ` : ''}
                         {year}
                     </strong>{' '}
-                    · <a href={basePath}>show all</a>
+                    · <SmartLink href={basePath}>show all</SmartLink>
                 </p>
             )}
             {items.length === 0 ? (

--- a/components/article-listing.tsx
+++ b/components/article-listing.tsx
@@ -1,10 +1,11 @@
 import { getArticlesByPattern, getPagesUnder, type ListedArticle } from '../lib/article-listings';
+import { SmartLink } from './link';
 
 export function ArticleListing({ article }: { article: ListedArticle }) {
     return (
         <div className="article-listing">
             <h3>
-                <a href={article.path}>{article.title}</a>
+                <SmartLink href={article.path}>{article.title}</SmartLink>
             </h3>
             {article.published && (
                 <time dateTime={article.published}>

--- a/components/book-promo.tsx
+++ b/components/book-promo.tsx
@@ -1,16 +1,17 @@
 import { LATEST_BOOKS, bookForUpgrade, type Book } from '../lib/books';
 import { BOOK_COVERS } from './book-covers';
+import { SmartLink } from './link';
 
 function PromoCard({ book }: { book: Book }) {
     return (
-        <a className="book-promo-card" href={book.href}>
+        <SmartLink className="book-promo-card" href={book.href}>
             <img src={BOOK_COVERS[book.cover]} alt={`${book.title} book cover`} loading="lazy" />
             <div>
                 <strong>{book.title}</strong>
                 <p>{book.tagline}</p>
                 <span className="book-promo-cta">Check it out 👉</span>
             </div>
-        </a>
+        </SmartLink>
     );
 }
 

--- a/components/book-sidebar.tsx
+++ b/components/book-sidebar.tsx
@@ -2,6 +2,7 @@ import { allPages } from 'content-collections';
 import { getSegmentParams } from '@timber-js/app/server';
 import { LATEST_BOOKS, bookForUpgrade, type Book } from '../lib/books';
 import { BOOK_COVERS } from './book-covers';
+import { SmartLink } from './link';
 
 function currentPageUpgrade(): string | undefined {
     const { slug } = getSegmentParams();
@@ -13,11 +14,11 @@ function currentPageUpgrade(): string | undefined {
 
 function SidebarBook({ book }: { book: Book }) {
     return (
-        <a className="book-sidebar-book" href={book.href}>
+        <SmartLink className="book-sidebar-book" href={book.href}>
             <img src={BOOK_COVERS[book.cover]} alt={`${book.title} book cover`} loading="lazy" />
             <strong>{book.title}</strong>
             <span>{book.tagline}</span>
-        </a>
+        </SmartLink>
     );
 }
 

--- a/components/byline.tsx
+++ b/components/byline.tsx
@@ -1,4 +1,5 @@
 import avatar from '../app/assets/swizec-byline.jpg';
+import { SmartLink } from './link';
 
 export function Byline({ published }: { published?: string }) {
     return (
@@ -6,9 +7,9 @@ export function Byline({ published }: { published?: string }) {
             <img src={avatar} alt="Swizec Teller" width={44} height={44} />
             <div>
                 <span className="byline-name">
-                    <a href="/about" rel="author">
+                    <SmartLink href="/about" rel="author">
                         Swizec Teller
-                    </a>
+                    </SmartLink>
                 </span>
                 <span className="byline-meta">
                     {published ? (

--- a/components/link.tsx
+++ b/components/link.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Link } from '@timber-js/app/client';
+import type { AnchorHTMLAttributes } from 'react';
+
+// Anything with a scheme (http:, mailto:, tel:), protocol-relative (//), or a
+// bare hash fragment stays a plain <a>. Everything else is an in-app route and
+// goes through timber's <Link> for RSC client-side navigation.
+function isExternal(href?: string): boolean {
+    if (!href) return true;
+    return /^([a-z][a-z0-9+.-]*:|\/\/|#|mailto:|tel:)/i.test(href);
+}
+
+// Drop-in <a> replacement that upgrades internal links to client navigation.
+// Works in both server and client trees (it's a client component, so server
+// components render it as a boundary; client components import it directly).
+export function SmartLink({ href, children, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) {
+    if (isExternal(href)) {
+        return (
+            <a href={href} {...props}>
+                {children}
+            </a>
+        );
+    }
+    return (
+        <Link href={href ?? '#'} {...props}>
+            {children}
+        </Link>
+    );
+}

--- a/components/related-articles.tsx
+++ b/components/related-articles.tsx
@@ -1,5 +1,6 @@
 import { sql } from '@vercel/postgres';
 import { Suspense } from 'react';
+import { SmartLink } from './link';
 
 interface RelatedArticle {
     url: string;
@@ -33,7 +34,7 @@ async function RelatedArticlesList({ url }: { url: string }) {
             <ul>
                 {articles.map((article) => (
                     <li key={article.url}>
-                        <a href={article.url}>{article.title}</a>
+                        <SmartLink href={article.url}>{article.title}</SmartLink>
                     </li>
                 ))}
             </ul>

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,3 +1,5 @@
+import { SmartLink } from './link';
+
 export function SiteFooter() {
     return (
         <footer className="site-footer">
@@ -6,52 +8,54 @@ export function SiteFooter() {
                     <div>
                         <h2>Read</h2>
                         <nav aria-label="Content">
-                            <a href="/blog">Latest articles</a>
-                            <a href="/categories">Categories</a>
-                            <a href="/collections">Curated collections</a>
-                            <a href="/interviews">Interviews</a>
-                            <a href="/talks">Talks</a>
+                            <SmartLink href="/blog">Latest articles</SmartLink>
+                            <SmartLink href="/categories">Categories</SmartLink>
+                            <SmartLink href="/collections">Curated collections</SmartLink>
+                            <SmartLink href="/interviews">Interviews</SmartLink>
+                            <SmartLink href="/talks">Talks</SmartLink>
+                            {/* RSS is an XML endpoint, not an RSC route — keep a full load */}
                             <a href="/rss.xml">RSS feed</a>
                         </nav>
                     </div>
                     <div>
                         <h2>Books & courses</h2>
                         <nav aria-label="Books and courses">
-                            <a href="https://scalingfastbook.com">Scaling Fast</a>
-                            <a href="/senior-mindset">Senior Engineer Mindset</a>
-                            <a href="https://serverlesshandbook.dev">Serverless Handbook</a>
-                            <a href="/books">All books</a>
-                            <a href="/courses">Courses</a>
-                            <a href="/workshops">Workshops</a>
+                            <SmartLink href="https://scalingfastbook.com">Scaling Fast</SmartLink>
+                            <SmartLink href="/senior-mindset">Senior Engineer Mindset</SmartLink>
+                            <SmartLink href="https://serverlesshandbook.dev">Serverless Handbook</SmartLink>
+                            <SmartLink href="/books">All books</SmartLink>
+                            <SmartLink href="/courses">Courses</SmartLink>
+                            <SmartLink href="/workshops">Workshops</SmartLink>
                         </nav>
                     </div>
                     <div>
                         <h2>Collections</h2>
                         <nav aria-label="Collections">
-                            <a href="/collections/seniormindset">Senior Mindset</a>
-                            <a href="/collections/react">React</a>
-                            <a href="/collections/javascript">JavaScript</a>
-                            <a href="/collections/serverless">Serverless & Backend</a>
-                            <a href="/collections/indie-hacking">Indie Hacking</a>
-                            <a href="/collections/fullstack-web">Fullstack Web</a>
+                            <SmartLink href="/collections/seniormindset">Senior Mindset</SmartLink>
+                            <SmartLink href="/collections/react">React</SmartLink>
+                            <SmartLink href="/collections/javascript">JavaScript</SmartLink>
+                            <SmartLink href="/collections/serverless">Serverless & Backend</SmartLink>
+                            <SmartLink href="/collections/indie-hacking">Indie Hacking</SmartLink>
+                            <SmartLink href="/collections/fullstack-web">Fullstack Web</SmartLink>
                         </nav>
                     </div>
                     <div>
                         <h2>About</h2>
                         <nav aria-label="Meta">
-                            <a href="/about">About Swizec</a>
-                            <a href="/testimonials">Testimonials</a>
-                            <a href="/letters">Newsletter</a>
-                            <a href="https://twitter.com/swizec">Twitter</a>
-                            <a href="https://github.com/swizec">GitHub</a>
-                            <a href="https://youtube.com/swizecteller">YouTube</a>
-                            <a href="/privacy">Privacy policy</a>
+                            <SmartLink href="/about">About Swizec</SmartLink>
+                            <SmartLink href="/testimonials">Testimonials</SmartLink>
+                            <SmartLink href="/letters">Newsletter</SmartLink>
+                            <SmartLink href="https://twitter.com/swizec">Twitter</SmartLink>
+                            <SmartLink href="https://github.com/swizec">GitHub</SmartLink>
+                            <SmartLink href="https://youtube.com/swizecteller">YouTube</SmartLink>
+                            <SmartLink href="/privacy">Privacy policy</SmartLink>
                         </nav>
                     </div>
                 </div>
                 <p className="site-footer-note">
-                    Made with ❤️ by <a href="/about">Swizec Teller</a> · © {new Date().getFullYear()}{' '}
-                    Swizec LLC · <a href="mailto:hi@swizec.com">hi@swizec.com</a>
+                    Made with ❤️ by <SmartLink href="/about">Swizec Teller</SmartLink> · ©{' '}
+                    {new Date().getFullYear()} Swizec LLC ·{' '}
+                    <SmartLink href="mailto:hi@swizec.com">hi@swizec.com</SmartLink>
                 </p>
             </div>
         </footer>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,18 +1,20 @@
+import { SmartLink } from './link';
+
 export function SiteHeader() {
     return (
         <header className="site-header">
             <div className="site-header-inner">
-                <a className="site-logo" href="/">
+                <SmartLink className="site-logo" href="/">
                     Swizec Teller
                     <span className="site-logo-sub">software engineering lessons from production</span>
-                </a>
+                </SmartLink>
                 <nav aria-label="Main">
-                    <a href="/blog">Blog</a>
-                    <a href="/books">Books</a>
-                    <a href="/about">About</a>
-                    <a className="site-header-cta" href="/letters">
+                    <SmartLink href="/blog">Blog</SmartLink>
+                    <SmartLink href="/books">Books</SmartLink>
+                    <SmartLink href="/about">About</SmartLink>
+                    <SmartLink className="site-header-cta" href="/letters">
                         Get the newsletter 💌
-                    </a>
+                    </SmartLink>
                 </nav>
             </div>
         </header>

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,0 +1,13 @@
+import type { MDXComponents } from 'mdx/types';
+import { SmartLink } from './components/link';
+
+// Root MDX provider (Next.js-style convention timber picks up). Routes every
+// markdown link in MDX content — article bodies, standalone pages, and shared
+// MDX imports — through SmartLink, so internal links get client navigation
+// while external ones stay plain <a>.
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+    return {
+        ...components,
+        a: SmartLink as MDXComponents['a'],
+    };
+}

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -10,6 +10,7 @@ import Courses from "./courses.mdx"
 import Talks from "./talks.mdx"
 import Books from "./books.mdx"
 import About from "./about.mdx"
+import { SmartLink } from "@/components/link"
 
 # Read Software Engineering Lessons from Production
 
@@ -31,7 +32,7 @@ Subscribe below 👇
 
 <LatestArticles limit={5} />
 
-<a className="button" href="/blog/">Read more latest articles 👉 /blog</a>
+<SmartLink className="button" href="/blog/">Read more latest articles 👉 /blog</SmartLink>
 
 ## Or try a curated collection
 
@@ -45,7 +46,7 @@ Getting that senior title is easy. Just stick around. Being a true senior takes 
 
 <LatestArticles pattern="SeniorMindset|Mindset" limit={3} />
 
-<a className="button" href="/collections/seniormindset/">Read more Senior Mindset essays 👉</a>
+<SmartLink className="button" href="/collections/seniormindset/">Read more Senior Mindset essays 👉</SmartLink>
 
 ### Read JavaScript and TypeScript lessons from production
 
@@ -53,7 +54,7 @@ I took a bet on JavaScript in 2005 when it was known as DHTML. It's been my favo
 
 <LatestArticles pattern="JavaScript|TypeScript" limit={3} />
 
-<a className="button" href="/collections/javascript/">Read more JavaScript and TypeScript lessons from production 👉</a>
+<SmartLink className="button" href="/collections/javascript/">Read more JavaScript and TypeScript lessons from production 👉</SmartLink>
 
 ### Take your React beyond the tutorial
 
@@ -61,7 +62,7 @@ React is here to stay. It solves many problems you may not even know existed. Th
 
 <LatestArticles pattern="React|Reactjs|React.js|gatsby|nextjs" limit={3} />
 
-<a className="button" href="/collections/react/">Read more React lessons from production 👉</a>
+<SmartLink className="button" href="/collections/react/">Read more React lessons from production 👉</SmartLink>
 
 ### Find insights into Serverless and modern backends
 
@@ -69,7 +70,7 @@ I've been building web backends since ~2004 when they were just called websites.
 
 <LatestArticles pattern="Serverless|Backend|Backend Web" limit={3} />
 
-<a className="button" href="/collections/serverless/">Read more serverless and backend articles 👉</a>
+<SmartLink className="button" href="/collections/serverless/">Read more serverless and backend articles 👉</SmartLink>
 
 ### Read about indie hacking from the trenches
 
@@ -77,7 +78,7 @@ Indie Hacking has been near and dear to me for over a decade. Diversifying your 
 
 <LatestArticles pattern="IndieHacking|Business" limit={3} />
 
-<a className="button" href="/collections/indie-hacking/">Read more essays about running an indie business 👉</a>
+<SmartLink className="button" href="/collections/indie-hacking/">Read more essays about running an indie business 👉</SmartLink>
 
 ## What others are saying
 


### PR DESCRIPTION
Per the TimberJS author: plain `<a>` tags only client-navigate on browsers with the modern Navigation API; `<Link>` works across all clients. This routes every internal link through timber's `<Link>` for RSC client-side navigation, while leaving external links as plain `<a>`.

Stacked on #139 (base: `timber-archive`).

## SmartLink

`components/link.tsx` — a drop-in `<a>` replacement (`'use client'`) that renders timber's `<Link>` for in-app routes and a plain `<a>` for anything external (scheme like `http:`/`mailto:`/`tel:`, protocol-relative `//`, or a bare `#` fragment). Because it's a client component, it works in both server trees (rendered as a boundary) and client components (imported directly).

## Coverage

- **Chrome (TSX):** header, footer, byline, book sidebar + promo, article listings, archive pagination + time rail, Filed-under chips, blog/category index + listing pages
- **MDX content:** a root `mdx-components.tsx` provider (timber's Next.js-style convention) maps every markdown link `[x](/y)` → SmartLink. This covers article bodies, standalone pages, **and** shared MDX imports (About/Workshops/Books/Courses/Talks embedded on the home page) — all in one place
- **Literal button CTAs** in `index.mdx` converted to `<SmartLink className="button">`

## Left as plain `<a>` (external)

Embed components (giphy/tweet/bluesky/youtube), social links, `mailto:`, and the `/rss.xml` feed (an XML endpoint, not an RSC route — a full load is correct there).

## Verified

- ✅ **SPA navigation confirmed**: clicking a *markdown-sourced* link (`/testimonials/` from the home page) fired an RSC `?_rsc=` fetch with no full document load — proving the MDX provider is wired and Link works end to end
- ✅ Internal + external links render with correct hrefs
- ✅ Production build passes; dev server compiles clean, no hydration errors

## Test on preview

- [ ] Click around header/footer/listings — instant client transitions, no full reloads
- [ ] External links (books, socials) still open normally
- [ ] Works on a browser without the Navigation API (the whole point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)