### PR TITLE
Cleanups from TimberJS review: feed lib, zod trim, _actions

### DIFF
--- a/app/_actions/subscribe.ts
+++ b/app/_actions/subscribe.ts
@@ -38,15 +38,21 @@ async function kitPost(path: string, body: Record<string, unknown>) {
 // rejects them first, so nothing gets subscribed on those either.
 function isBot(input: { email: string; first_name: string; website?: string }) {
     if (input.website) return true;
-    if (input.email.trim().toLowerCase() === 'null') return true;
-    if (input.first_name.trim().toLowerCase() === 'null') return true;
+    // email/first_name arrive trimmed from the schema below
+    if (input.email.toLowerCase() === 'null') return true;
+    if (input.first_name.toLowerCase() === 'null') return true;
     return false;
 }
 
 export const subscribe = action
     .schema(
         z.object({
-            email: z.email("That doesn't look like an email address"),
+            // Trim before validating so padded input (mobile keyboards) still
+            // passes and reaches Kit clean — no manual .trim() downstream.
+            email: z
+                .string()
+                .trim()
+                .pipe(z.email("That doesn't look like an email address")),
             first_name: z.string().trim().min(1, 'What should I call you?'),
             // Honeypot — hidden from humans, bots fill it
             website: z.string().optional(),

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,4 +1,5 @@
 import { allPages } from 'content-collections';
+import { Feed } from 'feed';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
@@ -7,21 +8,7 @@ import rehypeStringify from 'rehype-stringify';
 const SITE_URL = 'https://swizec.com';
 const FEED_TITLE = 'Swizec Teller';
 const FEED_DESCRIPTION = 'A geek with a hat';
-const FEED_URL = `${SITE_URL}/rss.xml`;
-
-function escapeXml(str: string): string {
-    return str
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&apos;');
-}
-
-function escapeCdata(str: string): string {
-    // ]]> ends a CDATA section — split across two sections to neutralize it
-    return str.replace(/]]>/g, ']]]]><![CDATA[>');
-}
+const AUTHOR = { name: 'Swizec Teller', email: 'hi@swizec.com', link: SITE_URL };
 
 // markdown → HTML via the same remark/rehype stack the site uses for MDX.
 // allowDangerousHtml passes through any raw HTML already in the prose.
@@ -89,43 +76,50 @@ export async function GET(): Promise<Response> {
         .slice(0, 50);
 
     // Use the most recent article's date so the feed is stable between deploys
-    const lastBuildDate =
-        publishedPages.length > 0
-            ? new Date(publishedPages[0].published!).toUTCString()
-            : now.toUTCString();
+    const updated =
+        publishedPages.length > 0 ? new Date(publishedPages[0].published!) : now;
 
+    const feed = new Feed({
+        title: FEED_TITLE,
+        description: FEED_DESCRIPTION,
+        id: SITE_URL,
+        link: SITE_URL,
+        language: 'en-us',
+        copyright: `© ${now.getFullYear()} Swizec Teller`,
+        updated,
+        feedLinks: { rss: `${SITE_URL}/rss.xml` },
+        author: AUTHOR,
+    });
+
+    // Render excerpts in parallel but keep the sorted order (Promise.all
+    // preserves array order); addItem in a plain loop so the feed stays
+    // newest-first regardless of which excerpt resolves first.
     const items = await Promise.all(
         publishedPages.map(async (page) => {
             const url = pageUrl(page._meta.path);
-            const pubDate = new Date(page.published!).toUTCString();
-            const description = await renderExcerptHtml(page.content, url);
-
-            return `    <item>
-      <title>${escapeXml(page.title)}</title>
-      <link>${url}</link>
-      <guid isPermaLink="true">${url}</guid>
-      <pubDate>${pubDate}</pubDate>${page.description ? `\n      <description>${escapeXml(page.description)}</description>` : ''}
-      <content:encoded><![CDATA[${escapeCdata(description)}]]></content:encoded>
-    </item>`;
+            return {
+                title: page.title,
+                url,
+                date: new Date(page.published!),
+                description: page.description || undefined,
+                content: await renderExcerptHtml(page.content, url),
+            };
         }),
     );
 
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0"
-  xmlns:content="http://purl.org/rss/1.0/modules/content/"
-  xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>${escapeXml(FEED_TITLE)}</title>
-    <description>${escapeXml(FEED_DESCRIPTION)}</description>
-    <link>${SITE_URL}</link>
-    <atom:link href="${FEED_URL}" rel="self" type="application/rss+xml" />
-    <language>en-us</language>
-    <lastBuildDate>${lastBuildDate}</lastBuildDate>
-${items.join('\n')}
-  </channel>
-</rss>`;
+    for (const item of items) {
+        feed.addItem({
+            title: item.title,
+            id: item.url,
+            link: item.url,
+            date: item.date,
+            description: item.description,
+            content: item.content,
+            author: [AUTHOR],
+        });
+    }
 
-    return new Response(xml, {
+    return new Response(feed.rss2(), {
         headers: {
             'Content-Type': 'application/rss+xml; charset=utf-8',
             'Cache-Control': 'public, max-age=3600',

--- a/components/newsletter-signup.tsx
+++ b/components/newsletter-signup.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useActionState } from '@timber-js/app/client';
-import { subscribe } from '../app/actions/subscribe';
+import { subscribe } from '../app/_actions/subscribe';
 import { getNewsletterForm } from '../lib/newsletter-forms';
 
 interface NewsletterSignupProps {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vercel/postgres": "^0.10.0",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitejs/plugin-rsc": "^0.5.27",
+    "feed": "^6.0.0",
     "highlight.js": "^11.11.1",
     "lite-youtube-embed": "^0.3.4",
     "react": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@vitejs/plugin-rsc':
         specifier: ^0.5.27
         version: 0.5.27(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.25.12)(yaml@2.9.0))
+      feed:
+        specifier: ^6.0.0
+        version: 6.0.0
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -1170,6 +1173,10 @@ packages:
       picomatch:
         optional: true
 
+  feed@6.0.0:
+    resolution: {integrity: sha512-rvFOF1POce0ijAKy3tZN5T8PuprgIit/VbMyXJWcoYwcMOTSIJ7NqZb8DTLPJr77yiEO27kidm/fw0kcSIV+ww==, tarball: https://registry.npmjs.org/feed/-/feed-6.0.0.tgz}
+    engines: {node: '>=20', pnpm: '>=10'}
+
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
@@ -1753,6 +1760,10 @@ packages:
     resolution: {integrity: sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==}
     engines: {node: '>=16'}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==, tarball: https://registry.npmjs.org/sax/-/sax-1.6.0.tgz}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2029,6 +2040,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==, tarball: https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz}
+    hasBin: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -2952,6 +2967,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  feed@6.0.0:
+    dependencies:
+      xml-js: 1.6.11
+
   fflate@0.7.4: {}
 
   format@0.2.2: {}
@@ -3864,6 +3883,8 @@ snapshots:
       postcss-value-parser: 4.2.0
       yoga-layout: 3.2.1
 
+  sax@1.6.0: {}
+
   scheduler@0.27.0: {}
 
   section-matter@1.0.0:
@@ -4070,6 +4091,10 @@ snapshots:
   ws@8.21.0(bufferutil@4.1.0):
     optionalDependencies:
       bufferutil: 4.1.0
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
Addresses three nits from the TimberJS author's review.

## 1. RSS via the `feed` library (feedback #3)

`app/rss.xml/route.ts` no longer hand-builds the XML string with custom `escapeXml`/`escapeCdata` helpers — it uses [`feed`](https://github.com/jpmonette/feed) (`new Feed(...)` → `feed.addItem(...)` → `feed.rss2()`), following the author's [example](https://github.com/switz/rsc-mdx-blog-starter/blob/migrate-to-timberjs/src/app/feed.xml/route.ts). The library handles all escaping, CDATA, and namespace declarations.

Preserved from the old implementation:
- The rich `content:encoded` excerpts (first 3 prose paragraphs rendered through the same remark/rehype stack as MDX, plus a "Continue reading →" link)
- Newest-first order (excerpts render in parallel via `Promise.all`, which keeps array order; items are added in a plain loop)
- Stable `lastBuildDate` (most recent article's date), `application/rss+xml` content-type, and 1h `Cache-Control`

Verified: `/rss.xml` returns well-formed XML (`xmllint` clean), 50 items, all with `content:encoded`, `atom:link rel=self`, correct ordering.

## 2. Consistent zod `.trim()` (feedback #4)

The email field wasn't trimmed, so cleanup was done by hand in `isBot`. Now:

```ts
email: z.string().trim().pipe(z.email("That doesn't look like an email address")),
```

`.trim()` before validation (confirmed `z.email().trim()` validates *before* trimming in zod v4, so the `.pipe()` order matters). This makes email consistent with `first_name`, and the redundant `input.email.trim()` / `input.first_name.trim()` calls in `isBot` are gone.

## 3. `app/actions` → `app/_actions` (feedback #5)

The actions directory was declaring a route segment with no page. Renamed with the underscore prefix so it opts out of routing. Only real importer (`components/newsletter-signup.tsx`) updated — the other grep hit was inside an article's code sample.

Build passes; feed verified in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)