### PR TITLE
Add XML sitemap + robots.txt

### DIFF
--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,16 @@
+// Served as a route because public/ is gitignored (stale Gatsby build output
+// lives there locally), so files in it never reach deploys.
+const robots = `User-agent: *
+Allow: /
+
+Sitemap: https://swizec.com/sitemap.xml
+`;
+
+export function GET(): Response {
+    return new Response(robots, {
+        headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+        },
+    });
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,77 @@
+import { allPages } from 'content-collections';
+import { SitemapStream, streamToPromise } from 'sitemap';
+import { Readable } from 'node:stream';
+import { getCategoryIndex } from '../../lib/categories';
+
+const SITE_URL = 'https://swizec.com';
+
+// Routable pages that shouldn't be crawled: the status page, dev scaffolding,
+// and post-signup / unsubscribe pages. Explicit list — a pattern could
+// silently swallow a future legit slug.
+const EXCLUDED = new Set([
+    '404',
+    'example',
+    'bye',
+    '5-steps-thanks',
+    'scaling-fast/thanks-for-voting',
+]);
+
+// Google ignores <priority> and <changefreq>, so entries carry only the URL
+// and — where we can vouch for it — <lastmod>. Articles use their publish
+// date; listing pages use the newest article they list (they change exactly
+// when an article ships); undated standalone pages omit lastmod rather than
+// report an inaccurate one.
+async function buildSitemap(): Promise<Buffer> {
+    const now = new Date();
+    const links: { url: string; lastmod?: string }[] = [];
+    let newest: string | undefined;
+
+    for (const page of allPages) {
+        const path = page._meta.path.replace(/\/index$/, '');
+        if (path === 'index') continue; // home is added below as /
+        if (EXCLUDED.has(path)) continue;
+        // Future-dated posts are routable but unannounced — keep them out,
+        // same as the RSS feed.
+        if (page.published && new Date(page.published) > now) continue;
+
+        if (page.published && (!newest || page.published > newest)) {
+            newest = page.published;
+        }
+        links.push({ url: `/${path}`, lastmod: page.published });
+    }
+
+    // Listing pages: home, the article archive, and per-category listings.
+    links.unshift(
+        { url: '/', lastmod: newest },
+        { url: '/blog', lastmod: newest },
+        { url: '/categories', lastmod: newest },
+    );
+    // Most categories are frontmatter one-offs (1,035 of ~1,520 hold a single
+    // article) — thin near-duplicate listings that waste crawl budget. Only
+    // categories with a real collection of articles go in the sitemap; the
+    // pages themselves stay routable either way.
+    for (const category of Object.values(await getCategoryIndex())) {
+        if (category.articles.length < 3) continue;
+        links.push({
+            url: `/categories/${category.slug}`,
+            lastmod: category.articles[0]?.published,
+        });
+    }
+
+    // ~2k URLs — well under the 50k/50MB single-file limit, so no index file.
+    const stream = new SitemapStream({ hostname: SITE_URL });
+    return streamToPromise(Readable.from(links).pipe(stream));
+}
+
+// Content is fixed per deploy; build once per instance and reuse.
+let cached: Promise<Buffer> | undefined;
+
+export async function GET(): Promise<Response> {
+    cached ??= buildSitemap();
+    return new Response(await cached, {
+        headers: {
+            'Content-Type': 'application/xml; charset=utf-8',
+            'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+        },
+    });
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "remark-mdx-frontmatter": "^5.2.0",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
+    "sitemap": "^9.0.1",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       remark-rehype:
         specifier: ^11.1.2
         version: 11.1.2
+      sitemap:
+        specifier: ^9.0.1
+        version: 9.0.1
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -861,6 +864,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==, tarball: https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz}
+
   '@types/node@26.0.1':
     resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
@@ -877,6 +883,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==, tarball: https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -929,6 +938,9 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==, tarball: https://registry.npmjs.org/arg/-/arg-5.0.2.tgz}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1788,6 +1800,11 @@ packages:
     resolution: {integrity: sha512-NKKjWzR6LIGL3sXBrWDw9sDS9cxx42/DkysaNqJEeOWE8Kix5gpak0bc00OfDVEO4oyXSyz8+aRaqKoBD1yo7A==}
     engines: {node: '>=20'}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==, tarball: https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1859,6 +1876,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -2700,6 +2720,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/node@26.0.1':
     dependencies:
       undici-types: 8.3.0
@@ -2719,6 +2743,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 26.0.1
 
   '@types/unist@2.0.11': {}
 
@@ -2765,6 +2793,8 @@ snapshots:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  arg@5.0.2: {}
 
   argparse@1.0.10:
     dependencies:
@@ -3940,6 +3970,13 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.6.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
@@ -3994,6 +4031,8 @@ snapshots:
   turbo-stream@3.2.0: {}
 
   typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
 
   undici-types@8.3.0: {}
 


### PR DESCRIPTION
Sitemap for Google, built with the [`sitemap`](https://github.com/ekalinin/sitemap.js) library rather than hand-assembled XML, at `/sitemap.xml` with `robots.txt` pointing at it.

## What Google actually wants (research)

From [Google's sitemap guidelines](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap):
- **`priority` and `changefreq` are ignored** — omitted entirely
- **`lastmod` is used only if "consistently and verifiably accurate"** — so it's set only where we can vouch for it
- Absolute canonical URLs, UTF-8, entity-escaped (the library handles this)
- 50k URLs / 50MB per file — we're at ~2.3k, single file, no index needed
- Discovery via `Sitemap:` directive in robots.txt

## lastmod policy

| Page | lastmod |
|---|---|
| Articles / dated pages | publish date |
| `/`, `/blog`, `/categories` | newest published article (listings change exactly when an article ships) |
| Category listings | newest article in that category |
| Undated standalone pages | omitted rather than faked |

## What's included / excluded

**In (2,295 URLs):** 2,009 published pages, the three listing pages, and 283 category listings with 3+ articles.

**Out:** `404`/`example`/`bye`/thanks pages (routable but shouldn't be crawled), future-dated posts (same rule as RSS), and the **1,237 categories holding only 1–2 articles** — 1,035 of the site's 1,520 categories are frontmatter one-offs with a single article, i.e. thin near-duplicate listings that would waste crawl budget. They stay routable; they just aren't advertised. Threshold is one line in `app/sitemap.xml/route.ts` if you want it looser.

## robots.txt as a route

`public/` turns out to be **gitignored** (Gatsby-era rule — it was the build output) yet it's Vite's resolved publicDir, so nothing in it ever reaches a deploy. robots.txt is therefore served from `app/robots.txt/route.ts` like `rss.xml`. ⚠️ Side discovery: the stale local `public/` is why `/social-cards/` and `/wp-content/` assets work in local builds but are missing from Vercel deploys — flagged as a separate follow-up task.

## Verified

- `xmllint` valid, 2,295 `<url>` entries, correct canonical form (no trailing slash, matches the pages' canonical meta)
- Exclusions confirmed absent; newest lastmod is the latest real article (no future dates)
- Both routes serve with correct content-type + cache headers (1h client / 1d edge, rebuilt once per instance)
- Production build exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)