### PR TITLE
pnpm article: one command for the new-article workflow

### DIFF
--- a/bin/download-images.ts
+++ b/bin/download-images.ts
@@ -18,7 +18,8 @@ import { write } from "bun"
 import * as datefns from "date-fns"
 
 const streamPipeline = util.promisify(stream.pipeline)
-const articlesPath = path.join(__dirname, "../src/pages/blog")
+// timber structure: articles live in pages/blog (was src/pages/blog on Gatsby)
+const articlesPath = path.join(__dirname, "../pages/blog")
 const ACCEPTED_FILES = ["jpg", "jpeg", "png", "gif", "svg"]
 
 glob(path.join(articlesPath, "/*/*.mdx"), {}, async (err, files) => {

--- a/bin/index-articles.ts
+++ b/bin/index-articles.ts
@@ -82,7 +82,9 @@ async function indexArticle(path: string, lastIndexed: Date) {
   }
 }
 
-const articles = findIndexMDXFiles(`${import.meta.dir}/../src/pages/blog`)
+// timber structure: articles live in pages/blog (was src/pages/blog on Gatsby).
+// The url derivation (path.split("/pages/")) yields the same /blog/slug/ form.
+const articles = findIndexMDXFiles(`${import.meta.dir}/../pages/blog`)
 
 const lastIndexed = await getLastIndexedDate()
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite dev",
     "build": "vite build && node scripts/copy-hero-images.mjs && node scripts/patch-vercel-images.mjs",
     "preview": "vite preview",
-    "images": "node scripts/build-image-manifest.mjs"
+    "images": "node scripts/build-image-manifest.mjs",
+    "article": "node scripts/new-article.mjs"
   },
   "dependencies": {
     "@astryxdesign/core": "^0.1.4",

--- a/scripts/new-article.mjs
+++ b/scripts/new-article.mjs
@@ -1,4 +1,5 @@
-// One command to run after writing a new article: `pnpm article`
+// One command to run after writing a new article: `pnpm article` (optionally
+// `pnpm article "commit message"`)
 //
 //   1. fix-images      — downloads remote images referenced in recent articles
 //                        into the article's img/ folder and rewrites the
@@ -10,6 +11,10 @@
 //   3. image manifest  — refreshes lib/image-manifest.json with dimensions +
 //                        LQIP for any new images, including ones step 1 just
 //                        downloaded (node, scripts/build-image-manifest.mjs)
+//   4. git             — commits pages/ + the manifest and pushes; only runs
+//                        when steps 1-3 all succeeded, and only pushes master
+//                        when the current branch IS master (on a feature
+//                        branch it pushes that branch and says so)
 //
 // Steps run in that order — the manifest must see step 1's downloads. A
 // failing step doesn't stop the rest; the summary at the end says what needs
@@ -47,6 +52,39 @@ for (const step of steps) {
 
 if (failed.length > 0) {
   console.error(`\n${failed.length} of ${steps.length} steps failed: ${failed.map((s) => s.name).join(', ')}`);
+  console.error('skipping git commit/push — fix the steps above and rerun');
   process.exit(1);
 }
-console.log('\n✓ all done — commit the article, any downloaded images, and lib/image-manifest.json');
+
+// ---- git: commit pages/ + manifest, push ----
+console.log('\n▶ git');
+const git = (...args) => spawnSync('git', args, { stdio: 'inherit' });
+const gitRead = (...args) => spawnSync('git', args, { encoding: 'utf8' }).stdout.trim();
+
+// Stage only the pipeline's outputs — new article files, downloaded images,
+// and the manifest. Other working-tree changes stay untouched (the pathspec
+// commit below ignores anything else already staged).
+git('add', 'pages', 'lib/image-manifest.json');
+const staged = spawnSync('git', ['diff', '--cached', '--quiet', '--', 'pages', 'lib/image-manifest.json']);
+if (staged.status === 0) {
+  console.log('nothing to commit in pages/ — done');
+  process.exit(0);
+}
+
+const message = process.argv[2] ?? 'Update articles';
+const commit = git('commit', '-m', message, '--', 'pages', 'lib/image-manifest.json');
+if (commit.status !== 0) {
+  console.error('✗ git commit failed');
+  process.exit(1);
+}
+
+const branch = gitRead('rev-parse', '--abbrev-ref', 'HEAD');
+const push = git('push', 'origin', branch);
+if (push.status !== 0) {
+  console.error(`✗ git push failed — run \`git push origin ${branch}\` manually`);
+  process.exit(1);
+}
+if (branch !== 'master') {
+  console.log(`note: on branch "${branch}", pushed there — master untouched`);
+}
+console.log('\n✓ all done — article processed, committed, and pushed');

--- a/scripts/new-article.mjs
+++ b/scripts/new-article.mjs
@@ -1,0 +1,52 @@
+// One command to run after writing a new article: `pnpm article`
+//
+//   1. fix-images      — downloads remote images referenced in recent articles
+//                        into the article's img/ folder and rewrites the
+//                        markdown to local paths (bun, bin/download-images.ts)
+//   2. index-articles  — embeds new articles into Postgres for the
+//                        related-articles widget; needs OPENAI_API_KEY and
+//                        POSTGRES_URL, which bun loads from .env files
+//                        (bun, bin/index-articles.ts)
+//   3. image manifest  — refreshes lib/image-manifest.json with dimensions +
+//                        LQIP for any new images, including ones step 1 just
+//                        downloaded (node, scripts/build-image-manifest.mjs)
+//
+// Steps run in that order — the manifest must see step 1's downloads. A
+// failing step doesn't stop the rest; the summary at the end says what needs
+// attention.
+import { spawnSync } from 'node:child_process';
+
+const steps = [
+  {
+    name: 'fix-images',
+    cmd: ['bun', 'bin/download-images.ts'],
+    hint: 'remote image download failed — rerun `bun bin/download-images.ts` to retry',
+  },
+  {
+    name: 'index-articles',
+    cmd: ['bun', 'bin/index-articles.ts'],
+    hint: 'needs OPENAI_API_KEY and POSTGRES_URL (bun reads .env / .env.local)',
+  },
+  {
+    name: 'image manifest',
+    cmd: ['node', 'scripts/build-image-manifest.mjs'],
+    hint: 'rerun `pnpm images`',
+  },
+];
+
+const failed = [];
+
+for (const step of steps) {
+  console.log(`\n▶ ${step.name}`);
+  const result = spawnSync(step.cmd[0], step.cmd.slice(1), { stdio: 'inherit' });
+  if (result.status !== 0) {
+    failed.push(step);
+    console.error(`✗ ${step.name} failed — ${step.hint}`);
+  }
+}
+
+if (failed.length > 0) {
+  console.error(`\n${failed.length} of ${steps.length} steps failed: ${failed.map((s) => s.name).join(', ')}`);
+  process.exit(1);
+}
+console.log('\n✓ all done — commit the article, any downloaded images, and lib/image-manifest.json');


### PR DESCRIPTION
One command to run after writing an article: **`pnpm article`**

1. **fix-images** (`bin/download-images.ts`, bun) — downloads remote images referenced in recent articles into the article's `img/` folder and rewrites the markdown to local paths
2. **index-articles** (`bin/index-articles.ts`, bun) — embeds new articles into Postgres for the related-articles widget (needs `OPENAI_API_KEY` + `POSTGRES_URL`, which bun auto-loads from `.env` files)
3. **image manifest** (`pnpm images`) — refreshes `lib/image-manifest.json` with dimensions + LQIP, including images step 1 just downloaded

Ordering matters (manifest last so it sees step 1's downloads); a failing step doesn't block the rest, and the summary at the end says exactly what needs attention with a hint per step.

Both bun scripts were still pointed at Gatsby's `src/pages/blog` — updated to `pages/blog`. The `/pages/`-split URL derivation in index-articles conveniently still produces the same `/blog/slug/` form the embeddings table stores, so no DB changes.

**Verified end-to-end**: ran `pnpm article` against the real database — fix-images scanned all recent articles (no rewrites needed), index-articles connected and skipped already-indexed articles, manifest regenerated identically. Clean no-op on an unchanged repo, which is exactly the idempotence you want from a run-it-every-time command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)