### PR TITLE
Serve legacy wp-content images through the content image pipeline

### DIFF
--- a/lib/image-manifest.json
+++ b/lib/image-manifest.json
@@ -13642,5 +13642,5047 @@
  "pages/senior-mindset/img/SeniorMindset-cover-3d.png": {
   "w": 2048,
   "h": 2048
+ },
+ "static/wp-content/uploads/2009/11/1259019730277.jpg": {
+  "w": 548,
+  "h": 717,
+  "lqip": "data:image/webp;base64,UklGRq4AAABXRUJQVlA4IKIAAACwBACdASoUABoAPzmIuVOvKSWisAgB4CcJQBYj6YhI28cx1yLpXNg1W9HvcbYAAP6ex39cgdPfGmbm4bxZEPu/tOiN0IswEjPWVYwya3zH8v8BPNdLuiNt3WXSHnKkJAH2EVEU6RrfdfNsmABbfpWJh+peZjUnapqfMgbHIUhn4Lb1AEgUFxSYZVwVh9rxpZ+G/Ff2iIOmdFmAjABGqFjJkAA="
+ },
+ "static/wp-content/uploads/2009/11/2007_grindhouse_pt_003.jpg": {
+  "w": 1920,
+  "h": 1080,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAACQAwCdASoUAAsAPzmGulOvKSWisAgB4CcJZwAASnJ2bZZv6+0AAP653ZqU3ApJ9j64Ew6NNCZoKs8Ck6GvQy88dshF/ucYwYZY4speYooy2gQybRAAF8BsgAA="
+ },
+ "static/wp-content/uploads/2009/11/6054550-300x225.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJbAC+SCFdAJIns3f+tv14APyyDsUCtXL138hKDff2XgHcNjNNWJHwyOvszzb3ZIGFRb+piHUerT/E7z2RTmB4z0+rf9jkiUL/2OOoAAA="
+ },
+ "static/wp-content/uploads/2009/11/i_pmsmv5f-300x300.jpg": {
+  "w": 300,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRqwAAABXRUJQVlA4IKAAAADwBACdASoUABQAPzmUwFmvKiajqAgB4CcJaAC7M1XBooD/bPB0KgshjBqKT1QYrwAAyUqxhCej8NjKdwXXwZ88oXmA6Q1qcDmqqtZjwd3JMHc+r1W+2gMuBS01Fg94lI4D0xFHuTk3lSIlWlZi+Ts+dDVKmF8w/vqA26MBuTtzxAjWO9PvJF0oTH8V2BVKtzGbJYbb46d5a7Lt/NqyAAAA"
+ },
+ "static/wp-content/uploads/2009/11/i_pmsmv5f.jpg": {
+  "w": 1000,
+  "h": 1000,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAADQBACdASoUABQAPzmUwVmvKicjqAgB4CcJagAALZ8d9levR/JpdNL3eI+TeKAbIADJclVLWNptDz3QkE0Vyu8BthCtZOBZpmTtY0qXF3HOul7+/n6uA3b0y7DB0Jx2ACviYHc+/+iRAQ7jWL1jpVOgfJfBpW7ZiCSia5gMIwXzP+08fA+9up3qlUHuAEwapLkT4fcTs0R0yndxKRkq5lrnSVhmAAAA"
+ },
+ "static/wp-content/uploads/2009/11/IMG003511-300x225.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAABwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZQDDNBjvAfmbPjgA/uv89avnhfqn801Qq+VSdJPExBPNgzxPR1Q/c2oddHc4eryaSpQyZyoAAA=="
+ },
+ "static/wp-content/uploads/2009/11/michelle-obama-ape.jpg": {
+  "w": 356,
+  "h": 371,
+  "lqip": "data:image/webp;base64,UklGRqgAAABXRUJQVlA4IJwAAABQBQCdASoUABUAPzmUwFmvKiajqAgB4CcJagDA3BI2Z3OMI0r+0jh+sGhBGC3FWH3Vc4AA/uCm4Nkz0S2zR8jnvuS1fppl7ZSnUKAUGNN7rDwfDbBPg4njWV2/awKjn0rlUHVj7EdmI45usbMNjtROPBfXkav/LFsYMveD4eYTfPNn8ZZBHC2iRSdMl3Zx3EK+CahFndxEzo+IAAA="
+ },
+ "static/wp-content/uploads/2009/12/15af187398c7b780dc84289869c95f10.jpeg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBOgBEE0Yk1UbD4j4AD9Ym4Rgqd/MCQYx5RwGKWzeRhn6zIraGtnMegMBMR2fmGan99FssiJRT0AAAA="
+ },
+ "static/wp-content/uploads/2009/12/2312957360_7394ec5f6c_m.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAADQAwCdASoUAA8APzmGuVOvKKWisAgB4CcJZQDG9BcRIKXPt0Oz1mwA/hQfolBPr9ZIzR62EJM1q+BuWgmZFPL8T+NNA19vBRMduOS0wAA="
+ },
+ "static/wp-content/uploads/2009/12/300px-Brittanymurphynavy.jpg": {
+  "w": 300,
+  "h": 404,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAADwBACdASoUABsAPzmKu1YvKSYjsBgIAeAnCWgAwNw0aNbyWvYZb351zOPzQgZ3V/AA/s4ByiBia5g0rG3Qjj/IXqb8veH1K/lhdmiU0dhwpQcCbvRvSSvUuNk8fSK7joJ/WKOGFdaO5/FB+BYEhDrYbzg5h7VeXhsfg3HbejytI4yDDova3irpwsucs23bt1LF+HsBHinq+hEAEnIAeRDy2Q2GMAAA"
+ },
+ "static/wp-content/uploads/2009/12/300px-Fear_and_Loathing_in_Las_Vegas.jpg": {
+  "w": 300,
+  "h": 458,
+  "lqip": "data:image/webp;base64,UklGRp4AAABXRUJQVlA4IJIAAABQBQCdASoUAB8APzmKvFYvKSYjsBgIAeAnCWMAsO2JqEqHUpGWiRM+X1Bwx1g5Fv7CmwAA343m+J2dTpvgYVwAjxHi9g+jd6Jvo+XiU++u4Bl4pLFHqwqZlnwcd0ZF+51ew8zUOoD4NmdZXAoSbiG+aYxUh7l9zWo5CTsSZ7KwNlm2BkQtHCey3AyRlnXZ1gAAAA=="
+ },
+ "static/wp-content/uploads/2009/12/300px-Heath_Ledger.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJQBYhhMzAAU/qWu/uJlBIUAD+cXXShLZnCuX4l5LVP9SrgE25qVD8RK0Aorm/N7jMLCOB6jaHnC0+s5XInKQPiK16tXiwuMUY+UhkAnKAx4U5V6GQ9SwAAAA="
+ },
+ "static/wp-content/uploads/2009/12/300px-James_Dean_in_East_of_Eden_trailer_2.jpg": {
+  "w": 300,
+  "h": 239,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAACwAwCdASoUABAAPzmGuVOvKKWisAgB4CcJZQAAXKvoJZNpDKqLgAD+y8jRMLarSHXOgsshBTes4DusW2lC1McTG8FaJ5Sx5v3i4AAA"
+ },
+ "static/wp-content/uploads/2009/12/4152708765_0c04d2b380_m.jpg": {
+  "w": 240,
+  "h": 168,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAACQAwCdASoUAA4APzmGuVOvKSWisAgB4CcJZwAAQu2VoAnvVsIAAP7r/P8mNV1X0iNQ4HVw7je7269TJOT86STcSLfWB37m9Qe91bEhAL7VMfdPD74BA3ifYuMFUAAA"
+ },
+ "static/wp-content/uploads/2009/12/4153364026_fa218c6d0c_m.jpg": {
+  "w": 240,
+  "h": 189,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBOgBDqYNeWnr0v2gpQAAP7NXGclELVqMvy00EEfduNcotWL3tJ8sVPInOlBd4R94h9xWEEq9Ql8npogAA=="
+ },
+ "static/wp-content/uploads/2009/12/Avatar-Teaser-Poster.jpg": {
+  "w": 298,
+  "h": 442,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAADwBACdASoUAB4APzGAs1OuqCSisAwB0CYJZAAAXBcbavnBKJEq3RKE0xoIHse0PAAA/ujR6gP00mn9BAPp6mrD1RMMwpZUsEos2YevrYrMCgbWCqJdk9l+m9TB8ovJaYy6iv3C7iDagkB05b5tSrNdOsvfSWlTwSOUppcIXWzvc0WBfQAAAA=="
+ },
+ "static/wp-content/uploads/2009/12/FatherChristmastrial.jpg": {
+  "w": 255,
+  "h": 360,
+  "lqip": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4IJ4AAADQBACdASoUAB0APzmKvFYvKSYjsBgIAeAnCWkAACHkyuxKw3FGJ7mAOOEPzp55AAD9b+9VkVKDMBppEhPrzTZSWBUXa3RglZjrklYzCxc46IktL/IoBhys+LoAq8wZcsNHzesIlySHfg/UcQMzdUcm5dVghQLcqbdxviX63OIB2HAZ/ww3He63HvIugR02MSL9+uYTz0zVJ7tAd94AAA=="
+ },
+ "static/wp-content/uploads/2009/12/IMG00077.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAADwAgCdASoUAA8APzmGuVOvKSWwsAgCECcJZQC7ADLxQAD+7hPOjQa8iQ/kzqSeblnLPyAA"
+ },
+ "static/wp-content/uploads/2009/12/IMG00084.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBdgA8paf00PeNGFqAAA/juUuAUucEGzYBYin3Xpmdgt/2KKvEOI/M7XFx0HFPUHVQz5B+/+3fwsW/s/Ma/W8/IAAA=="
+ },
+ "static/wp-content/uploads/2009/12/IMG00133.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZwAAYfMk/fJscjGAAP7pJ/VykrkzLMnbj8yfoxxLEgU26GXUymTaRNlBON3N2y3yigUAAAA="
+ },
+ "static/wp-content/uploads/2009/12/IMG00135.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZwAAYafuxTz0Hah94diQAP7o3jny51aWXVFz4JFKX0tr8GBTbjq/Yj+O1qKi1HrSuLUtBHnHqhzA3tKOTApAPAA="
+ },
+ "static/wp-content/uploads/2009/12/IMG00137.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZQAAWpo8r41so17LQVoAAP7o3E6HdKAc3i3rzvLhzIBMji21gObSMu0QbvOxba7UGbZ5Kcrx1e0B50UrcxPStmsgjLUkqShgGyE/wU+OAmL0eM03rwAA"
+ },
+ "static/wp-content/uploads/2009/12/Jim_Morrison_-_Fillmore_East.jpg": {
+  "w": 200,
+  "h": 285,
+  "lqip": "data:image/webp;base64,UklGRpAAAABXRUJQVlA4IIQAAACwBACdASoUABwAPzmGulavKCWksBgIAeAnCWkAACalq9eUFePQzRttPJ5WBdKAAP6py7aoRcCB7tmgtfRBFuH5mVgN/dUOz6DjLD2+6dK+rNYyBLLne+7xfpZjN6XGz9oRAHyveeovSQYTCFKMG2kp4/Rdle5eDCJp+r2J8vSGwTkAAAA="
+ },
+ "static/wp-content/uploads/2009/12/Jimmy_Hendrix.JPG": {
+  "w": 220,
+  "h": 318,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAABQBACdASoUAB0APzmGulQvKKWjMAgB4CcJaQAAW+tBj7KrxGB22z2desAAAP7ryyhL7R5+FNmR4VnHjkc4YvjnCnpWXpQb+09zmR9lpQyhyqyGpV0cYAvsH5cSas27ldn6ceh2Pt5FAQAA"
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.34.50-AM.png": {
+  "w": 602,
+  "h": 269,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAACQAwCdASoUAAkAPzmIuVQvKSWjMAgB4CcJZwAARIMKwT2A1OAAAPWYPr3P6Lbx4BNHPuAGBo5Dxs6JG39Ct2OEIlSqssNUcHJ7+HBvViy2hjDKsBeP02q2nM6TwhlKC8PhyigA"
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.35.00-AM.png": {
+  "w": 700,
+  "h": 280,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAADQAwCdASoUAAgAPzmGulQvKSWjMAgB4CcJZQDG9B9+3jYKcmWAmAAA76H3ufj+Xl/N4gYAQkvZHHr5St4y87I5nns162AH22vY1Oti69PCAAAA"
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.35.09-AM.png": {
+  "w": 755,
+  "h": 322,
+  "lqip": "data:image/webp;base64,UklGRo4AAABXRUJQVlA4IIIAAADQAwCdASoUAAkAPzmGulOvKKWisAgB4CcJbACdMoADgv28aakbsyAA/un3kAftuXJGH7glZOnFmz24jDgPG44lCFMrmXwQobdGrp0Oga83/JL1zsN35Qi6+NqW4e+fNbnsdk8Z+kxi8pLe+JJqzoDWwihRo3sXTajuO0WeDvLB10AA"
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.35.20-AM.png": {
+  "w": 615,
+  "h": 314,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAADwAwCdASoUAAoAPzmEuVOvKKWisAgB4CcJZQDA3BuVu5Arp/ughWvIAP7nQXlbgVOZT9825Upp0/RSuVexV16NLDIGNlX4V74huffJJYF66jiiCmui3AAA"
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.35.31-AM.png": {
+  "w": 718,
+  "h": 306,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAACQAwCdASoUAAkAPzmEulOvKKWisAgB4CcJZwAATvD9qZtp3SCgAP5Uz3DIXECfxNNZN4MC0p9H40y4NqUwKup85lAPJV1TsXDGOcwL5nMyVv5YdTHNybyHAgAAAA=="
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.35.37-AM.png": {
+  "w": 824,
+  "h": 298,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAAAwAwCdASoUAAcAPzmIuVQvKSWjMAgB4CcJZQAAhAv8MmZAAP7qRu9L96wH0UxvmRS63zgFH+663kcSXlcG03q8XAA="
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.35.44-AM.png": {
+  "w": 695,
+  "h": 294,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAADwAwCdASoUAAgAPzmGuVOvKSWisAgB4CcJYwDE2CIaGJl/F5oFxdwAANzTySyya8rojMB7VVB7P/CMxP5aMT+8fgF8A9hDY98mTDkJYzfAAA=="
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.35.50-AM.png": {
+  "w": 679,
+  "h": 255,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAABQAwCdASoUAAgAPzmEuVOvKKWisAgB4CcJQAAKO5kWNM7bgAD+s7wFbfz6inLO+krWSqnCRMw/PWc1c7cjDKq6RK4b8YtPmw4eEUEmMRF/APZUxkzAU0euAAA="
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.38.56-AM.png": {
+  "w": 852,
+  "h": 284,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAADQAwCdASoUAAcAPzmEuVOvKKWisAgB4CcJZQCsAB6GefIYf4ybEgAA/HhUgECr6K5/+Rh3K+Q2LAKHniTqpxIYiUCs/uxfUC3LGtGDBK9xzmVcxF8V92yosryigAAA"
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.42.14-AM.png": {
+  "w": 701,
+  "h": 323,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAADQAwCdASoUAAkAPzmGulQvKSWjMAgB4CcJQAAK9jy3V32SucBGvKwA/sxWyZbB1Ckcs+0RFKvnP3E+kMAn8IM00McwOiBr+PW+uRTUYnVeh2EKFVmGPTmvpXrOgZXF71vZee9Xf4msY3TYeAAAAA=="
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.44.28-AM.png": {
+  "w": 517,
+  "h": 243,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACQAwCdASoUAAkAPzmGulQvKSWjMAgB4CcJQBWAAqYu0t9j4BAAAP6voatwk7UksvdaVRrC3T4xbqAoz8Oy1DNbcuPpkeqy2hoEUUg6CmAAAA=="
+ },
+ "static/wp-content/uploads/2009/12/Screen-shot-2009-12-14-at-1.45.30-AM.png": {
+  "w": 708,
+  "h": 289,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAADwAwCdASoUAAgAPzmEuVOvKKWisAgB4CcJZQC06BU1K20IPa99NtAAAMsVJTof/7sCwPXV9Gc5TzTEctQOVGFknXJOjgQmgn+hC+Ty9moyY14UAAA="
+ },
+ "static/wp-content/uploads/2010/01/300px-2005_walking_penis.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRroAAABXRUJQVlA4IK4AAACwBACdASoUABsAPzmOv1evKaajqAqp4CcJYwDG9AvAZOktoLvhkxgmZwzz+sYAAP6EWr8IGPwtLt/LUE+o7WZJ++sX8mw/cwJXIFqYuA695RsubgZDsQFat88z/vTF0KovcQYoJ37o8U51tWFjDHdxrn2j2g7yapNpQ0uBo21aVzVQvnf7MXzFIOtWXxDatxP6CoVhkRF6QUkSw09Y9qcmjIH9qPuA2gcCM3AAAAA="
+ },
+ "static/wp-content/uploads/2010/01/300px-Cray-1-p1010221.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAACQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwC06AgQZWZhU3IAAP7l8LKMeoP3AvMKri3Ft5c2vV88JyUxIjeGkDzQhZq8Ei4iMNmOtzzgv0luqcf4qFa60U5rAAAA"
+ },
+ "static/wp-content/uploads/2010/01/300px-Devils_Punchbowl_Waterfall,_New_Zealand.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4IJgAAAAwBQCdASoUABsAPzmOvVgvKaYjqAqp4CcJZAAALb7hKCkxM1a31aatC90CWzYcuE6gAAD+31oYfabcVAAN/lk0wPIJ0MIMq+rMEI/rUrqw8U8+/iP7/YJjAuHtZ03v/CQmGJRxRNqPziN/5iJTt6yEtyQJ50Wau962zalk7eMkFN2+M3vPm5njUuepJAxpQSkjfhzOhPIwAA=="
+ },
+ "static/wp-content/uploads/2010/01/300px-IBM402plugboard.Shrigley.wireside.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJZgCw7CKxnNe0TEtC34NKOYAA/qjeaSiT90ACGg+ccVS15AdEW2zbWNeNcLdEXQRM029JepbEytOukBDaUwzHSJTjOeU+CYUt9NbJ3sDe4uYIzgAAAA=="
+ },
+ "static/wp-content/uploads/2010/01/4239434615_b1222ecde2_m.jpg": {
+  "w": 240,
+  "h": 135,
+  "lqip": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4IEYAAACwAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJZAAAUq61+23PBZujgAD+6/5DkbTbQN/5KsTGT39NJIicmyKHofK+tkEoVYAA"
+ },
+ "static/wp-content/uploads/2010/01/4239467371_544c36b1ec_m.jpg": {
+  "w": 240,
+  "h": 135,
+  "lqip": "data:image/webp;base64,UklGRlAAAABXRUJQVlA4IEQAAACQAwCdASoUAAsAPzmEuVOvKKWisAgB4CcJQAAJTwCeFL1/aLGgAP7p3aiTWCpIbr7ITl4P20wI2qXlJ698eQnSbgAAAA=="
+ },
+ "static/wp-content/uploads/2010/01/4239506225_3770d2b598_m.jpg": {
+  "w": 240,
+  "h": 135,
+  "lqip": "data:image/webp;base64,UklGRkoAAABXRUJQVlA4ID4AAABwAwCdASoUAAsAPzmEuVOvKKWisAgB4CcJaQAAXAYi5Mng/wAA/uvnXGr4RYDYi6+LYFn1Td+QHvHad+AAAA=="
+ },
+ "static/wp-content/uploads/2010/01/4240224898_6a358bc6c9_m.jpg": {
+  "w": 240,
+  "h": 135,
+  "lqip": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4IEYAAACwAwCdASoUAAsAPzmEuVOvKKWisAgB4CcJYwAAUWLScip62URrAAD+6/qjbxMzaiJqLIJVHefqinJ+jICuaT/ivx03EgAA"
+ },
+ "static/wp-content/uploads/2010/01/4240229860_6765caab5f_m.jpg": {
+  "w": 240,
+  "h": 135,
+  "lqip": "data:image/webp;base64,UklGRlAAAABXRUJQVlA4IEQAAACQAwCdASoUAAsAPzmIulQvKSWjMAgB4CcJYwAATA7veIp18yGAAP7r5U1uN8ydB8mOjG0ZAxiyW7hXtSbvxKUxE8AAAA=="
+ },
+ "static/wp-content/uploads/2010/01/4240288076_ed0295c6db_m.jpg": {
+  "w": 240,
+  "h": 135,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAADwAwCdASoUAAsAPzmGuVQvKSWjMAgB4CcJZADE2B6SjDPEcDQOhEUAAP7p2hSpB1p/A9b+5q+J8lS7qljXIeWt64bD44/nfhL3RZN9Zi4F8L/A6oAAAA=="
+ },
+ "static/wp-content/uploads/2010/01/IMG00090.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAAAwBACdASoUAA8APzmGuVOvKSWisAgB4CcJYgAAXjDUJH/0SJQqnY3VTAAA/Z8x3mrWjFEkuRXVyC1b5vWl92m5bvOXGziFtBjXBFn512hVw+L31n9va/aPphhEAA=="
+ },
+ "static/wp-content/uploads/2010/01/IMG00097.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBhQBD4b68nXFNLMPOeQAP0w6VudWJGJbPyL/ubbLOfggNhhr9HriI0mq4L0zAr2ProC4f5j+U7v5YRWgAEFzWcf/sLVRhRepAAA"
+ },
+ "static/wp-content/uploads/2010/01/IMG00104.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwAAXE9Mf/6s+W/fwAD+hF8HHFPOUciwyWdYDIrRMbuEji/wq+NuMDzM3qvWbaOOgQiy0VgAAA=="
+ },
+ "static/wp-content/uploads/2010/01/IMG00152.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAAAwBACdASoUAA8APzmGulOvKKWisAgB4CcJZACdMoMzGEnIcRUvrzqa+AAA/tkOkq78P7OhsNkyZl70XFaW/lSmLqBsElcHtXhdQR0d7ilNtEIotqhyBg0gAAA="
+ },
+ "static/wp-content/uploads/2010/01/IMG00153.jpg": {
+  "w": 528,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAACQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJagCsABofUs92wqoAAP461VtezY49Lgkn4rSwuS8mhHWkcpB6hjFhu27a7SYvO5c3uDnOlj4mAaw0oAA="
+ },
+ "static/wp-content/uploads/2010/01/IMG00156.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZgCw7BX8atvqFQ+gQAD5tKHvZJ5cIeIztdNo6y+jyzNKvBlNxKtDvwqvgGt0DgLNxFyviwAAAA=="
+ },
+ "static/wp-content/uploads/2010/02/300px-Bruce_Crandall's_UH-1D.jpg": {
+  "w": 300,
+  "h": 209,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAADQAwCdASoUAA4APzmEuVOvKKWisAgB4CcJaQAAW1l/tfKQ5i6B9wAA/q8BBRgulJaQG149t1QrvGHv/0YnTP/V2Zq8fNOEcx3tXggv/H6FuK+DxxQZ/tWL0ouZ+6gjBvvTmk38meMBtcwvP8AegJwAAAA="
+ },
+ "static/wp-content/uploads/2010/02/300px-CarolCleveland.jpg": {
+  "w": 300,
+  "h": 335,
+  "lqip": "data:image/webp;base64,UklGRrQAAABXRUJQVlA4IKgAAABwBQCdASoUABYAPzmQvFgvKaWjqAqp4CcJZACdMuov/gG7Ej3T8llN5U8uCkrWPPyZsjUgAP7e5/5WievTm/YVO7QwsG2dUXrEZ4Nd7q9FnXOECYHZaNUZC1sM0kgkbjrTw1Zz8oIl6vtsCkqM2OEN2CBwsIuYT29bsSmQN3677n4yYf2DENvQy+tpARszhVD2Z4WEvulReyYtMZRXOxcHXRpRINMQAAA="
+ },
+ "static/wp-content/uploads/2010/02/300px-Flyingcircus_2.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJaQAAQxoFtxOGM5lCgAD+y3VHmvzCFEDlXQIJxSVZrPFHaMsbEqZRsxQnmIXAvk56IXejI9wMPjWGbqSd+JKWVP8phPhmGa8tegfV11p/4KaWEoAAAA=="
+ },
+ "static/wp-content/uploads/2010/02/Screen-shot-2010-02-04-at-6.09.19-PM.png": {
+  "w": 394,
+  "h": 330,
+  "lqip": "data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAADQAgCdASoUABEAPzmWwlmvKqcjqAgB4CcJaQAAPaOgAP7uvJQUwAAA"
+ },
+ "static/wp-content/uploads/2010/02/Screen-shot-2010-02-04-at-6.11.36-PM.png": {
+  "w": 248,
+  "h": 235,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAABwAwCdASoUABMAPzmUwFmvKiajqAgB4CcJaQAALnRkzVFuuAAA/ucVd6FqSo/mvXWliqy4AAA="
+ },
+ "static/wp-content/uploads/2010/02/Screen-shot-2010-02-04-at-6.13.41-PM.png": {
+  "w": 423,
+  "h": 321,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAABwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJaQAAW+vnmJTpOOgA/ucVS1ylCAAA"
+ },
+ "static/wp-content/uploads/2010/02/Screen-shot-2010-02-04-at-6.15.31-PM.png": {
+  "w": 428,
+  "h": 288,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAABQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJaQAAXBuqpFnPQAD+3pj6RyjZ40uEL3qCbnqrsdQwEAAA"
+ },
+ "static/wp-content/uploads/2010/03/1269949052928.jpg": {
+  "w": 400,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAAAwAwCdASoUAA8APzmGuVQvKSWjMAgB4CcJaQAAetGMgE/AAP7n/660bJfNZ64B1MwRAUQiJQWl0mOuw8ravhO7AAA="
+ },
+ "static/wp-content/uploads/2010/03/300px-AndyWarholBridgePittsburgh.jpg": {
+  "w": 300,
+  "h": 155,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAACQAwCdASoUAAoAPzmGuVOvKSWisAgB4CcJZQAAV4LJn/wsv6AAAP7FBttUrkSQoazIYIb6RwFCuK1ZLnmUTXEfuuWhSG6e/WAsQFIKVKd/kqo8RIAAAA=="
+ },
+ "static/wp-content/uploads/2010/03/300px-Boxing080905_photoshop.jpg": {
+  "w": 300,
+  "h": 185,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAABwBACdASoUAAwAPzmEuVOvKKWisAgB4CcJZgCdMoGv/gNDdUl6HYTc7KavgAD5tEOGE9D7/mTwHA6mbFWOVps79DIDYrG29LrEHxL3Qc8fDbWf4rj+LQaPKAOqYizoEKbR/0QOghT8zYB7AAA="
+ },
+ "static/wp-content/uploads/2010/03/300px-GodfreyKneller-IsaacNewton-1689.jpg": {
+  "w": 300,
+  "h": 412,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAAAQBQCdASoUABwAPzmQu1gvKaWjqAqp4CcJQBhmgjIyoQjIQdIc/tApl1xUNj4eZWIAAP7o66nyC0+q/y71em4GQj6ixadTPmApRpAgdy1C6OMKZQY+nz9L6D5CSpOdVjVeidDQ0FYlWwsorYiFls6od1zQAA=="
+ },
+ "static/wp-content/uploads/2010/03/300px-Purepwnage.jpg": {
+  "w": 300,
+  "h": 165,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAAAQAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJZwAAXc78DyAA/uvnZQ5D/0ATOGpc80MX63Lci+qQweYCo0lQfwAA"
+ },
+ "static/wp-content/uploads/2010/03/300px-ZographensisColour.jpg": {
+  "w": 300,
+  "h": 477,
+  "lqip": "data:image/webp;base64,UklGRpoAAABXRUJQVlA4II4AAAAQBQCdASoUACAAPzmSu1gvKiWjqAqp4CcJYwC/OA+4baFF5Pcz8pkbPIwLowcQZvuAAPfQyZjmixOeTc9xRpI0ANmvnhK1a+PFn60Y1W854yL2ipe8R3faNIyuL0pALlTfTtNTAk+bO8xQAUoKZbzSjIOco4+s9RgT9I7Q+gJ3YCAzgZjMmUx2lgKGAAAA"
+ },
+ "static/wp-content/uploads/2010/03/principle_of_explosion.png": {
+  "w": 740,
+  "h": 252,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAACQAwCdASoUAAcAPzmEuVOvKKWisAgB4CcJaQAAYcP9xrmJ3hAAAP6xhqTz+y4fzzubuZpF/j5FbAAA"
+ },
+ "static/wp-content/uploads/2010/03/solved.jpg": {
+  "w": 500,
+  "h": 1732,
+  "lqip": "data:image/webp;base64,UklGRg4BAABXRUJQVlA4IAIBAACQBgCdASoUAEYAPzmYwVqvKqakJmgB4CcJZQAAJeGPEaldVix9fPwHAkaPU4Et0a9bDkekHALvq9ajWzgAAP6JElzmcFWfrRf1ENK0MYOUP6RzaGNqCAr6PY4KS7VYK1bz7JBz8DWDyc0A0pPT6pX50dEX8Fp8WifhJvxdeuTKKiLegHHHAi5HWF+cFTd/qzVHftuMHdCbE3xcjPL/1a8cH+F6Nhugq3em9oz6Az1VfAP8AARR0N4F0wrQnKhu4BRgsFm6O9lAibbWX7m3oEisVCjZeVicBo8fzVoF7gvVfBXIwsB+/U2NYXJKwy+shlUAHWpfVTCHepY/IDtpA7X14AA="
+ },
+ "static/wp-content/uploads/2010/04/19797v1-max-250x250.jpg": {
+  "w": 250,
+  "h": 195,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAAAwBACdASoUAA8APzmKulQvKaWjMAgB4CcJZQAAWq36z7ESwRY2PoPBhAAA/ucsB+ubqSz5TpWI+cNir+nAdKvJa17Qz4uH9qXmVfhiuXZZn6kY9G3V5To0fakqqN3bR8nQ995s6uDEvAAA"
+ },
+ "static/wp-content/uploads/2010/04/2597952748_4ae4250c21_m.jpg": {
+  "w": 180,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAADQBACdASoUABsAPx12r1OtJyQit+gBoCOJQAANdtyOicpybi5k3bjQDJzFOnF7IAD9G/ENb2ibzqdChPE/wZVexCnuTyfEt3p+rLpdwTJnkLcsyzh5YeD+xKVx/TPkMzPMaVY7ZlcHqeMzKR7XnhfpMAA="
+ },
+ "static/wp-content/uploads/2010/04/2715700690_c7f92c51d2_m.jpg": {
+  "w": 240,
+  "h": 156,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAADQAwCdASoUAA0APzmIulQvKSWjMAgB4CcJagC7ABDghnPFieaeY4AA54uLxP30VBITWZMchB9+rjrpZPh4qwyoWecB1Kt1ZXJm5k4SrcEIAvwAAAA="
+ },
+ "static/wp-content/uploads/2010/04/300px-Bolivia_Yunga_Road.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAACQBACdASoUABsAPzmEt1OvKCUisAgB4CcJYwDOOBjub9RV1ZJtEJ/AHtHtMgAA/j2WSdNA6EOTZJQF/7nKqWl4id3BR4ZckaSVjIWDFRTPgNOXIhlBtloBGYjDNo1YyWEmpIAACfmwa/LPPAAAAA=="
+ },
+ "static/wp-content/uploads/2010/04/300px-SixHardDriveFormFactors.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJZADE6f/gNXgjjLiXRaKWQAD+0+guM7LGJ4u97bppMDrYnORCO276DyT+6NOQpqN8S4N7vPb3QzvqAXVkWVj2rOoppaXKoewTdl1W+fiWILjlp0DAfN1hG1/tw1/jAAA="
+ },
+ "static/wp-content/uploads/2010/04/Screen-shot-2010-04-07-at-4.21.12-PM.png": {
+  "w": 925,
+  "h": 627,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAADwAgCdASoUAA4APzmEuVOvKKWisAgB4CcJZwDDNDBsAAD+7muGu8QoyRm30nso3B1gbj+0h0AAAA=="
+ },
+ "static/wp-content/uploads/2010/04/Screen-shot-2010-04-30-at-9.51.27-AM.png": {
+  "w": 799,
+  "h": 529,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAADQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJZwDM0CEreQl3Ffx58QAA8ONUYwtAeb+hD4hbS8O7tCHf1DoCDLb+m9nW0OWsfsRiQAAA"
+ },
+ "static/wp-content/uploads/2010/04/sGMHosUzGq3f97umNNcaQBvXo1_500.png": {
+  "w": 500,
+  "h": 533
+ },
+ "static/wp-content/uploads/2010/05/237431962_1444b6dad7_m.jpg": {
+  "w": 240,
+  "h": 160,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAAAwBACdASoUAA0APzmGuVOvKSWisAgB4CcJaQAD5eobOr0gIvMsG2ftqCwA+5WhkGT3SIBb12EeD64u08lsAzhOIikx5+66ROHV5mEL+33/y1GyU1HgAV4nuib/IyM2cPSCzYV/Fc9BBCszIwUY9KjwqAAAAA=="
+ },
+ "static/wp-content/uploads/2010/05/300px-Aristotle_Altemps_Inv8575.jpg": {
+  "w": 300,
+  "h": 401,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAADwBACdASoUABsAPzmOwFcvKacjqAqp4CcJYwDKADTwtlqL6ICew5/+SO7k0aow0oAA/lKqKhnLMXXF2YzcAnKm3ebIdwYGl/t9mdRdCrya7Aa8TlS5CYjW6Dj4JjKwq1pcTmSeyhy9VPd0xrZuYklOzkbfOW0VtyPsjIg9kguCUgmqXrbTcJYAAAA="
+ },
+ "static/wp-content/uploads/2010/05/300px-Ataturkstatue.jpg": {
+  "w": 300,
+  "h": 236,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAACQAwCdASoUABAAPzmEuVOvKKWisAgB4CcJaACw8azAJEZeEgWYAPnsGhZyX3uTePcBtGL5Xma9DkX8nebeYScSY5w3NhL5HfibbWR5Kj6560/JOq+o4Ogcg/a/MwFb7V7DSjTkLYZVsgpgAAA="
+ },
+ "static/wp-content/uploads/2010/05/300px-Jordanhill_college.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQAALbJQ2pPi6tMZXX5wA/t6yjZr7fG6WBdseoP1itMqfSeADAOR2Rbckz1cLwdY5EuCOE8/s/CtfSqNwNuYxRKNkO5CqolYAAA=="
+ },
+ "static/wp-content/uploads/2010/06/1275855598323.jpg": {
+  "w": 370,
+  "h": 331,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAACwBACdASoUABIAPzmUwVmvKicjqAgB4CcJYwDImA8hfRJFRJdSMV9XSf5EJDkAAP0gLqxiDHtGuIhqLQAwOTiRHSx4YkyOSdNI39jNt8QqGMvI9lFGxHDFxwc6f/bzFzcgN6O8JGt8p374BWdM0hxkDP3dQ1QAAAA="
+ },
+ "static/wp-content/uploads/2010/06/4449940571_0e57af61b0_m.jpg": {
+  "w": 240,
+  "h": 191,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZAC2yBt+ydixkZFw+91AAP3jthCwxu2JMMjbN+Ytc1DvopbQrzT0+jvgFy03NUtWGsQaiZ/AklcuauA93UkFewGMDj9MzYb1IZ+H4+DAJ6y8PAA="
+ },
+ "static/wp-content/uploads/2010/06/639800453_8b1b6f3c26_m.jpg": {
+  "w": 185,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4IJ4AAAAwBQCdASoUABoAPzmUwVmvKicjqAgB4CcJZgCdM2QBqDZrDckWtczdING+SiIOgjHKAAD+0NYQ1H57wqrd7r+fQUp+vCOisnW/2REhzMWLlr3a1J8bQ+mSA3ZpCUBj56AqV80ujY5S1FomGXUrA/t/2oeubFiySrM7E7V06I0z3hcFGdiBCXKYg+BIxLFL/iMWSA12ovJ1spij3eAAAA=="
+ },
+ "static/wp-content/uploads/2010/07/300px-Bust_shot_leather_art.jpeg": {
+  "w": 300,
+  "h": 414,
+  "lqip": "data:image/webp;base64,UklGRqIAAABXRUJQVlA4IJYAAABQBQCdASoUABwAPzmIulOvKSWisAgB4CcJbAC2yCHhllVwdk3xoNMSJS/6bCRiIn+2l1AA/pYc5GJg1WmILhadFr/qdGpJG7aVlKqRCxCzJcoOm/zWwWoMuM4XrnYJnCvPHgJbrIg1sbv6xyoaRMcbcrh0xqSMciBUKs1kdxnDbbXmWglSpQSPqNi3o64LxQ0ah+bgAAA="
+ },
+ "static/wp-content/uploads/2010/07/300px-Derfflinger's_crow's_nest.jpg": {
+  "w": 300,
+  "h": 429,
+  "lqip": "data:image/webp;base64,UklGRq4AAABXRUJQVlA4IKIAAAAwBQCdASoUAB0APzmIuVOvKSWisAgB4CcJaQAAUh/0VVQ3eueIVN/0wT7kdEUZ33KLAADfc5uMpr08Lknt9ukPnW8lK4XsFsIKu8r0myIbx9CGpdreJADF80I6zJmqpcTrapCqmb7VB5vdeTBmWmcrWEzYp37h2MBK/pp4f8ODToz2rJ8peGzaAjMp4rkBGipdb3ysmg0WD99468F6R4UAAAA="
+ },
+ "static/wp-content/uploads/2010/07/l_2044_1536_12ABBB3A-7507-4E33-96FD-6DFFAB675883.jpeg": {
+  "w": 640,
+  "h": 481,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQAAJ3O02pksDdOsiAAD9OuXDeZVQ1GEGzHFWRifOnSH6eJjSi53HARcDpVU0DXaQ58eGpML0KAAA"
+ },
+ "static/wp-content/uploads/2010/07/l_2044_1536_15167C8F-D294-4688-8C00-44F8AF9B84A2.jpeg": {
+  "w": 640,
+  "h": 481,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJYwC7IP8DA0Fev/3UbeqkauAA/ucdoGtz58nHUvYzBoZKZbuUECEjHH548FAClyV0tAkstxmayF794InRjuyoS2hstmAA"
+ },
+ "static/wp-content/uploads/2010/07/l_2044_1536_4A52AA59-5C29-4ABD-B0B6-01F57F9736ED.jpeg": {
+  "w": 640,
+  "h": 481,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQBdmUAAtxCPAAQ/0kAD+3uhXY6PDPlEeWGnx8zC2Uwk4tdVMNTTaK72JGb28iRcZe/xnDg7opmRulnb5lnAOaQzA2OHPTrLEa1qppLCwEYv4+Rl8K5AA"
+ },
+ "static/wp-content/uploads/2010/07/l_2044_1536_6D6880BA-1CB1-4A8C-ADAF-405C28C592AC.jpeg": {
+  "w": 640,
+  "h": 481,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACwAwCdASoUAA8APzmGuVQvKSWjMAgB4CcJQBdgBDvwRPUkZJ3CAAD+5xbh+RfPZ+Y5pjT4Pxl9RoGqGLV1uUff4rsKsGP1Kxcr+Zv9AAA="
+ },
+ "static/wp-content/uploads/2010/07/l_2044_1536_77873199-4A7A-4FA5-AAD0-17FBE163B039.jpeg": {
+  "w": 640,
+  "h": 481,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAADwAwCdASoUAA8APzmGulOvKSWisAgB4CcJYwAAW+0BVDrvtP13GsMAAP7qew08ttVv9ERAf45WjiK0TznUp9JirRM44rOvAYnIJ79gNiD5ZVtE1tLa6x+yqwAAAA=="
+ },
+ "static/wp-content/uploads/2010/07/l_2044_1536_9A770133-F516-473B-AD52-122F6D3451F4.jpeg": {
+  "w": 640,
+  "h": 481,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQAAL4V3gvH5QsiXAAP7L6OS6qXYcFu6WVBQeNWe+X9UBjyQCbT0b8d/9DNQPMQkVuucQ1BHHfyQ7aeX3gChwOKyzuRf3AJSIiIby8AA="
+ },
+ "static/wp-content/uploads/2010/07/l_2044_1536_F77F4C04-C5E3-461E-9969-EBDED8BEC833.jpeg": {
+  "w": 640,
+  "h": 481,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAABQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQAAHEor/R0wyAAD4RRBOrFpGFcfvpS+BxcyDTG1tcrU5TuqFWtcvcRp7l7dKyHNQnqb/Ge5wnBmjQJgAAA=="
+ },
+ "static/wp-content/uploads/2010/07/l_2044_1536_FFB489E9-7FD2-4E9D-8A75-7F69964878DD.jpeg": {
+  "w": 640,
+  "h": 481,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAABwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBOgBDrXcmCfR4AA/ucN5xKxMtHoWIzcteegcHVHzTJWqdSiHLfSe+rurVlmjEgLOAAA"
+ },
+ "static/wp-content/uploads/2010/08/2686845422_d924cc453e_m.jpg": {
+  "w": 160,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAABwBQCdASoUAB4APzmGuVOvKSWisAgB4CcJYgDCgB6XjNtaEJoDvg814xAAtRtg3CB/BBAAAP7Oy4YbsLEQvbc6CCuWt5y7OxfETXyZMBwU30mOGGoFbTtnJMbpGCYIIzw4NNcHoiPDV5YYk4g3h0nuWD1Na0VOH84CEGHxm0WIMG6bONVMtIMIus9AXKotz+DV9k5C6aSqwsnwnsvzyt2QeO/iAAAA"
+ },
+ "static/wp-content/uploads/2010/08/300px-Oauth_logo.svg_.png": {
+  "w": 300,
+  "h": 301
+ },
+ "static/wp-content/uploads/2010/08/4906662333_7139b3e5cf_m.jpg": {
+  "w": 160,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRsAAAABXRUJQVlA4ILQAAADwBACdASoUAB4APzmOvFWvKiYjMBgIAeAnCWcAy2gOmX7YKXmuNz6qL/kklWWLMeAA9x/iGISHoJcYMgiBWJuz6+8W6Bxkj2qoom+SmnltiRqSoy3R/9aLxbu9qHhrxNtgac4yfMlu290mpDwRAl7HrHRHP6ClTkXwvaXkcaVNcbE5rU9KlLh+f6j9bkll0mdxAHBY8VmBD4rIZcpfwKKEcJHbpkF07qnd6aypmzZ40OFgAAA="
+ },
+ "static/wp-content/uploads/2010/08/IMG00443-300x225.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZQDG9B92JZS4m6J6M4AAyxT99peoS21uPao/9rOZRm5Ly7Dr1K4ttjBlDVa+jSZLPkIvjf4VYLoRLWkMC28YQ4okUPwli7AAAA=="
+ },
+ "static/wp-content/uploads/2010/08/IMG00443.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZQDG9BOvcbPRinOwqawAAMsU/faXqX3HzZnlBriMOVHLWwLfiL2OHHQWHjZcRUiZDMmJoB5+3Nj+s3nvOccxmchLZeIfziIeJYuwAAA="
+ },
+ "static/wp-content/uploads/2010/08/IMG00445-300x225.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJZgCdACP1MeiKxLY1fJP/ygAA/kNH7LmOKL1+PlNqNMBFhNUALasAj4JVteHRbu98K9UO3zcbmzWKMtzrnJE1BRionAAA"
+ },
+ "static/wp-content/uploads/2010/08/IMG00445.jpg": {
+  "w": 1600,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAABwBACdASoUAA8APzmEuVOvKKWisAgB4CcJZgCw7CP02Sh0w58WOaaPqpyAAAD+Q0eYbcPgzMaW3UcTH0OVFLgKoEw/sVMaCteI5nICTEL2/I2dZHOFnKRwYtAmrABWe1VoAA=="
+ },
+ "static/wp-content/uploads/2010/09/300px-NodeJS.png": {
+  "w": 300,
+  "h": 79,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAAAwAwCdASoUAAUAPzmEuVOvKKWisAgB4CcJZQAAK5SlXdTwAPuhyb9Ou6ufi6QTltsAvN3iRvjFrw4MIYP3bzFYuf5EKG3y8aYhmbAX6xq6GsNYsoAAAA=="
+ },
+ "static/wp-content/uploads/2010/09/300px-SteacieLibrary.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZgCdMoADZUYuUKm6SmjsAP0fi4mshpM2484c1/LWq3MvflrjZOdLEeUb0GWGKxZHKt/y61mvgOG1vpgcEdjuiSd+i8/a91oKDfjmyiRQAAAA"
+ },
+ "static/wp-content/uploads/2010/09/54559v1-max-250x250.png": {
+  "w": 250,
+  "h": 138,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAACQAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJYgCdACGqQ6luVjBQAP5XhsXWI7AXvi7xEBxpvqtY57VXRwvZFEExkDikofhcDzOKTMkKXIlZWq5uqrToSByEhjso/hKlOowO6AAA"
+ },
+ "static/wp-content/uploads/2010/09/Screen-shot-2010-09-03-at-1.17.23-PM.png": {
+  "w": 798,
+  "h": 196,
+  "lqip": "data:image/webp;base64,UklGRjgAAABXRUJQVlA4ICwAAADwAgCdASoUAAUAPzmGulOvKSWisAgB4CcJaQAAetvwYAD+7l1NAZNFaDHAAA=="
+ },
+ "static/wp-content/uploads/2010/09/Screen-shot-2010-09-03-at-1.17.32-PM.png": {
+  "w": 812,
+  "h": 115,
+  "lqip": "data:image/webp;base64,UklGRjYAAABXRUJQVlA4ICoAAACwAgCdASoUAAMAPzmGuVOvKSWisAgB4CcJaQAAeyAA/u4mJ2YjUDlocAA="
+ },
+ "static/wp-content/uploads/2010/09/Screen-shot-2010-09-03-at-1.19.39-PM.png": {
+  "w": 621,
+  "h": 287,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAABwAwCdASoUAAkAPzmIu1QvKSYjMAgB4CcJZwAAXFIv3lMLWOAA/pgK4noBxV8hPe2wPqGGw8OgXFnx1Wx00/Jv4qGdEK6DnkJeAAAA"
+ },
+ "static/wp-content/uploads/2010/09/Screen-shot-2010-09-03-at-1.29.51-PM.png": {
+  "w": 592,
+  "h": 166,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACwAgCdASoUAAYAPzmEuVOvKKWisAgB4CcJaQAAeyAA/u36sE8vcrnRzXrwD/AA"
+ },
+ "static/wp-content/uploads/2010/09/Screen-shot-2010-09-03-at-1.33.27-PM.png": {
+  "w": 697,
+  "h": 247,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACQAwCdASoUAAcAPzmEuVOvKKWisAgB4CcJaQAAXm/d241umB0AAP6w8VKa0E3J4FWeTlaumihAZvNpyzrdhplmaeNR4izZh0KE3iyr1AIAAA=="
+ },
+ "static/wp-content/uploads/2010/10/300px-IPad-02.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRr4AAABXRUJQVlA4ILIAAABwBQCdASoUABsAPzmIvVavKKajsBgIAeAnCWoAs4AOJSz4vCBE2QtOWFwiQVPK+Nw1k8YAAPeNrGFVfzgS1PVcDWsTAuHndOxseJpmBcSvkf8zci1g1OvfIqnVzEae6BjKaBUUG3iUPVXgoWAegx9UmTfcWDp9zGGeyZlgAido+jUTAqleDUC2hHraqjRTn64tA6S+nSOyM4NJ2iUTVyytMT1mYml3Ek2Uw64Wm/XQAAAA"
+ },
+ "static/wp-content/uploads/2010/11/2518202548_eb63607c20_m.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJagCdMoAC/jb4g7Rw2VsAAP54DVv0xa8IMsDJ8lTIOHpyx4KypZRLLRjitgmAP8NulGp6sgL0oT4C5x69laZ65XWKKyKYP9eEGCMZUAA="
+ },
+ "static/wp-content/uploads/2010/11/300px-Alcatraz_Island_Lighthouse.jpg": {
+  "w": 300,
+  "h": 196,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAACwAwCdASoUAA0APzmGulOvKSWisAgB4CcJYwC/OB3sOSJlRHIUAAD+b8Nsek61V71/WM2+FfeGQkxBtFEcZz13Yvr9aYegngmzD1Haad8+DHsd4TmiEQStmarwN2PgAAA="
+ },
+ "static/wp-content/uploads/2010/11/300px-Interactive_whiteboard2.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJaAC/OB3vr5VDrP94OMYsAAD+s6/8C7/xdFPw85M8NbUtUm6TyIhtiCZTQmCUMBU+aJj+AhC/OGrC6n5f1v//U8sytjYQEX1at8a2SsWLgAAA"
+ },
+ "static/wp-content/uploads/2010/11/300px-Paryż_père-lachaise_wilde.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRoYAAABXRUJQVlA4IHoAAAAwBACdASoUABsAPzmSv1mvKaYjqAgB4CcJZwDPZBBaxkXLKhFLwDND4xAA9XXqktwl7n1ZfMVxrvbrpDEx/G0z0I6i8BhMt1VCXdJJwhl4wkYorWoNFpiHX7bUoygeqfUikCEGhXh2U8b2pDKfC8wB4VyL1FyAqkP4AA=="
+ },
+ "static/wp-content/uploads/2010/11/Screen-shot-2010-11-24-at-12.33.17-AM.png": {
+  "w": 903,
+  "h": 570,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAAAQAwCdASoUAA0APzmIulQvKSWjMAgB4CcJaQAAetG4eYAA/u7LNvvKcRhyiTTBXYnUA4AA"
+ },
+ "static/wp-content/uploads/2010/12/300px-Oscar_Wilde_3g07095u.jpg": {
+  "w": 300,
+  "h": 499,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAADwBQCdASoUACIAPzmUxFovKaekJWmZ4CcJQAAKXpJHkIokswFx5Hcl6Ctr7i78bJu6DIo5v6mzYACGgwahasRkBPnb8eYJnZlw/6aLD8AeI0v6/+qqeZ+v4MttQPSFwVq/pJasBpHAKrVfENFghnwMURl8pdjXEVKkwkiA5OxYiOyWHHSCI5ckZ2mGelYagOhUn1ExsyHWh6e6wkQItEixwsUNAAAA"
+ },
+ "static/wp-content/uploads/2011/06/300px-Il_pomodoro.jpg": {
+  "w": 300,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAAAwBQCdASoUABQAPzmMulYvKSWjqA1R4CcJbAC7MxgBqgJ4sEKCjUVsfTzwrJPpzFPnoAD+0t+j/UwBiRtpq1kZhRsab2NT/TnubnF+jwVj7v/eRXMGU5nghfI25jthR43Y0KtmYsbRaHFZcZIyAAAA"
+ },
+ "static/wp-content/uploads/2011/06/300px-Nail_in_a_block_of_wood8.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAAAQBACdASoUAA4APzmGu1QvKSYjMAgB4CcJZACdMoADUfhyOpms3beQUAD+VmgMsvX9VQrSk5xqSXt7nCJEDKF467oJEvDU+rEtbM6sxL9k0to/amKsgAAA"
+ },
+ "static/wp-content/uploads/2011/06/300px-Wfm_palo_alto4.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAACQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQAAIZYNU8B3QB8mgAPqEKoW2wc8jv0ecx3RlHRy0JhLu4oOucJt+zbluKkgDp/SO4Oh8efoHba1Khxl/eTxjAMawdDBjuLLX+Rev8PwCgS8xUfrUsH8LMhCpAAAA"
+ },
+ "static/wp-content/uploads/2011/06/3242353102_d77481609e_m5.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRlAAAABXRUJQVlA4IEQAAACwAwCdASoUAA8APzmKu1SvKaYjMAgB4CcJQBOmUABR7pq5u1B1iAD+y9Ot+sojVTAW4pQHI+3rx3wLc9hjDZTkcwAAAA=="
+ },
+ "static/wp-content/uploads/2011/06/5785335346_32457a62b2_m47.jpg": {
+  "w": 240,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAABQBACdASoUABQAPzmUwVmvKicjqAgB4CcJYwAALnFKxCUHDs+1pfZx4PMAAP7kXsNqi0U//GExfEqKQfdVp/tySF96AHvF7qAjxuNAeIw+DPyuCD0Y8gK6A+uzgZffEFmrLJgA"
+ },
+ "static/wp-content/uploads/2011/06/5883352394_72b348a448_m.jpg": {
+  "w": 240,
+  "h": 160,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAABQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJZwAAKm09xspWAAD+ceh9WVHXe1TmKuuMNQx5VHzzimE/wJk8xCiiIQTe6JU7iKEJo1SE3X+14AAA"
+ },
+ "static/wp-content/uploads/2011/06/bnJLr3.png": {
+  "w": 546,
+  "h": 186,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAACwAgCdASoUAAcAPzmGulQvKSWjMAgB4CcJZwAAeyAA/u0zizbfm5u211tfQCHkbPhAAA=="
+ },
+ "static/wp-content/uploads/2011/06/DILnH3.png": {
+  "w": 501,
+  "h": 154,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAAAwAwCdASoUAAYAPzmGuVOvKSWisAgB4CcJZwDImDJ8K6gAAP7tscDz0CtTirR+4ensMyNjLaOAAA=="
+ },
+ "static/wp-content/uploads/2011/06/g9XOu4.jpg": {
+  "w": 1299,
+  "h": 814,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAADQAwCdASoUAAwAPzmGuVOvKSWisAgB4CcJZwAAWp8z8jIT4np50OAA/s0HAZ/7pC1KZZKb7ZGW4pzunW1dhUMksOwQDcUQoYQoAXSo9MJeAAAA"
+ },
+ "static/wp-content/uploads/2011/06/hZEh52.png": {
+  "w": 509,
+  "h": 216,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAABwAwCdASoUAAgAPzmGuVOvKSWisAgB4CcJZwAAXfEQ8RVaPwAA/sWq51vd6awAe68OBL+csAAAAA=="
+ },
+ "static/wp-content/uploads/2011/06/jLW0g4.png": {
+  "w": 480,
+  "h": 239,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAADwAgCdASoUAAoAPzmEuVOvKKWisAgB4CcJZwDDNC0kAAD+7i4oiy9/06xCYBo5hYcJQAjMWGYAAA=="
+ },
+ "static/wp-content/uploads/2011/06/mj6ki3.png": {
+  "w": 458,
+  "h": 214,
+  "lqip": "data:image/webp;base64,UklGRkoAAABXRUJQVlA4ID4AAABwAwCdASoUAAkAPzmGuVQvKSWjMAgB4CcJaQAAW++KMQSUAAAA/rYIit9zRB8mD9qLhMnwEbVhQjX44AAAAA=="
+ },
+ "static/wp-content/uploads/2011/06/pvYVB4.png": {
+  "w": 1216,
+  "h": 714,
+  "lqip": "data:image/webp;base64,UklGRkoAAABXRUJQVlA4ID4AAABwAwCdASoUAAwAPzmGulQvKSWjMAgB4CcJZwAAW+jJWThoQgAA/ui/fMtbOea4eAtaLDGZZfN73DNTcCAAAA=="
+ },
+ "static/wp-content/uploads/2011/06/QEj894.png": {
+  "w": 1146,
+  "h": 559,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAAAwAwCdASoUAAoAPzmEuVOvKKWisAgB4CcJaQAAetGN/bqAAP7vLftOaCyeGEAOORrg7htY1rYAAA=="
+ },
+ "static/wp-content/uploads/2011/06/TkHsM4.png": {
+  "w": 885,
+  "h": 619,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAACQAwCdASoUAA4APzmEuVOvKKWisAgB4CcJaQAAXAYX47EYHaQAAP7r2vYkX6a81tGDPoQmHiAAAA=="
+ },
+ "static/wp-content/uploads/2011/06/uoQke2.png": {
+  "w": 531,
+  "h": 186,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAACwAgCdASoUAAcAPzmGulOvKSWisAgB4CcJaQAAeyAA/uz5WC3yWLkRhKMp2jTpwcb+OIDVO8CAAAAA"
+ },
+ "static/wp-content/uploads/2011/06/Vdo2i4.png": {
+  "w": 1230,
+  "h": 742,
+  "lqip": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4IDwAAAAQAwCdASoUAAwAPzmIulQvKSWjMAgB4CcJaQAAetExQwAA/u7hIKLm3DrteeVEUjJCB+gbNsLL0UPjgAA="
+ },
+ "static/wp-content/uploads/2011/07/009d0c8621ad402fb7a5c1ea3efc429d_7.jpeg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAACwBACdASoUABQAPzmSv1mvKaajqAgB4CcJQBibAfhCIvVAUpw/grYJoH1GTMgAAPke4/lcBjIumKM5PDYw1h7ZU7QOD56svQde2iguypPf2iZn58z7XeF/+UPDxs+Iz1qcqwuchOuIzeg3h3xUrRCgrUFdapfhGC9xNOiyQhgyinOJLQAAAA=="
+ },
+ "static/wp-content/uploads/2011/07/11f3ebb3ac804d4182fc72487e333a56_7.jpeg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAABQBACdASoUABQAPzmQuVcvKaUjqA1R4CcJZQC4MBENSVZ9BfJC3/VMG3wAAPaIxKkQgJfUTuW/i6gMwkOCyqJUqIvxIfYOEh4j6j08wTqkE4W4UnRnVZCtpIvAAA=="
+ },
+ "static/wp-content/uploads/2011/07/16c0f3efb66f42f8972bdecd18a37c07_7.jpeg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAABQBACdASoUABQAPzmSvFgvKiWjqAqp4CcJQBbZAbv/8vkidjR7CxF6CegAAP7l6AYiPZqK9fdMxXa5UeFtGkWbZgoX1Dtu08gAb7W+HxOdqiuV99hGXL8ydXTFpRRBoi7sN0F8c2J6qS6O0Xe7Y7imMqQ2gniqVUBdgbZzd0ag1EkTJ7wAAA=="
+ },
+ "static/wp-content/uploads/2011/07/300px-Chappe_telegraf1.jpg": {
+  "w": 300,
+  "h": 431,
+  "lqip": "data:image/webp;base64,UklGRpgAAABXRUJQVlA4IIwAAADQBACdASoUAB0APzmIuVOvKSWisAgB4CcJaQAAUqu9gZehnAMT73zXhSijFEL1oAD+50E5swVv9cDwYkfi/WM8udewYyC4t1skerXkdPt2uXa8UScWwHxpzuWTWMpe5DtxMQXfulkKSyjsnz0X0RI/am7pv0+CL9NoCyS4DmT05GiuCwffKADw4AAAAA=="
+ },
+ "static/wp-content/uploads/2011/07/300px-DD-Tank1.jpg": {
+  "w": 300,
+  "h": 198,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAADQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJaQAAW+hHauew/13I8kAA/ucZorxDsneGh1ENrrCP81OUfla0HgIb0LsmN9ulrD+q71pIghE84QhcSlzyNuNnYB2NQAAA"
+ },
+ "static/wp-content/uploads/2011/07/300px-Palo_Alto,_California_(City_Hall)_2004.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAAAwBQCdASoUABsAPzmEtVSvKCSjMBgMAeAnCWYArDMJwakyoM8ReOIscg+vOM3ygel8AAD+UTdrtZ7u3xgLlbzWGKPlx1NAw10wImGaFW+tORM/CCUpbopfi8u0M+BwV0dwOw0RX7ZuvsXanFrWGGvL+OUZOCFCHzA1SXVjfjM9RClsyIgAAA=="
+ },
+ "static/wp-content/uploads/2011/07/300px-Slavoj_Zizek_in_Liverpool_cropped1.jpg": {
+  "w": 300,
+  "h": 425,
+  "lqip": "data:image/webp;base64,UklGRroAAABXRUJQVlA4IK4AAAAwBQCdASoUAB0APzmEt1OvKKUisAgB4CcJYwDH5CHuzfjGxFfwkdBnyL91ejFxgXbgmAD+6nsQMPTJsHkUk90ZP5HY2M+FQUftmIG5N0niW5e33wXo6zI1LDWQSm2DPx2HHhtPvQ06mbdixMTBMPkPZgxdS9mywXVricLErYaibTZCqZNoX9+9Cz5ZVHbs1EXrDc7FcmKmjcxiQ9hqE1L0gi5qpASZDs4hCPhAAAA="
+ },
+ "static/wp-content/uploads/2011/07/300px-Twitter_Inc_HQ.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4IJgAAABQBQCdASoUABsAPzmUwFmvKaajqAgB4CcJYgDChagAWrDEhb/K7hGDGKglO3y0ajsCvAAA/rnimmLDqiyNgKoAJcph11nGnmuV82/ALZ2YdlyBFb+oeeWyHIZAOF25IJvFuJBba4NeSlsfW66D6u3jaFQw5kAq1EiEn8QaWFHVA4dylDsLUGFBrecGQ3XLSKU/VI1H7xKgAA=="
+ },
+ "static/wp-content/uploads/2011/07/300px-Twttr_sketch-Dorsey-2006.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAACQBACdASoUABsAPzmOv1evKaajqAqp4CcJYwDBkA3pa8hZknBIwJV1XA7tEAAA/RmIDp96LJ81aYs+pGhwt4gRmshoBgTHOwfSrzDvqvEMPCORbb9DagMxOhVNRTNi3F5b5gAA"
+ },
+ "static/wp-content/uploads/2011/07/300px-University_Avenue_at_the_Circle_with_train_steaming_toward_El_Palo_Alto,_1894.jpg": {
+  "w": 300,
+  "h": 206,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAACQAwCdASoUAA4APzmGuVOvKSWisAgB4CcJaQAAW6FNGbZHMWWQAP7TFtQEhBooIvPEPX1tlZI4aSsDOpwQPqm+oOpHlOD1vjnfhSNKXZB7Kl6YfMLSR/skXk5QFrQ5r22+o6774gAAAA=="
+ },
+ "static/wp-content/uploads/2011/07/5883431001_8af6e98dc3_m.jpg": {
+  "w": 240,
+  "h": 181,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwC7ABg772xErvdGf4AA/o0jLICA45nHca4xUMuU9Z4CGqjROl7Sjk9QQHBQfmZQZnimxdAAAA=="
+ },
+ "static/wp-content/uploads/2011/07/5zDNd.png": {
+  "w": 792,
+  "h": 484,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAAAQAwCdASoUAAwAPzmKulOvKaWisAgB4CcJaQAAW+nyMUAA/tq3CzoRf9B6aLb74iu+m8WUCgAAAA=="
+ },
+ "static/wp-content/uploads/2011/07/68za7.jpg": {
+  "w": 2592,
+  "h": 1936,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAAAQBACdASoUAA8APzmIuVQvKSWjMAgB4CcJYwAAXE87Kp6xPza9Dp4hwAD+3GahmzUrZtfloM3gejH11trDvjVesSuAz7pqxp4fJQQ7MmjiZr4xBVAAAA=="
+ },
+ "static/wp-content/uploads/2011/07/7l8re.png": {
+  "w": 1440,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAABQAwCdASoUAA0APzmGuVOvKSWoMAgB4CcJaQAAWSWkErk5gAD+h5W53fp2nasmQVYLGvyXQ5ib5NSO95HegAAA"
+ },
+ "static/wp-content/uploads/2011/07/9q4ii.jpg": {
+  "w": 1440,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAACwBACdASoUAAwAPzmGuVOvKSWisAgB4CcJbACsMoAzAA44RRo8fGgZFQ3nR+1AAP7jVKkMv/LJdhyo0ZEwM3jMp8LCyaYGbpHCOb6YzNvuFdW14psztTqGHTmgcN0pgHi7gg8r6g86dXwiWBuYAAAA"
+ },
+ "static/wp-content/uploads/2011/07/Caffeinated_spiderwebs2.jpg": {
+  "w": 277,
+  "h": 463,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAABwBQCdASoUACIAPzmEtlSvKCSjMBVdUeAnCWkAAB9JpwD3DZLo9VGEgq2An0oAkzvr2lAAAP7o2ftBvg8k7v8EnWDjC80MsFkefi/fPGpTYV3inKvIAdbK7rJH5yqMeC0jdN9V35isKvZwpYpNfATyaqcAAAAA"
+ },
+ "static/wp-content/uploads/2011/07/hfzUX.jpg": {
+  "w": 600,
+  "h": 775,
+  "lqip": "data:image/webp;base64,UklGRsAAAABXRUJQVlA4ILQAAACwBQCdASoUABoAPzmQvVgvKaYjqAqp4CcJYgCxH4DOWxH5+gqwx7Ev/1mDtIeQOpaRjv6GbMAA4drfAdzjZqT5AJqzI64NuDoB0J8MDcFI/KaKwgWGX9rjDSdrhonoIJAP4x0G2gplTfm9E6iLfYqPO4vNdIr8+/KPp1+LeBiO6XJBq1cDbpfyGBRYhdD1WSOkDd3syA8wa8DTLP2Oq/kBQdyQ+mrva73M1wmOXqcG1Y4UAAA="
+ },
+ "static/wp-content/uploads/2011/07/IJWfg-300x300.jpg": {
+  "w": 300,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4IJ4AAADQBACdASoUABQAPzmUwFmvKialKAgB4CcJaADG9BI8DweOcLIh6KvSJy5ODRdOrAD+wbdrZvHXa6tnuJ763TVdWvwHJCNlyaNyCewsVFeX2tP9YZtUg4+LO8ggNRKkKRyvU4AoF13FSLtWVQX66zhiXRY+mauXgxLEOp8edvjxY30TOiZtZSrQmWYzAsbFRYD69dxCutk6ppjZGaAAAA=="
+ },
+ "static/wp-content/uploads/2011/07/KRd0W1.png": {
+  "w": 758,
+  "h": 563,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwAAXw7s4k8u8ulcXtIAAP5UeSrLtUK5uE+qjGya8dy5JDTZSMuvGqLqzbKimMCpksm+wwMrHAcYYkN9eH3TThTKs9r2SkLpIE6LJ6c8JISnx8wqbl2vodMlogAA"
+ },
+ "static/wp-content/uploads/2011/07/Screen-Shot-2011-07-27-at-1.35-300x179.png": {
+  "w": 300,
+  "h": 179
+ },
+ "static/wp-content/uploads/2011/07/Screen-Shot-2011-07-28-at-11.35.51-AM-300x176.png": {
+  "w": 300,
+  "h": 176
+ },
+ "static/wp-content/uploads/2011/07/Screen-Shot-2011-07-28-at-11.42.12-AM-e1311879209766.png": {
+  "w": 600,
+  "h": 363
+ },
+ "static/wp-content/uploads/2011/07/sNKpI.jpg": {
+  "w": 1440,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAACwAwCdASoUAAwAPzmEuVOvKKWisAgB4CcJZwAAQb1NqOuflfrdAAD2NJJgekiW4g/2hbBp3AZz/tJomH5wrZRf0tgbJd2xJS4GEldZZbNkK9mzd6j9KyuvyQAAAA=="
+ },
+ "static/wp-content/uploads/2011/07/xfMzh.png": {
+  "w": 750,
+  "h": 461,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAABwAwCdASoUAAwAPzmGuVOvKSWisAgB4CcJaQAAVMFBHEK/KgAA/o06/7lyREE5OhsghXzNgAA="
+ },
+ "static/wp-content/uploads/2011/08/07ad0f735cb64150992323a48cc29fbc_75.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAACQBACdASoUABQAPzmSv1mvKaajqAgB4CcJQBibAjXq3Xz5SNHQgXXe5c7xJAAA/tFit0YtW49jl6YIl48jm3HL2XcEezokTZc3cgRuiGMDAEgMWqPIyMgM8bWz9yroNTQabeRlXuSw3m3qd/AgQAAA"
+ },
+ "static/wp-content/uploads/2011/08/20110813-084033.jpg": {
+  "w": 480,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAABwBACdASoUABQAPzmUwVmvKicjqAgB4CcJZwDE2BI19zOeOiqA8KFSNy4MoAD+wGjVNgrlME66ApllbcpVWNENgKZVAD+nws1aQMATUJQzo4ytztjp0D1m4CXV8wYK7mFWINzHzgPIlsZOCPsjCnHWoUqyaLfaAKlU7e/sv9ZkDa4mzzqxByf4AAA="
+ },
+ "static/wp-content/uploads/2011/08/20110825-083626.jpg": {
+  "w": 480,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAAAwBACdASoUABQAPzmQvFgvKaWjqAqp4CcJYwAALmPE7dKNUuwbu0FllAAA/gkd3D77VqG21mnLr4OMGXIY7um8x1xmcu2ZEkD4zudnkv+0XZFFCEq3gwFRLaHzWLtQF7dVkRk2iKyEqDmUR1AXOGyN15j3YQCZgAA="
+ },
+ "static/wp-content/uploads/2011/08/300px-Audrey_Hepburn_screentest_in_Roman_Holiday_trailer_25.jpg": {
+  "w": 300,
+  "h": 422,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAAAQBQCdASoUABwAPzmGvlavKCajsBgIAeAnCWkAAC4wHY48UVG+tnxO66B9C2gVosYAAP6dbqFYHP8mSAhYQIpWa4qQ6r+lsJGKClfAnyqGvYA8h6LzjoTI+7QGl/kI1n0z3N/ehFdbpNVwfhxNb4VuY2CrJW969fYjmAAA"
+ },
+ "static/wp-content/uploads/2011/08/300px-Ayrton_Senna_Imola_1989_Cropped3.jpg": {
+  "w": 300,
+  "h": 283,
+  "lqip": "data:image/webp;base64,UklGRpgAAABXRUJQVlA4IIwAAABwBACdASoUABMAPzmOuVcvKaUjqA1R4CcJaACdM0xBJLHG4N7VM0z0fgwKwAD+Ge9NimxuLV5IYlXQQppbdBKc2Phs1oHLDjuHi8MVTkYJMtGtGoNvlNUTKPcwfpQEDaAFy8+NIH6wXjwTpwgEymLvqVtJb0GdxAhe6nAbdzeRNvOuAKCZzgcfIzoAAA=="
+ },
+ "static/wp-content/uploads/2011/08/300px-Elearnroom1.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJYwAASq48mH+7n35Pd7FCAADfdFJfPeQUsuEUpTT2pH+HllfUXGTeVjx3KWE56BF9LC+b7ho55N5r5VZ1/9annS0XF5p0oEr8YAFaBY0PtsAAAAA="
+ },
+ "static/wp-content/uploads/2011/08/300px-Internet_map_10243.jpg": {
+  "w": 300,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAAAQBACdASoUABQAPzmGvVQvKKajKA1R4CcJZV2AABrdvJEeqRnlTN6suAD+7NlYGJ+j0N3UmIIIN1V69sgpOsYoF5lMz+mBl3VgkFFDl9LhAAAA"
+ },
+ "static/wp-content/uploads/2011/08/300px-Lac_de_Faux2.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACQBACdASoUAA8APzmGulQvKSWjMAgB4CcJaACdMoGv/gNoHHO2dMiW4j/tDwAA9Oqrr9k/XgZYkzrdsPsuTCjSlq9GUW75y3d8sHhUXWJsDsRqAfka3MGwSjQoScYhBQctvVAgAAA="
+ },
+ "static/wp-content/uploads/2011/08/300px-Lorenz_attractor.svg_.png": {
+  "w": 300,
+  "h": 300
+ },
+ "static/wp-content/uploads/2011/08/300px-Mavericks_Surf_Contest_2010b3.jpg": {
+  "w": 300,
+  "h": 199,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAADwAwCdASoUAA0APzmGulOvKKWisAgB4CcJZQC06BU1bKjLsxS9tzEAAPzYrhDLDeKzn3gv0AmmT5mSDag8oRextia++mt7DJniqfY+ZAWWwt/SvZgu+3FsjgUAAA=="
+ },
+ "static/wp-content/uploads/2011/08/300px-Michael_Schumacher1.jpg": {
+  "w": 300,
+  "h": 403,
+  "lqip": "data:image/webp;base64,UklGRsYAAABXRUJQVlA4ILoAAACQBQCdASoUABsAPzmKu1YvKSYjsBgIAeAnCWIArhwKrK9JP+jSSf30Gg+G4PETog8D/OuU4AD52aT5DXiLBqbsVTN71lNK0w+gGCXmb+zc8bfhfK63hQlJO/l9N/LDY+4quk8uQzHDtGwfbTWdnR7zLYu1VmiDgdYTxEkuYRARvryMGAq6ROejiAkh86vI+1igC7FiiRbBgv/MOJB2gCJH+/N3IjEP7tcdcP7Y08WqvgkbRW0lgZYAAAA="
+ },
+ "static/wp-content/uploads/2011/08/300px-Mito_Art_Tower3.jpg": {
+  "w": 300,
+  "h": 465,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAABwBACdASoUAB8APzl+uVSvJz+jMBgMA/AnCWIAtRtVxSICQjcnzc+ez8ijQAD+uJDY0hqBW1ARVSIdBq+64EXtwTqK/cBQ9IhLYoHHjbFQCeH4GyhDup3k932iGZnVuHHtlGUJMsyQots5oIP4P5+QLvigAA=="
+ },
+ "static/wp-content/uploads/2011/08/300px-Moleskine_-_023.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACwAwCdASoUAA4APzmEuVOvKKWisAgB4CcJQBOgVf4YjQ2nw50/bgD+lDT319RHK9dyFPbvSDIDVIcwIUeAwDchMmhwFaSgyjRjlYVA0vykQ4j+RVWPjmYji05zbG6Q+Q3SH6fVoAA="
+ },
+ "static/wp-content/uploads/2011/08/300px-Oscar_Wilde_Aesthetic_Cigars.jpg": {
+  "w": 300,
+  "h": 550,
+  "lqip": "data:image/webp;base64,UklGRrYAAABXRUJQVlA4IKoAAADwBQCdASoUACUAPzmSwFkvKiajqrgIAeAnCUAXBgFWqOaRbNveIqLD9KQgW/KpjAGvcU1pQ86qAAD3aPCNicxwV18YVsmCoMFhs+wETH0wTaKe/P8XDH4Qm6oZ37eiIHU6YTyJyI7m/IsnDQsvrxg5mGC7BU4lpdOtWihYHkCvHz+CpFPoYD2JDK/enO26aZksm/Wyf1Wh1zsSQ2Y2kDg/IM7co1StOMAAAA=="
+ },
+ "static/wp-content/uploads/2011/08/300px-SF_Chinatown_CA6.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAADwBACdASoUABsAPzmIvFavKKYjsBgIAeAnCWwAvkssAFczwKlcTBPT/4MtodUHKYAA5Ho8tG56tFcGZqBk0oSc1rB1rJHZeDXJKchmTVaQbziw0j807cWSNCX1D1h02RS0j1DXzrz7zNrrbnCZsrLN6QYasO8BHKkTF5Zry2hY6nkhjf2AtTm6rAlk2SY1UHmCY4bKBzdqxrq/RHopOVGBC8okAAAA"
+ },
+ "static/wp-content/uploads/2011/08/300px-WiFi-detector1.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRlAAAABXRUJQVlA4IEQAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZwAAWSnQCeM+UHoGgAD9zByOWIvEPiUYSgkNh821x0Wh6yhMVrT69HqSAA=="
+ },
+ "static/wp-content/uploads/2011/08/4101129542_d3e9ae80f4_m2.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJbACdABhzT9XVgegDdwAA/tlY50AuncyKPvgi4kIEdkLRY9ZQDV7/tNQzUOzfJbZolAmj65+QAetJErNcHdxGZgY7SAAA"
+ },
+ "static/wp-content/uploads/2011/08/5089475323_3dd9dbf197_m1.jpg": {
+  "w": 240,
+  "h": 160,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAACQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJQBOmUABp0ooH0uIQAP65YIE5wNqo1tDjAlVPyzj4lKXkBrwZOwjdhy1EHaWgEoWtl9/QBbAAf39p3QAAAA=="
+ },
+ "static/wp-content/uploads/2011/08/5648756796_9b48467eec_m.jpg": {
+  "w": 174,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRqAAAABXRUJQVlA4IJQAAACwBACdASoUABwAPzmQulWvKqWjMBgIAeAnCWwAADFfkd1p1YVluYqxM6o+TvfQAP7baqUEHbKiiWL5aaLO1JixQUbrkcYkaynrvMfThddb/UkTdUSXvu1VL8tFrYPqVWZXuDO8mNW/PR7G1YrGN0jiYti8CBJn78jbNxMpPZ8gwKD4Rc4D6T24mTbnb9fVPxDVH1QA"
+ },
+ "static/wp-content/uploads/2011/08/9c46947719ee42638b2398044298e725_75.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRrAAAABXRUJQVlA4IKQAAAAwBQCdASoUABQAPzmUwVmvKicjqAgB4CcJZwDHMywA2xUxX5ZLWD6BSdkwdUHITEsc4AD+3ZmwUrkd6QlyqZ6JXxnC7DNoyLjALh+7GpU8kbwe/Jppj6tRvMi9z9VVVR/8LPBOK0Ie4bDt1GN8rtEpieuCBmCkeyEHO/3E1ZXniDuHmBZ7DnshaNTFoMXYTno9u9Sx4E6TX8+8oHqsE2mMAgAAAA=="
+ },
+ "static/wp-content/uploads/2011/08/dbef20877a0c4b5fb6bf32c8b95fdb1e_73.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAACwBACdASoUABQAPzmIu1avKKWjsBgIAeAnCWYAvzg0b2lI31OMq6nA+tcQKVoAAP7Bo34v9NDy8POuwxmm3Tm5tkmjHFiRwQ3L/JPuAibMxIlzRoE0Pt9ACQGZkKw4ZNOI4SdMyQ3tgXtOCYYasOGMov+gAA=="
+ },
+ "static/wp-content/uploads/2011/08/photo-300x224.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZADCgCIiL6iDhe7H3cAA/slRJ8L8MBXJAILRRa2nOCXB9XM2UFpWAjqBFUXZcePcnZpbTeZpQINMZZyJNiNa5AAAAA=="
+ },
+ "static/wp-content/uploads/2011/08/photo1-300x224.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJbAC7ABakITjngc5G4AD8XdcYh8ZYMfSwyGv4Ph4VHFHb6nATzCmkIwAg4Zd+3R6Fxt5E7Z2/jei+/eqbn/D14vFbQ1nNpb/gAA=="
+ },
+ "static/wp-content/uploads/2011/08/photo2-300x224.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRpQAAABXRUJQVlA4IIgAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJaAC7ABSjttiVjUiiI+WdAAD+e+G9P4H0oqcOG731HmSjw2Ex2F/BJni10Y6rxj91PPe6JlfJuZnqsTOmwhXX15PI7kRRfrNftBQlUxrwt/a1Cnn9oH5ngsOxzl/IfPirZjvo4R4t1PEHRuKwYAAA"
+ },
+ "static/wp-content/uploads/2011/08/Screen-Shot-2011-08-17-at-9.25.35-PM-300x234.png": {
+  "w": 300,
+  "h": 234
+ },
+ "static/wp-content/uploads/2011/08/Screen-Shot-2011-08-21-at-11.12.16-PM-300x255.png": {
+  "w": 300,
+  "h": 255
+ },
+ "static/wp-content/uploads/2011/08/Sleep-cycle1.gif": {
+  "w": 125,
+  "h": 369
+ },
+ "static/wp-content/uploads/2011/09/11f3ebb3ac804d4182fc72487e333a56_71.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAABQBACdASoUABQAPzmQuVcvKaUjqA1R4CcJZQC4MBENSVZ9BfJC3/VMG3wAAPaIxKkQgJfUTuW/i6gMwkOCyqJUqIvxIfYOEh4j6j08wTqkE4W4UnRnVZCtpIvAAA=="
+ },
+ "static/wp-content/uploads/2011/09/283px-Manhattan_distance.svg_.png": {
+  "w": 283,
+  "h": 283
+ },
+ "static/wp-content/uploads/2011/09/300px-Brigitte_Bardot3.jpg": {
+  "w": 300,
+  "h": 409,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAADQBACdASoUABwAPzmEvVavJ6YjsBgIAeAnCWkAACJl9TJ6P6vNucIBYWKXUk8BwAD+vU07T3dgGsq7yr3zo0owWPKKv4/rTxiQo0zmZXxsZDvGc1VqRXEYvhkxdamDHL8ZI9y+H3kvtEtG3GDmKAAnr3CPsxBEut9z6WTq/R/1y7lL4b/gAA=="
+ },
+ "static/wp-content/uploads/2011/09/300px-Chocolate_Fondant1.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAABQBACdASoUAA8APzmEuVOvKKWisAgB4CcJZQAAUyztww+KDAszuxgZnIwAAP7nPy+AW62sCUY33NVwpSqVROe+B+LRElLYqtjg5f4Mj4FyUjmeyVPD1tqq1/AMs7D8OYeq8HoAjqVtsSe6pjCmFgAA"
+ },
+ "static/wp-content/uploads/2011/09/300px-Distancedisplacement.svg_4.png": {
+  "w": 300,
+  "h": 186
+ },
+ "static/wp-content/uploads/2011/09/300px-First_Web_Server3.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAAAQBACdASoUAA8APzmGuVOvKSWisAgB4CcJYwDImCEog15orQ97b1w1AAD785hhgKy06XyLGAwUMUjSvV/UzRLMsFyLfRDO9y5zVxjYOv7uVGlvN82G7+lqGDrNdBiKZHxMU6qqAAA="
+ },
+ "static/wp-content/uploads/2011/09/300px-Interior_albin_brag_kvm_1.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAAAwBACdASoUAA4APzmEuVOvKKWisAgB4CcJZQC+SCIgY5Tk1nHaqsNh1AAA/frIjBwu/fBp+0+FcWARxsbWriyIdsNlsITKbL4k7FS9ERXpaG9LP/VW4vpA/RnPBWzX+zCSEAAA"
+ },
+ "static/wp-content/uploads/2011/09/300px-Longboard_skateboard3.jpg": {
+  "w": 300,
+  "h": 308,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAABwBACdASoUABUAPzmUwVmvKicjqAgB4CcJZwDLpAbA9OZfv7r+3SHcKEOokAD+0KGexXB0B30ESXiPwn/yc2dMNZuF1nHbwxLG4iAo/A28+0qNcLgoSswIE3rA/e7TAxTOrtxu8bnutQaAJLxJ+yGp41idIGsIWEdMQJQA"
+ },
+ "static/wp-content/uploads/2011/09/300px-Red_Devil_energy_drink1.jpg": {
+  "w": 300,
+  "h": 533,
+  "lqip": "data:image/webp;base64,UklGRrgAAABXRUJQVlA4IKwAAACwBQCdASoUACQAPzmMulivKKUjqrgKAeAnCWwAvzgjEy/flw7BoyQvD76/TAo7mO51MXGgqAAA/o0M+EdeZUM0+vrPBVy1u/7B8UoeA9b10sq1qUOOnOqFIbbwUjYKjq5oMhuLJ/drSNeKBIaFBy06o3fyp6skHNR4gVnOCb40Iw4h3PQWCwh4srqU+8NtcwfxOkJY+E3nVt9acQlP584br8F1WcR/AArcWNAA"
+ },
+ "static/wp-content/uploads/2011/09/300px-Something_Is_Expected_Cover2.png": {
+  "w": 300,
+  "h": 299
+ },
+ "static/wp-content/uploads/2011/09/300px-Studying.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJZQDCgBe4KMwj43d6LLQAAAD+P/Jvy8ZVhStoH963FacdjYYADrdRDjxJ9KO+Q//i6mnXR2u5TbPHNq3Uk15jyjKO3QkMdGSl7Ahb293oAAAA"
+ },
+ "static/wp-content/uploads/2011/09/300px-WPA_road_project2.gif": {
+  "w": 300,
+  "h": 394
+ },
+ "static/wp-content/uploads/2011/09/34630357_a5b1c00f5d_m.jpg": {
+  "w": 240,
+  "h": 170,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAAAwAwCdASoUAA4APzmEuVOvKKWisAgB4CcJQBOgBaDuJkwAAP7p2df7Z7UkcDvvR7cd0ripqueMCloIrt8tqPS7jwWNens4AAA="
+ },
+ "static/wp-content/uploads/2011/09/5057005056_6c46df1beb_m.jpg": {
+  "w": 191,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAACQBQCdASoUABoAPzmEvVavJ6YjsBgIAeAnCWkAAC3P6Fq1SPh2tllFWyI+H7VtqQPNQ+ErgADeNCNhCO2lhYcHSMIAz0RN6vyYFK6M/3nJkttqswo5SZto3LDHlsgHPSM7CfwVQyHmZFgAAAA="
+ },
+ "static/wp-content/uploads/2011/09/5d7f30542de74f2a982db3ac03e3925d_71.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRqAAAABXRUJQVlA4IJQAAACwBACdASoUABQAPzmQu1gvKaWjqAqp4CcJYgC+SBDQuZe7DB02hN3Mn9QE0qIAAP7o0FO72abdXpdnnvAzKXGILui9O9Y0g9uJLkDwU+lT5QxwDbd4DM6w7XnkyCO/f/O8zRGVVxsCTsfmTqVbGNb7oJWF6+ghMsvGyn+6fnq5fW32pOw0y70yWpJrx5AqgGO+qAAA"
+ },
+ "static/wp-content/uploads/2011/09/6192586527_c36407222c_m7.jpg": {
+  "w": 240,
+  "h": 160,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAABwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJYwAALUdYGyjeMkAA/p7VP4Nkz3hb0oLc9F9YC3l5UNepk2r8JyJSv/itoqId/udxMtyDbTlcQGcUxeq4CyNaH+FMg4WG1kcu5DOSbPk1U50/FjyuOgF6EibVKLzcAAA="
+ },
+ "static/wp-content/uploads/2011/09/8024ae956d1e4bebbf2562477c22dc4e_71.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRqIAAABXRUJQVlA4IJYAAACwBACdASoUABQAPzmSvlmvKaYjqAgB4CcJZQDH5AhDpSSngx+1DnXE6PjOdxMAAPyOouC+AMbqFrG0v5UzlmmOaeic2d2aQ91sO0ZA+5HzjOkZVnRT9IMVsiTTGdJlvp05iqZCrnGJyen+clnWl43YNJsH6F5XHYFOtytdmFzUIIYMKtHz42g4VFJAdwbeU2aa+xHkAAA="
+ },
+ "static/wp-content/uploads/2011/09/990b0015ab38406f950e2ce58f90f3af_74.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRrQAAABXRUJQVlA4IKgAAAAQBQCdASoUABQAPzmWwlmvKqcjqAgB4CcJZAC+et8BqbDajLEPzAMD7G6V7r7T+RuAAPzqokFlkI6Mz8Se2SJrtj7C/EesXQrPbPirnjK7maR4EF3mcIkiDBm9ePzrUIrwpHH8jlEuk1lHijsWCEqye8yFlqkOs46YOl+J11F9tFdhqlcXa5HhWGvRj2xKpEOvS1hIbrLz7cuyfun/uv1hrAA1K3/0wAA="
+ },
+ "static/wp-content/uploads/2011/09/Credit_card3.jpg": {
+  "w": 300,
+  "h": 169,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAADQAwCdASoUAAsAPzmEuVOvKKWisAgB4CcJbACdMoR3ABUbFnd2i6AA/hbcS5tSN4g9PWoTYcON44/cMGtNJIhr5zRxcv7YhL06sT9W4KzE+pAjBTz7q6mpdleZkOyVIIC1e4J42zkKzj9fx+GLC1mQsaNfAAAA"
+ },
+ "static/wp-content/uploads/2011/09/e798f70658fa4f61b0ea840ca5fcf50e_73.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRrAAAABXRUJQVlA4IKQAAAAwBQCdASoUABQAPzmUwFmvKiajqAgB4CcJZgCdINBBXFnTZybf7OOTI0kvAzU10qWYAAD+MvzhODd04yS/6fLuE80E4MSQyuDvY97fb+xFIQYG45QLkNRT5fHRez8A6vtQqB0g9qk0d10+/csSHE8jOIVlRGaG1AhSeo3pQjbQbqoRscz4VQWCMUKXTSEw9BPpK8MZTOg5jZgNTqR/WpAt5fAAAA=="
+ },
+ "static/wp-content/uploads/2011/09/highres-2eebf2d53a650de548943f24af86894bbb1d92ba1.jpg": {
+  "w": 640,
+  "h": 478,
+  "lqip": "data:image/webp;base64,UklGRpAAAABXRUJQVlA4IIQAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYgCsEf/gLsWyUHjmGn7AAPyv56/tb0snnXEIx2Dc0MBzILnkunQauioffuetcvqBpiH4FJZxeXze6s7jgIk6/rlba8gsPZg/AkX55+U4C5YcYPgESByQUQ0xYWjUjI5Bnz0xpfB9JqWgAAA="
+ },
+ "static/wp-content/uploads/2011/09/photo-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAADwAgCdASoUAA8APzmEuVO/qKWisAgD8CcJZQAAd+knwAD+kskKn5iPpKWRJhfYL1I4bn6d2HPUwAAA"
+ },
+ "static/wp-content/uploads/2011/09/photo-150x150.jpg": {
+  "w": 150,
+  "h": 150,
+  "lqip": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4IDwAAAAQAwCdASoUABQAPzmWwlovKqc1qAgCsCcJYwC/OBmrjgAA/ro1KMuPCp3y1vAqzRNQ7m8r+ABIRhw0FAA="
+ },
+ "static/wp-content/uploads/2011/09/Screen-Shot-2011-09-16-at-4.58.20-PM-300x199.png": {
+  "w": 300,
+  "h": 199
+ },
+ "static/wp-content/uploads/2011/10/152458957_9d68be3827_m1.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAADwAwCdASoUAA8APzmGulOvKSWisAgB4CcJZwAAW9oZf8aZfE4C1R4AAP7TFRjhbVE3+jGCqh9pe1He1CR90r3XWY8+Zq5uapzp49QT9fZhWko0dtBi6OAA"
+ },
+ "static/wp-content/uploads/2011/10/2011-10-28-12-43-18-131.jpg": {
+  "w": 640,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAACQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQAAIr/HIPvO6/5vwAP6Dgh0dLrET0EJUOks47455p763aSE/9O6NOggCs7eB+JNKTrXK8Orm5FcYgjRiiHBBGtNGiFl+N/ABfF5TNEgGv+KoQXAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/2011-10-28-16-49-43-336.jpg": {
+  "w": 480,
+  "h": 640,
+  "lqip": "data:image/webp;base64,UklGRqAAAABXRUJQVlA4IJQAAABwBQCdASoUABsAPzmEu1avJ6WjsBgIAeAnCWwAqPQNrDOJ74Odp6rEPGQqkgfRzeC04GkAAMqo510DNJd94B4m5H/PBsEOj3aZan4+pkuXsMXz7GIiS/9a3FIg92KNVmzSvRv9rglRH+zE1BnrXbxEsilbj37Yfc3g0vhDmW/6Vixi2oZDrL5p/C/2F+CgVUuNgAAA"
+ },
+ "static/wp-content/uploads/2011/10/2011-10-28-17-08-44-674.jpg": {
+  "w": 480,
+  "h": 640,
+  "lqip": "data:image/webp;base64,UklGRq4AAABXRUJQVlA4IKIAAABwBQCdASoUABsAPzmOwVcvKaejqAqp4CcJYgC+SA/P3aO259r0s43/s7AaDB9xI7nND2AAAP658rLrCsKTogsj1EGRfF/6cUML7D++/PP9suaPDjAv/Egtd47RCNFTtGBLd36cmFkoY7zUJ2eFM7+YY2O2GaZe1nVBA9sNvvXK3CrdDf9xJvBVsltxTKuCFxCgC5h1AR6DW+usgLDYACkAAAA="
+ },
+ "static/wp-content/uploads/2011/10/2011-10-28-17-53-59-968.jpg": {
+  "w": 640,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJQBOmUABtMG4NtbWrmdHMBgAA/U1Szb11gCBVuHkIHT//2Go9rLKdV3u61JYuHe/X5HpkyR/BjdxaBx8xziTbjVCZ718PG2KVAAAA"
+ },
+ "static/wp-content/uploads/2011/10/2306432416_ffb32d9b31_m2.jpg": {
+  "w": 180,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRqgAAABXRUJQVlA4IJwAAAAwBQCdASoUABsAPzmQvVgvKaYjqAqp4CcJbACdMoJX/RAABeiJhaF63cQQv8KKZPotAADaABlk99BLgcD1OXbK8025OwqAYMNmWIkk9ueJahTwqwgTs2T6smnrvih8roCjQEm8dGEMnRoNaG1je5PIiGkbP8EgOf1BmbqjzQfmR2vNsEhfCPOrXYUC2YIJttBxqDQDFEOH3xaoAAA="
+ },
+ "static/wp-content/uploads/2011/10/2990635787_f61ba8ce93_m1.jpg": {
+  "w": 180,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAAAwBQCdASoUABsAPzmQvFgvKaWjqAqp4CcJYwDL4dwAfMWjo/YyJPDBPUpGekt48+jBAAD94cQoO7B5lRiKo1ZUIpVvagt+eqfvcBdlHH7v0/gTt5rJFam1u3e/A5tfz+TQ8XcvsHr16L3fo3ihdWd3x7glA1w1RqVk6wuTarohDE4nCDyBUyGzNtAxy6iQeU8Sw/sk2MC8GjdHcPKfc/tjZVBGcwAA"
+ },
+ "static/wp-content/uploads/2011/10/300px-BDSM_collar_back3.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAACQAwCdASoUAA4APzmEuVOvKKWisAgB4CcJaQAAXveqXxkV0KVAAP7r+qPmcKwwX0kXIcuoGvK3t1qMtJSj31FcbHTDCNHusVRMMZ9FgX9QEPGjxm0Z2L0msyAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/300px-Beastie_Boys_Sonar_2007_Barcelona_Catalonia.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAAAQBACdASoUAA4APzmEuVOvKKWisAgB4CcJZQDG9BcT9nEKjksJPNplQAD+6/i8h1gSizCXMlmVP93cFzOr8OZrgYU+HQOtqRytRPcONXNhgLDgDv2/sfPo1wwehn+UaVlgcPXSepAnJfENRCMTjI4AAAA="
+ },
+ "static/wp-content/uploads/2011/10/300px-Glasses_800_edit2.png": {
+  "w": 300,
+  "h": 225
+ },
+ "static/wp-content/uploads/2011/10/300px-Power_Horse_Energy_Drink3.jpg": {
+  "w": 300,
+  "h": 411,
+  "lqip": "data:image/webp;base64,UklGRp4AAABXRUJQVlA4IJIAAAAQBACdASoUABwAPzmMvFYvKaYjsBgIAeAnCWwAygAPEmx6cg+4VMTtEAD+3tuw4u/E4Nux7s64Bs0Wi1IPNJo4hjo+z/M97ye4RFdcI4ZUb2FO9PhBXCDFvUZm0i8zxdDG9SDL+TsLs2Z6etqNi1QNEyioWJx7hBLS/mqhKzVwuKMu4GeiGVDbYdh2R1ZdQgAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/300px-RHP-Rollercoaster1.jpg": {
+  "w": 300,
+  "h": 295,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAACwBACdASoUABMAPzmMuVavKSUjqA1R4CcJZAC7AA9/0lF9grf9agr+n2+VyeDQAOIqu2FTw/KThK1C/wdwab3aRr35YwEmMe7PoYCvtpMHcjiL1tCbs9Blqe1JJUzempEz07hcx7EALKpR9hkMSKWZbsSUlULfCEf1H/qMTegpfoAEK8wAAA=="
+ },
+ "static/wp-content/uploads/2011/10/309262913_fe554e0a8c_m3.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQAAG9+ab+vGxu55GJwAA+e9GIEMOgjT7j/lHFGPWJlxmFwm2AR7e7PmadiDt7u8H9pX+o24ffi6eeuvB50HkusK1Emgm+GnvAgXwoP/69xwmaAplgPJM/QAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/3919560473_67c3256b2a_m.jpg": {
+  "w": 240,
+  "h": 160,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAACwAgCdASoUAA0APzmKulOvKaWisAgB4CcJaQAAeyAA/u7htLJRXD9vu5pPWv/2v/sY3hPR7iAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/3954094115_0f1a0e6a98_m9.jpg": {
+  "w": 180,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRpAAAABXRUJQVlA4IIQAAAAwBQCdASoUABsAPzmQvlevKaYjqAqp4CcJaAC2yDTvpQEdmugiJB9d4SJHTqQONMVJYAD+8Lz+rWYdXYZyj58jjYUGIhgEyaFIxkruq84gb04xstYy6gqLG5+vNyA4GdFxQtzuXrpgTHu2Ci5KRMPNMs8qu+vYe8r2dDBL8vWZweL2AAA="
+ },
+ "static/wp-content/uploads/2011/10/3qqjy-1-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRrAAAABXRUJQVlA4IKQAAABwBQCdASoUABsAPzmKuFOvKiUisBgMAeAnCWgAnTKAAaoD9MV/MeNMk9woFQvKOwi2m9eAAP5vElYpomIiiCyEhALTZArYTdtsJQ1VA7fgseszUoggM4eUxijJtdABCQwLvQ4bGEW2eeAsmJVb1hHIndDyzx+yZNxc8/M0xQ5aQZBHSJLFCF0ec0kniKzF7joGKFip+uIAgCEUw8oe06DsghjwAA=="
+ },
+ "static/wp-content/uploads/2011/10/4385225489_4f3b12247a_m2.jpg": {
+  "w": 240,
+  "h": 127,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAABQAwCdASoUAAoAPzmEuVOvKKWisAgB4CcJZQAAUdbSp4zJ0AD+r7dtb5tMDeulRX9E7ffURyv1+eUsnZQVHAAA"
+ },
+ "static/wp-content/uploads/2011/10/4466482623_6aea29d90a_m2.jpg": {
+  "w": 240,
+  "h": 159,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAABQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJZwC7ABgJzjhyYADhDRgY+SLittuXbO5agHaTN2BsAAAA"
+ },
+ "static/wp-content/uploads/2011/10/5059286742_eb649aaae3_m5.jpg": {
+  "w": 240,
+  "h": 219,
+  "lqip": "data:image/webp;base64,UklGRpwAAABXRUJQVlA4IJAAAABwBACdASoUABIAPzmMuVYvKSUjqA1R4CcJaQAAKWRt8ysPm4LrjZjS9J0wAAD+5+wLfhjKfT5h9uz96NaEQN9phwWWDBMn2pgTzPWexfvjqxsDfZfznV6kSFMxQqhi630eREZ2BuPSQZOYbS4ylDBRQrKHOVOMm0KVXRBLhYUt5Kfs5MkAYTAnCvLVTYgAAAA="
+ },
+ "static/wp-content/uploads/2011/10/57cab9bec4c74bf2b3c7ded9f6675d02_78.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRqIAAABXRUJQVlA4IJYAAAAQBACdASoUABQAPzmOuFcvKaSjqA1R4CcJYgC/OAyXuRJ3aS4bReOoAAD+5ZDUZCn/AmW18odehz3VL6P5ri1+gF0GpZzvc4MRqZ5r7Ql+ElkEB0jGZvCDKEDi1XdNUeLQOAfhZlz56a8R+OhljZO2EEA9qeaOpw0mhom8r5LlxjBQkidHNWTTN8/MOWES1THAKXMwAAA="
+ },
+ "static/wp-content/uploads/2011/10/6229977151_4f39755c38_m1.jpg": {
+  "w": 240,
+  "h": 155,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJQBdgAzeF8oFBBqVMLwAA/qUpBwHoea5Du87/EawRNiKg6S0Lxp6pRLULp/tvEaOZMqmAfgQ1PRbEGL/1mJYTReEOdVMk1gwyVjqAAAA="
+ },
+ "static/wp-content/uploads/2011/10/6260572607_be8dca7de4_m2.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAAAQBACdASoUAA8APzmGuVOvKSWisAgB4CcJZgCdEf/gL+ikaf73MCwN8AD9IRssrHbNt3vlCkC9yXtkxUfqarfOxkU1cgkUF0u+S9wyRrZQwN1UPi/tiNDbeovyZ+ks1pC0yq7FoKqrQozPv0Dq4Wn0Txh5PRcdzVsAAAAA"
+ },
+ "static/wp-content/uploads/2011/10/959a08a818b54dc89eb397dcf05b959e_74.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRpAAAABXRUJQVlA4IIQAAAAwBACdASoUABQAPzmSu1gvKiWjqAqp4CcJYwCpJ2QBQdtCh4okMbBW9gAA+TNAUgzq84IDQs4L96a7AV+g0u2UOrXEkfrM8RJ+5us9xLc2Ylox2XU7C1QFgh6tqTfVeboROwamtRi1loh0oAvfYeXX9SPKpE6esZzgM/ygayo7f+cAAAA="
+ },
+ "static/wp-content/uploads/2011/10/cad1.jpg": {
+  "w": 909,
+  "h": 734,
+  "lqip": "data:image/webp;base64,UklGRjIAAABXRUJQVlA4ICYAAACwAgCdASoUABAAPzmGulOvKKWisAgB4CcJaQAAeyAA/uWa0wAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/cad2.jpg": {
+  "w": 914,
+  "h": 730,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAAAQBACdASoUABAAPzmGulOvKKWisAgB4CcJZgCdMoAC/MbOy/O7JIA+HAD+i/EM1K4hADjsI5ICPV37hdIRyXRgIiS7iV4A8J5ZqwAA"
+ },
+ "static/wp-content/uploads/2011/10/cuts4.jpeg": {
+  "w": 640,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACQAwCdASoUAA8APzmGulQvKSWjMAgB4CcJYwAAW+uEvoyRRjAAAP7rz0Ld7P6YqT7JMKqBn+vfEdJWJvVgSWzxZpHKOkYMOdnB8/5I20UAAA=="
+ },
+ "static/wp-content/uploads/2011/10/fatty.jpeg": {
+  "w": 640,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZgAAW5BMjpawS0hh9xgA/uvwGGa6Ukn2GsRd9uNVGBN+bw88tt/SieYYklpGb7z39QcZV3zjRBMnq2AAAA=="
+ },
+ "static/wp-content/uploads/2011/10/IMG718-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZAC7AB7HLIQirq1sPb4wAP5xY4G6VMdfrBFT04tJKG2JRUfmH/DVJ/kX1NoTqSRqztC2UCvR2stE9gOR0C/6bvO8GWHamsDUNknbogywe7OA7AAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/IMG719-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACwBACdASoUABsAPzGAt1OuqCWisAwB0CYJQBmwhDvQZtZl3XpmPI9VMCuqoLngAP7NtBQ0KvULCrw4qvt/2thqUK9wizo9cMHtwbjtk3ZCoCHdyPq8pCRayJo2eJU807uOxhRO2AA="
+ },
+ "static/wp-content/uploads/2011/10/IMG725-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4IEYAAABwAwCdASoUAA8APzmGulQvKSWjMAgB4CcJYwC/OB9L/Ai8QgAAnwELNimVEYp4FP6NmTzi1tJN8FH9jQ0EsbaJ8STLXAAA"
+ },
+ "static/wp-content/uploads/2011/10/MOBIUS-CAKE_00031-1024x878.jpg": {
+  "w": 1024,
+  "h": 878,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAAAQAwCdASoUABEAPzmMwVcvKSejqAqp4CcJaWuVABpvokAA/u5oYhds1+FuPSVxf7XUw1T5ZkaazwAA"
+ },
+ "static/wp-content/uploads/2011/10/MoebiusGearA-300x226.jpg": {
+  "w": 300,
+  "h": 226,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAABQBACdASoUAA8APzmGuVOvKSWisAgB4CcJZACdMoAC/4GSoaGimfbVJroAAP6vJFozfWZwaoZapRupuGQ+yGGl9JayGVIJ+V4k0ZjDSA7+G5G2QlFtRekqdyfhWun/mz9OzGyEvT7oo9QAAAA="
+ },
+ "static/wp-content/uploads/2011/10/Rainbow_2_by_bittykate15.jpg": {
+  "w": 600,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRswAAABXRUJQVlA4IMAAAABQBQCdASoUAB4APzmGuFOvKSUisAgB4CcJbACdMzLzGEKQuZ+Ao6poScAlXlVixxSJkswA/RTbIws+NiZ6YS4cqXfPGXR5y8MrOje0L7EBQgxn5tiw26AcTHQdUhNmVp60SF83eDa2QdyYd2u4ZDg1AV9vAYcRvTnP/9/1shW2j8YfOFc4hSelQD1iyBWz/Koww9RD8FEB+IOR61rzbVI62CcoNI4FY40RN+03PG16kwxzjzwRExdsnYKkKXcAAAA="
+ },
+ "static/wp-content/uploads/2011/10/Screen-Shot-2011-10-01-at-1.48.03-AM-300x289.png": {
+  "w": 300,
+  "h": 289
+ },
+ "static/wp-content/uploads/2011/10/Screen-Shot-2011-10-01-at-1.48.19-AM-300x290.png": {
+  "w": 300,
+  "h": 290
+ },
+ "static/wp-content/uploads/2011/10/Screen-Shot-2011-10-03-at-11.50.58-AM-300x185.png": {
+  "w": 300,
+  "h": 185
+ },
+ "static/wp-content/uploads/2011/10/Screen-Shot-2011-10-03-at-11.50.58-AM.png": {
+  "w": 585,
+  "h": 362,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAABQBACdASoUAAwAPzmEuVOvKKWisAgB4CcJQApgmkHP/gNcHK5JMrCjuILgAP7fwllxF8bpAEHxG1RsMqldivdkmjNDhzaKdvVeQ/SYEwUdvIuWNa+P5nQabDAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/Selection_044-300x122.png": {
+  "w": 300,
+  "h": 122
+ },
+ "static/wp-content/uploads/2011/10/Selection_044.png": {
+  "w": 818,
+  "h": 334,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACQAwCdASoUAAgAPzmEulOvKKWisAgB4CcJQBWABDrqiWmI0L0AAPyOjwyUp5Ar52yXdcexGriTzdAMaJYRMxxxuMseUz9HOeaYjPUuAAA="
+ },
+ "static/wp-content/uploads/2011/10/Selection_045.png": {
+  "w": 448,
+  "h": 327,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJbAAAW9b3CNw5uAy/A7IAAP7EVD8r4K8gkcNNwt+Mri15rMEjr89l0VEwjt/km4Er6LuP3cC4fz4VH2AAAAAA"
+ },
+ "static/wp-content/uploads/2011/10/tumblr_lt1vmgp30U1qekjngo1_50010.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAACwBACdASoUABQAPzmKu1SvKaYjMAgB4CcJYwDLLCHgICPsWzhe4ZCa0ONFanDAAPwVIYSNYQRdk3Zv/PzVEjSKfiQm5EiNVLIIZjc99WI4F8IqMRTmMI4A63luWAAA"
+ },
+ "static/wp-content/uploads/2011/10/tumblr_lt24i0Xa601qekjngo1_50010.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAADQBACdASoUABQAPzmQu1gvKaWjqAqp4CcJQBhmgiOKGN8Nx9jwbmnznpFMsLa5gAD+mlePaP8FswbOmLdoa9RsMf1dEVt9Visk3NPiZ0oOJKo8kMtgM92QIgkJnXI7O4JjrJxzfSIyR5BjQRL45mQuluZfqm8jkKqV/jf7QtxRpnYsKoAAAA=="
+ },
+ "static/wp-content/uploads/2011/10/tumblr_lt28wyJXyg1qekjngo1_5009.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRrYAAABXRUJQVlA4IKoAAAAwBQCdASoUABQAPzmUwFmvKiajqAgB4CcJbACpBf/gF5aVNyu43817fxlczkQt/mk6AAD+6/juedgKYTUbYd1D+uaNR8w0WUZEQfO9IelF6M3532ociPDzkwoWpGrkEMQ/6qnQSXgG/dUdXA6KntJWRzpK4JR+zjUe/XyfuaIjyihOhZpIXVWiguq3Ez/pQRBvRAM+nMipNzAR8GKLQGMJ0+/urTs3QMugAA=="
+ },
+ "static/wp-content/uploads/2011/10/tumblr_lt2h1exdVZ1qekjngo1_5009.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAAAQBQCdASoUABQAPzmUwFmvKiajqAgB4CcJagCdMwnBf5rQgiZhoino6e+qlK6q9iMAAP3UMBEnqrUEmQrp7NMMNhwyU/a9AVUrF3IsoxCzBi1pFFuIwI2lvhQSsOofRcoQLGaUzmb0XVYPgrqS8vn7WbEkzJqRJ3E0C159cD68zJli4jnjQuHHTjMJHVwwFHz4r+11D4Z4Lomta5sRqBKJTXriIAAA"
+ },
+ "static/wp-content/uploads/2011/10/tumblr_lt2j9ptowg1qekjngo1_5009.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAACwBACdASoUABQAPzmUwVmvKicjqAgB4CcJZAC06BEcbgR5h6CvbddA2Tx973iSAP59Vka/aewYJek838v6Ie6xo3IK/JrCSfMXLCPZzpLqCYb2ELF2sBc0z3GCU0/IOTYPJDLbovEfk32obElgJ2qT/LEj56VJjv6Odmir5C4sKEQgbXwAAA=="
+ },
+ "static/wp-content/uploads/2011/10/tumblr_ltgwa8Y4Ka1qekjngo1_5001.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRooAAABXRUJQVlA4IH4AAAAQBACdASoUABQAPzmSulivKiUjqAqp4CcJYwAALGg9cA4UMMJjG5+1AAD+wT/O9zs97C3rI9ZSIkabs/VY89RhnqKsKUmYCGe7NNAwyxnZejfxRcTVhkZC+bCWTXwGVRTN46PnHUaijN8Jo8BqrOjtFBAUQt9nsvYTcJVAAAA="
+ },
+ "static/wp-content/uploads/2011/10/tumblr_ltgywtGhCz1qekjngo1_500.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAABwBQCdASoUABQAPzmUwFmvKiajqAgB4CcJQBadZYPyUG8CJMxG9Dm1aS6GfrmbpDUAvNAAAPaZfQmLZ5CGGKNi/8zezIc2wMTSmYGMgcem+UokWMo/CN1oHuYrAQZtPI+g08fgAUNUM5u5ggdg6UUdUvU8SAyH9UfJV4SH+eqT326Wd4wYI4kKrTpZe+ytfWFhiOlTxxkAPBZNnTU66LT4sAOmAAAA"
+ },
+ "static/wp-content/uploads/2011/10/tumblr_ltmfltFSp91qekjngo1_500.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRpQAAABXRUJQVlA4IIgAAADQBACdASoUABQAPzmUwVmvKicjqAgB4CcJYgCqXBBcbszDhKVNnnuAxVFAKz+5sAD+E4yjRKNFagHvFusfVsYTwg0nqb7yz4rwUeeYxkpiwrqNJ/c6rfyqd4Qc6LZrl4LOp94HPmpYTAY0IvnARq1hoczI1dlqwWggeZYlAhS4wv+xnKPfpoAA"
+ },
+ "static/wp-content/uploads/2011/10/tumblr_ltq8eqTVOT1qekjngo1_50016.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAACwBACdASoUABQAPzmMv1evKSajqAqp4CcJQBUkx0AL2QQvAuiv/1zNmT0x59sAAP59srs7Bg1CGHJ/LkCiHCqM61vFggxLFDOdRbkD+RTD4gmF8s8pN57lPqqcwpMAw4AIOVpis1zAC2YtiaQ0uGLiatChYyis4C+SlAAA"
+ },
+ "static/wp-content/uploads/2011/10/tumblr_ltq983kENF1qekjngo1_5001.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRqAAAABXRUJQVlA4IJQAAABwBACdASoUABQAPzmCvFcvJ6WjsBgIAeAnCWYswAMKADNUdwkeKtzSXclcAADN8cMCPEmGcb9QgH0q6grH2DADZgSFU+vWC2CGdngF1/CKMUP0Sadb41szo2drBCXXTiYeFDGSrH1NpljvBeUmW3AtMWxFpxQC83lQSX9iS2K0A9DfukCiTedlA2gbyVMtKYcy4OAA"
+ },
+ "static/wp-content/uploads/2011/10/tumblr_ltq983kENF1qekjngo1_5006.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRqAAAABXRUJQVlA4IJQAAABwBACdASoUABQAPzmCvFcvJ6WjsBgIAeAnCWYswAMKADNUdwkeKtzSXclcAADN8cMCPEmGcb9QgH0q6grH2DADZgSFU+vWC2CGdngF1/CKMUP0Sadb41szo2drBCXXTiYeFDGSrH1NpljvBeUmW3AtMWxFpxQC83lQSX9iS2K0A9DfukCiTedlA2gbyVMtKYcy4OAA"
+ },
+ "static/wp-content/uploads/2011/10/tumblr_ltsgrvEsBK1qekjngo1_5002.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRqYAAABXRUJQVlA4IJoAAADwBACdASoUABQAPzmQu1gvKaWjqAqp4CcJbACxHxx+ABTUEV+g2RWEowy0lca29EAA/n1WRrmMP/c6gwvZ2IKrU19XT54HQSQqdbN9JalZ/FNmHmd+LBj/x4eEHmZU+tPtyzdZwdCOymgU5AEKm0B1iebx4oD0Acio9ssSTF2KU3Ir5zSlwphZeHc9xHbjTCfJTC3xEX6oAAAA"
+ },
+ "static/wp-content/uploads/2011/10/twisted_33.png": {
+  "w": 376,
+  "h": 435,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAACwBACdASoUABcAPzmMulYvKSWjqA1R4CcJbAAAIz+xTV0Cn2NjAZUObxhtHfNwAP7qksL8hoJjt/hge96wLys+qzlR8d6IGV4eFckSlu/7l0bIyQLm14qJea1XPXciKVu1oFDPLdqDdp3RplIwuuQyCVEj//bfApQgdp/itkzDjpvXyQAAAA=="
+ },
+ "static/wp-content/uploads/2011/11/11193169_gal7.jpg": {
+  "w": 300,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4IJgAAADQBQCdASoUABsAPzmOvFWvKiYjMBgIAeAnCWkAAC3YLODS5jh88jNX9gfgbp2kPXfsKKKSbzuAAP7i9c0MbMxk62HbvAKPKJEGVs/vk52rIJr0G88fm09YKUPrsgaNKy3gczEi5ORLfiGSIYtwk+BUB9veQ2D3v/DBbEXM+gkLBYXhRrzLvoFzHuUETRvskavGbM5w4AAAAA=="
+ },
+ "static/wp-content/uploads/2011/11/300px-Bicycle_Wheels1.jpg": {
+  "w": 300,
+  "h": 206,
+  "lqip": "data:image/webp;base64,UklGRooAAABXRUJQVlA4IH4AAAAwBACdASoUAA4APzmEuVOvKKWisAgB4CcJaQAD5XHo3rZc/LS+VxqD3AAA9qatw+pLXX1ICTx0E0cQHw9YzpEKIo66wFRlFdv9nONamsRTe7Gth2VlGQk6Z46u7Gt7Jtq49lUHp2G+A9xP/lkTxqvveYzOiykgmYzz7Y6BAAA="
+ },
+ "static/wp-content/uploads/2011/11/300px-Gradient_ascent_(surface).png": {
+  "w": 300,
+  "h": 246,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAAAQBACdASoUABAAPzmGuVOvKSWisAgB4CcJaADE2B6XQ5K/Rs18JAx6cAD+50CqP3eOYmDKsPlhLdSQF37a0s5lEQlwgneygzeS3NuSBaGiAAAA"
+ },
+ "static/wp-content/uploads/2011/11/300px-Neural_network_example.svg_14.png": {
+  "w": 300,
+  "h": 400
+ },
+ "static/wp-content/uploads/2011/11/300px-NFAexample.svg_1.png": {
+  "w": 300,
+  "h": 276
+ },
+ "static/wp-content/uploads/2011/11/300px-SculptureMQ23.jpg": {
+  "w": 300,
+  "h": 217,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYgC+SBerB3Fg2EgXjIAA/lXj4FEw+XgItC/fuFWSH0qWD9KV9pBB65uiAMXeLVCuu9+cyCDmlsRN+Z5EoChDwx6HRI54LlMAAA=="
+ },
+ "static/wp-content/uploads/2011/11/433029904_27dd44a95a_m3.jpg": {
+  "w": 240,
+  "h": 183,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAACwBACdASoUAA8APzmGuVOvKSWisAgB4CcJYgDCn8GJ/gPQptf1u+GET57sDyUYAP5qFifjxQ2EjuPfBmAVwpEr5mv+sg+nhDT6xKhF6fFRALiezp36Z/74geSnet5E8kZVNOmE3+1fgAAA"
+ },
+ "static/wp-content/uploads/2011/11/4610893696_7d66700b4d_m1.jpg": {
+  "w": 240,
+  "h": 160,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAADQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJbACdMoACXAjvKOALj4AA/rmtY+/6jOOvm9CzhXU7yZJuZ9ttR8BeEbs6vKXHaVvMV3XoExORvNBGDFpel6a/MaqrAIuAAAA="
+ },
+ "static/wp-content/uploads/2011/11/4631606862_5148f506ef_m3.jpg": {
+  "w": 240,
+  "h": 131,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAABQAwCdASoUAAsAPzmGulOvKSWisAgB4CcJaQAAWlf4k+ZoYAD+0yCbqNx6FR8V+sNYHkZPJETK04fFLKy3FSzGAAA="
+ },
+ "static/wp-content/uploads/2011/11/6325383183_2d45304650_m3.jpg": {
+  "w": 240,
+  "h": 160,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAACQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJQBdgAuE8B07yIA3cAP6oteeAvRRk3saS/2CKtFR+9INcGIhcWICw4zyLfvL7D/qtCSNddsSIjUDh57Eh4rcunV+Izii6ofI0kQAA"
+ },
+ "static/wp-content/uploads/2011/11/6325384369_10e9b3492f_m5.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwC7ABkpKGQblJZZrSEAAP6BHnI9J4b8No/Nj+qI8fn4OVTchdZxA5PxmIj84J/ND8n9Pl6BZABBMFwlWxGeYBlfLaAA"
+ },
+ "static/wp-content/uploads/2011/11/6334305146_57b7976719_m1.jpg": {
+  "w": 240,
+  "h": 160,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAACQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJQBibAeU+lCtxBgYAAM1tXC0t1COjCyybGAEFrBabsGrzrBimP8L3DyAz0tu6t+0lkVQz02ITn+OreX3nLHtEmLfjYeqprMwpfG1d6Ij6/AobimAsgAAA"
+ },
+ "static/wp-content/uploads/2011/11/Conlie_postcard.jpg": {
+  "w": 250,
+  "h": 169,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAABQBACdASoUAA4APzmGuVOvKSWisAgB4CcJZQCsACBi+M1Omk+ZNnVjX1QAAP7D8LBXq+ZxxhTxJOFdHRZvEXrlLU1RL8n5CiKDkKpJowGpIP/OzWsvnNDERHQDNzAJ9FywgAAA"
+ },
+ "static/wp-content/uploads/2011/11/photo-1-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAADQAwCdASoUAA8APzmGuVQvKSWjMAgB4CcJQBOgBDpHTAJmHZ+AbgAA/tQa3CiB4+hPaWNsR0S1pfdyy58h7f+PexL9uRNxpcHbIAAA"
+ },
+ "static/wp-content/uploads/2011/11/photo-1.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2011/11/photo-2.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2011/11/photo.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2011/11/Planet_of_youth2.jpg": {
+  "w": 200,
+  "h": 295,
+  "lqip": "data:image/webp;base64,UklGRo4AAABXRUJQVlA4IIIAAAAwBACdASoUAB0APzmIuVOvKSWisAgB4CcJQAAIIIRHlg0QcVr3y9Sn+QAA/oZF2ttJ/rtirC0B2WKQEUd42u10molTFL9B8XL+YNcznYszearChNonNio+xMQGqCjc8Tr9+h28LIJ7fXDjQuqlK0xPR1zaDvQizNAYYvMn8RvceQAA"
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-04-at-12.32.27-PM.png": {
+  "w": 924,
+  "h": 366,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAABwAwCdASoUAAgAPzmGulOvKKWisAgB4CcJZwAAXKOynJGYMAAA/t+2jTRAYocDQkXXaUUAAAA="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-10-at-12.22.54-PM-1024x698.png": {
+  "w": 1024,
+  "h": 698
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-10-at-12.23.46-PM-240x300.png": {
+  "w": 240,
+  "h": 300
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-10-at-12.23.46-PM.png": {
+  "w": 604,
+  "h": 752,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAACQBACdASoUABkAPzmKuVQvKaWjMAgB4CcJaADDrCFTNR0CWd5sXO7eebBMsuAA/ucfftf0v3ZezDx4Y+MvxffGrJh+LJ9YQMk4T9COJk3jPIUdzzd/ht9BzQG87/6oo0y62RTBktMXz7ycGZS+MSZp78g8SAAA"
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-10-at-12.24.26-PM-1024x567.png": {
+  "w": 1024,
+  "h": 567
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-16-at-1.07.26-AM.png": {
+  "w": 761,
+  "h": 277,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAAAwAwCdASoUAAcAPzmGuVOvKSWisAgB4CcJaQAAW+jCveUAAP7eznV4He3AAAAA"
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-16-at-1.08.17-AM.png": {
+  "w": 928,
+  "h": 431,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAAAQAwCdASoUAAkAPzmGu1QvKSYjMAgB4CcJaQAAetHZlkAA/u3DEf0mHHX5sbmUlcwJdEyzPYHgAA=="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-21-at-7.07.47-PM.png": {
+  "w": 1027,
+  "h": 376,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAACwAgCdASoUAAcAPzmGuVQvKSWjMAgB4CcJaQAAeyAA/u6enr/KLo2Kqgk1JB8drgCAAA=="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-21-at-7.14.29-PM.png": {
+  "w": 969,
+  "h": 452,
+  "lqip": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4IDwAAABwAwCdASoUAAkAPzmIuVOvKSWisAgB4CcJZwAAXfT1qGuRWAAA/ucJ0Vn9UxBsn4MyHJrmu642byOMAAA="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-21-at-7.15.38-PM.png": {
+  "w": 979,
+  "h": 446,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAABwAwCdASoUAAkAPzmGuVOvKSWisAgB4CcJaQAAV/7BTJS1BAAA/udAimbzJEvelAA+cNW7xEAAAA=="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-21-at-7.30.53-PM-300x206.png": {
+  "w": 300,
+  "h": 206
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-21-at-7.34.35-PM.png": {
+  "w": 645,
+  "h": 117,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAAAQAwCdASoUAAQAPzmEuVOvKKWisAgB4CcJZwAAW+9rgaAA/tPbU9aVgHY8fTbHUx2sZxv0vQAAAA=="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-23-at-10.10.32-PM.png": {
+  "w": 570,
+  "h": 686,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACQAwCdASoUABgAPzmMulavKSWjqA1R4CcJZQDNhAHLpgwI0lKAAP5W8OZYAcqrp8nPH5qbnqlSkLcx4G0297nl1RvrwlAb/jvxefZGEZjwAA=="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-24-at-2.27.06-PM.png": {
+  "w": 816,
+  "h": 367,
+  "lqip": "data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAABwAwCdASoUAAkAPzmGvFQvKSYjMAgB4CcJZQDE2B4+lEadLAAA/sbA0ec4xb9PKN0E11ExErPazHtCPAxskgwVTZ7yUwa32igAAA=="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-24-at-2.27.18-PM.png": {
+  "w": 812,
+  "h": 159,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACwAgCdASoUAAQAPzmGulQvKSWjMAgB4CcJaQAAeyAA/u7wy1LGFRo/SnvMAAAA"
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-28-at-11.16.05-AM.png": {
+  "w": 562,
+  "h": 547,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAADwAgCdASoUABMAPzmMulYvKSyjqA1R4CcJZwAAPGS78AD+ufcH8T0NMPF5htphR88VDDyAAAA="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-30-at-8.16.59-PM.png": {
+  "w": 936,
+  "h": 743,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAABQAwCdASoUABAAPzmIulQvKSWjMAgB4CcJZwDA3B6U+6JwAAD3vvkZNfok7zEWmNvhGPB8/oZCNm5alLe6iI96AAA="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-30-at-8.18.15-PM-300x246.png": {
+  "w": 300,
+  "h": 246
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-30-at-8.18.15-PM.png": {
+  "w": 915,
+  "h": 751,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAABQAwCdASoUABAAPzmGulQvKSWjMAgB4CcJZwC+SB4/HdxkAAD81Xs7K1hhoQ0YBrl8xaUnMfoc8AHuheCi/AQAAAA="
+ },
+ "static/wp-content/uploads/2011/11/Screen-Shot-2011-11-30-at-8.20.14-PM.png": {
+  "w": 938,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAABwAwCdASoUABAAPzmGulQvKSWjMAgB4CcJZwC7AB87CxQwrAAA/NV6QWhfENbNE5p2QgGTA/AHO7t6QD0IQt6loAA="
+ },
+ "static/wp-content/uploads/2011/11/tumblr_lummi415Um1qekjngo1_50010.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAAAQBQCdASoUABQAPzmCvFOvKCaisBgMAeAnCWYAqPQM8aIMemQZqw5PNGe/z6cIRwDAAP5r3MkGAI49AfMCNjq552CBLQ1HXz/zh0dbVdq+CDPIgbBexKsajVS9gMAK801RWXrpu87XzeHefmblp/fd41aiRFXgAAA="
+ },
+ "static/wp-content/uploads/2011/11/tumblr_lun8x9awgB1qekjngo1_5003.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRq4AAABXRUJQVlA4IKIAAADQBACdASoUABQAPzmUwlmvKicjqAgB4CcJQBibAZHoIHW+h/PBcZpI9pt6IUd0QAD+0z7RXSohfnOO9CkUIuUQ28HQ3qON3sW+/voQyud3zjYad2bXFyt1f9AySkuZ76XL7jn5Q03h+4nOlgED7L4GJ73pUOvCFrKJzM4yZ/ynsWAsdgtKHHefKVkMSA4ex5UX7y+YTkYhAgDDMiWI+1T8AAA="
+ },
+ "static/wp-content/uploads/2011/11/Youth_in_revolt2.jpg": {
+  "w": 200,
+  "h": 296,
+  "lqip": "data:image/webp;base64,UklGRtwAAABXRUJQVlA4INAAAACQBQCdASoUAB4APzmIuVOvKSWisAgB4CcJbACdM2cul+qCT52HH4I15+D0LTcMnil2/UUzWAD8tGFjBsOttfmDDD8Na9rMUUs3DX+fTLkL8pS9F9VpT31aboLJjCfQZapmlbMBFaezKE+izTZL8GCC+pZJJ5WbmrEls/zX0rgg4FFalb8gwDk6OAT0Q4T9iwnC9ii1PX3GFewBpRw0cRvj0ZpAruiVeKV9/UHSAYRR1mN9gToQmAeUsrs+U/PDRutmAwBJtnCbUbgeswUQAAAA"
+ },
+ "static/wp-content/uploads/2011/12/14310922_6ed3badf9e_m1.jpg": {
+  "w": 240,
+  "h": 178,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZgC22f/gPGGRO4qPmgAA/sjlImAMg9/nLpdU2RtYrAi5dk1fpn3PnNtKrjPKwHdNkOUNcQ5l1UVYIfft4/qGzr8oeT3A+f7AAA=="
+ },
+ "static/wp-content/uploads/2011/12/300px-5th_Floor_Lecture_Hall3.jpg": {
+  "w": 300,
+  "h": 196,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAADwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJbACdABoNXrJmeVkMnakAAPt95vyarIi6Me4x0Ab/orOJvBz1vHPswfD0bfQY9/m0WS7drWCZqehsK/MD0jx/jvXhin6YVMnIKtiVtJ0aNzdYqWOpICcuzSAAAA=="
+ },
+ "static/wp-content/uploads/2011/12/300px-AlanTuring-Bletchley3.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAAAQBACdASoUAA4APzmGuVOvKSWisAgB4CcJZQCw7CHZ3MHyixiFwSJsgAD+5A6isrgD2Sb+ksP8e0kEBf1dAkYjycQwKFa7wh6wEwVpik1YQMzyFoR+zqKcU/nVP6cgAAA="
+ },
+ "static/wp-content/uploads/2011/12/300px-Chimp_Brain_in_a_jar8.jpg": {
+  "w": 300,
+  "h": 378,
+  "lqip": "data:image/webp;base64,UklGRrQAAABXRUJQVlA4IKgAAAAQBQCdASoUABkAPzmQulgvKaUjqAqp4CcJQBj8gfcOlwj2TB48oFhQlBCczSzjNz4AAP6mfe+zIuxuKtRDQDVaRxqFv8HOYp/Z+UZJ+WkQCMX0XCQqaZ36BpBeBi05RHEt2TJVGQ32jgA9LBLZAgxy4v+VAVt9hCMIEF7BxY/KnUANjX77FZhTMKuI6PQWZri9DQOHPiVSTYBa4t8f3P3dCGBzabxYAAA="
+ },
+ "static/wp-content/uploads/2011/12/300px-Haskell-Logo.svg_4.png": {
+  "w": 300,
+  "h": 212
+ },
+ "static/wp-content/uploads/2011/12/300px-Innsbrucklarge5.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAABwAwCdASoUAA4APzmEuVOvKKWisAgB4CcJQAAKNuvlPSWQYWQA/Zyb4z+F+3UNOLZSXjScSRLXUs+4+H4WE69MfeAc4BHRM0QAAA=="
+ },
+ "static/wp-content/uploads/2011/12/300px-Longboarding4.jpg": {
+  "w": 300,
+  "h": 185,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAACwAwCdASoUAAwAPzmGulQvKSWjMAgB4CcJYwC7ACbHv+Z9cM3sAADInEEwAx4ckANTHaEKQvXiiw10eWLrddNBK9hZZOeLyr7fct9rIVWop6KgAAA="
+ },
+ "static/wp-content/uploads/2011/12/300px-Louis_CK_Kuwait_crop3.jpg": {
+  "w": 300,
+  "h": 367,
+  "lqip": "data:image/webp;base64,UklGRp4AAABXRUJQVlA4IJIAAACwBACdASoUABgAPzmUwFmvKiajqAgB4CcJZAB+vwCxf4yoRW9oeLuLf2QJdyYAAP5x3sxt8VggephZGNEG+EtIsuEFtx+zUBLCQieHOmAlMa5vi2WWi2odwoLe9TCGhwOd8tJAJatoFi+6BK1GsCFBEqYFS/2CcKg3NRBDeF5qKXAW1ybLuQLZ2OIoCm5yRoAAAA=="
+ },
+ "static/wp-content/uploads/2011/12/300px-Nice_air-raid_siren2.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwDImCP/tDohECzfTqAAzh2hbyR8v9QPyhGR7Otp79BhMy2UaqeW1QxWGphmC/ZTV/H46AUEZe9PYJcQxMWtVCDoUZ7fD1/aV3zwE5q+AA=="
+ },
+ "static/wp-content/uploads/2011/12/300px-Prim_clockwork4.jpg": {
+  "w": 300,
+  "h": 235,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAACwAwCdASoUABAAPzmEuVOvKKWisAgB4CcJQBWGUABRoNLjA3fgAAD+U8ngQytw0CS9IrD3M7CTROfBFLBCIu4TL/zqEWV+QWL5VjXGffad533wLmI99gKuvUlNHfAA"
+ },
+ "static/wp-content/uploads/2011/12/300px-Programming_language_textbooks1.jpg": {
+  "w": 300,
+  "h": 204,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAABwBACdASoUAA4APzmIulQvKSWjMAgB4CcJbAC7MoGvgAPpry3EZ730S/rgAADMBOuUr0VTBgAFXMh6TZZkLFecrQf2pbTaA8lwNco7q3aYtsuOo1zBnsuytzVKszVxR05n2j4M1gQRFMwRm6inDarACa8rRHeCX8Jj83AA"
+ },
+ "static/wp-content/uploads/2011/12/300px-Series_of_build_lights4.jpg": {
+  "w": 300,
+  "h": 402,
+  "lqip": "data:image/webp;base64,UklGRowAAABXRUJQVlA4IIAAAADwBACdASoUABsAPzmMwVcvKSejqAqp4CcJZADMhwAA9uBJPlOSSh+S8YAJ4IbsRgAA/RKYdqRhuSR/+hBVGr47ceV5D77Vm+bBpUxpgJ4MxZCzv0sYZMkv4lE9WB2lPORk4lEo3aVYBwQ8bei/pO+069MoOLMQhvbgBq91y/CAAA=="
+ },
+ "static/wp-content/uploads/2011/12/300px-William_Fettes_Douglas_-_The_Alchemist1.jpg": {
+  "w": 300,
+  "h": 387,
+  "lqip": "data:image/webp;base64,UklGRpoAAABXRUJQVlA4II4AAADQBACdASoUABoAPzmOwVcvKaejqAqp4CcJZAC1GyGBqGowJQfKA/A5BTPDtMwIlAD+uPQ/VFZuLl1t3DTNxo2YOs264tfTvUME38aJdsBRe81u0PJJLeUsD7apa4M4eShhvEBLHubFpEnbFWFqp/b1Sfdx0vTbK6gA8alw1oD6ZXnBr7f7WD8h2XmppgAA"
+ },
+ "static/wp-content/uploads/2011/12/313552641a8b11e19896123138142014_73.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRqYAAABXRUJQVlA4IJoAAABQBQCdASoUABQAPzmQvFgvKaWjqAqp4CcJZgCpFUwBg7BeDVS/bybiEOj7/T58MnMTRAAA/qWWGIjjFVnNjsDlnhhEVplr3rdgYqOf4/DUGuhzH/vSY6YGax1hqIR+GrVyIuqbvww8Hp8HoD7L6trZGxVpiX6hR7AwkQr1WhtU3n6a2W3SOS+yH07I9WMG8d4qFgJcAXyGAAAA"
+ },
+ "static/wp-content/uploads/2011/12/411755916_76a0807797_m1.jpg": {
+  "w": 180,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRpgAAABXRUJQVlA4IIwAAACwBACdASoUABsAPzmGuVOvKSWisAgB4CcJaACdMoR+AAsonWWmg3zlpXUZXQiAAOjofsnITQAugcez0n5unMH15TiqXLkUbwdb1fmH3d2FK+HUdfO+gR+IO33K5Ow2CkNvAb7RkQ8tja9+S4xjRWb2vvq9d8J7kCRXKv5z4jiCdJDHXzz4X2scqCtEAA=="
+ },
+ "static/wp-content/uploads/2011/12/41e1bb62226e11e19896123138142014_75.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRroAAABXRUJQVlA4IK4AAACwBACdASoUABQAPzmUwFmvKiajqAgB4CcJaABWZgPPKiLGsxPOYKJ0zcK6tfdgAP7PJiDtdq4hsLs2U++xldWXBxlxrwOi0v5nDAMbT8CGiibxSd2geQFzq6Ij8DPJVytjOWPW1tKxOBQf+wUm7lOi6MDunEUS+PZmjbcdJjKB4VHJuCybh4E9lISo0gv34upr0GBe1zuTWPSHzDmTOqyiWCMO79jXo1D5nXQAAAA="
+ },
+ "static/wp-content/uploads/2011/12/4371042134_c7431995c4_m6.jpg": {
+  "w": 240,
+  "h": 143,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAAAwBACdASoUAAsAPzmGuVOvKSWisAgB4CcJYgCdMoADDt8o2j5rePqH8QAA/uNBWhy+qUwE+JXQQw3UmrivhrVosFdVoLAPqsnKL/WoAAA="
+ },
+ "static/wp-content/uploads/2011/12/4800996644_c46de09b40_m1.jpg": {
+  "w": 240,
+  "h": 128,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAADwAgCdASoUAAsAPzmGuVOvKSWisAgB4CcJaQAAetEDAAD+7pD9R55SyXW4AAAA"
+ },
+ "static/wp-content/uploads/2011/12/5044996221_e7c0225126_m1.jpg": {
+  "w": 163,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4IJgAAAAwBQCdASoUAB4APzmOvlevKaYjqAqp4CcJZQDHMA/YBVnn/6k4mBEN2lTAXkfzHyJeAAD+Y8nZ27PPZs3/uh8VJcg9jTdNtAEeRKHiHrvf0RY94aLvAuuOsFEeHII6Dx1A3zjBOacVawTmKf7wZ1CW3aVQP6apmTI9IggDXiJAiOJIGtcpb2fk8TzPzhidUN9G4qrMAAAAAA=="
+ },
+ "static/wp-content/uploads/2011/12/5479666205_e74e748bf0_m3.jpg": {
+  "w": 232,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAAAQBACdASoUABUAPzmSvlmvKaYjqAgB4CcJZgAAKc/qPJUm9O6MWzZ1AAD+un2F1emzf1rKHQfWAziE+fC53+2UHBQ0HcycsPaIwmkrJ9UrlHqiCMvWUQJtWZT1mgDy84xCvzZNqnekfFFIAAA="
+ },
+ "static/wp-content/uploads/2011/12/65197v5-max-250x2503.jpg": {
+  "w": 250,
+  "h": 216,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAAAwBACdASoUABEAPzmKu1YvKSWjsBgIAeAnCWgAxNgRAUEBS07IjVSKzJgA/tYZTQNCNBe1/IeqqD9tjlb1DiRwliwZXRmBe9KoT1YPRUl+0ZdwMqMvGLvKrsQAuNHAAAA="
+ },
+ "static/wp-content/uploads/2011/12/85783f08227e11e1abb01231381b65e3_75.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRtIAAABXRUJQVlA4IMYAAABwBQCdASoUABQAPzmUwFmvKaajqAgB4CcJbACw7ywTmgUqG+0sf+jwcrw40hTitKSDEr8wAP3cdSHOJiML5TMuB9zMh7WW5EPeb/5PLcgcPjq6SVfQnIOsyxPU3hu07aCR8RGDHCJOSp1KSVPzKHb0nZdBxX3tGKCpsDfSLlpXMQeKEq2+sh885sFmLx4KQAU+cwvTaDnJFHaJojELriqb4LtM5aK6nYUMmDCFu0unvwx+OjhLpmmcNQmAmFQr8xI5c1T+AAA="
+ },
+ "static/wp-content/uploads/2011/12/9cc4d6860ef011e1a87612313804ec91_73.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRp4AAABXRUJQVlA4IJIAAACQBQCdASoUABQAPzmGvFavKCYjsBgIAeAnCWYAxPjugYHEph0965KAmjHeTdTchcpbASCLuAD+ru/p2bxdeQI/4IcrL64w41QXVHE7WZ9yZBxm8gpPvavRpvVfgvdI+ZdTCQMLo2FHI3zmsxvDLJYC060RVcfQmvkJm+7Iow8C3cVXPTfkVADBaNYGy4y0uIsAAA=="
+ },
+ "static/wp-content/uploads/2011/12/ai-car-lol7.jpg": {
+  "w": 463,
+  "h": 315,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAACwAwCdASoUAA4APzmEuVOvKKWisAgB4CcJYwAAOTd+/k7rijVEAAD+sBqPQIa20GkZpCjntiyIBcC2MlEsVO9wbsCSzE+7m5UDqPPQNNao9Kw518LjvMAm++yrRQLOcD4OMe5B56Pe1jy0AAA="
+ },
+ "static/wp-content/uploads/2011/12/ballmer_peak1.png": {
+  "w": 652,
+  "h": 592,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAADQAwCdASoUABIAPzmSv1mvKaajqAgB4CcJaWeeABtpH8/YxJ4DxIAA/u320MTQAw3hg6Y2Gu9gp2qnenpHxWIvOZFTkiJK8JruHVkAAAA="
+ },
+ "static/wp-content/uploads/2011/12/f2ea2d400a7211e1a87612313804ec91_72.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAADQBACdASoUABQAPzmIvVSvKKajKA1R4CcJYgC+SBI5SBAWiQgtdcQsGxXWKaQvwAD2K72IRMYj5dQEFQDnu9FdNyYOLXIRN+TkB14prsxrJ/9fnAxDkWBAWGNQ8vosjQAk+GznkQ/ss1iM4cJC4CQQ3gksQYAA"
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-05-at-12.34.59-PM.png": {
+  "w": 560,
+  "h": 236,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAACQAwCdASoUAAgAPzmGuVOvKSWisAgB4CcJaQAAW+9rPn/ia4gAAP7EVV3ERzmGhxuutI9yK/gBAAAA"
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-09-at-5.07.33-PM.png": {
+  "w": 1218,
+  "h": 596,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAABwBACdASoUAAoAPzmGulOvKKWisAgB4CcJZACdMoR4GCk5j2M70zjpXvV2AAD9JNzhul7IoFR2OhGYw9ZEz+U2OQnA16UZby4KACGnHqk8dtZDBzspQvkVsW5GWPamKYgm2uAvcv/5LJVrgIEhb8yAAAA="
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-09-at-5.20.07-PM.png": {
+  "w": 557,
+  "h": 724,
+  "lqip": "data:image/webp;base64,UklGRpAAAABXRUJQVlA4IIQAAAAQBQCdASoUABoAPzmMvVevKSYjqAqp4CcJQBdgAifnMdjIz+vxFrxOgRpnWLb4EJgAAP7apHAN9hZ7ibPaiKnPVoljhj1JFX9XjwfkWwDZBMRdy7mKMjymqcDSje4cpahtbJyMZaCQtfdIpmFsvQio2b4ODVHhX4cqhRKVcKi+EW7+QAA="
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-09-at-5.20.22-PM.png": {
+  "w": 1005,
+  "h": 747,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJaACdIHAB4O36LvjEQ8yXAADu12utqqtp3NRzPUdjsp0G/o++DmpR3YYKAU2bszCT1/kupMi+Gi8WuSqqCBKHzTMPzUnY+S9GsSwfdj904veAAAA="
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-16-at-1.53.20-PM-300x175.png": {
+  "w": 300,
+  "h": 175
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-20-at-4.50.42-PM.png": {
+  "w": 1019,
+  "h": 427,
+  "lqip": "data:image/webp;base64,UklGRjwAAABXRUJQVlA4IDAAAADwAgCdASoUAAgAPzmGulOvKSWisAgB4CcJaQAAetEDAAD+7p6ev8rkG6M8a+vAAAA="
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-20-at-4.53.01-PM.png": {
+  "w": 444,
+  "h": 176,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAABQAwCdASoUAAgAPzmEuVOvKKWisAgB4CcJZwAAW+j49KsmQAD+sjeqA0v/P2Hz+wir0BSvg+EAAA=="
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-20-at-4.55.25-PM.png": {
+  "w": 953,
+  "h": 445,
+  "lqip": "data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAACQAwCdASoUAAkAPzmGulOvKSWisAgB4CcJZwAAUV/jHfJ7XaAAAP7nO3gsfJrEnSxAvL+6ybAKQhns39tVS3kps1A2N+8e5kAAAA=="
+ },
+ "static/wp-content/uploads/2011/12/Screen-Shot-2011-12-20-at-5.03.15-PM-300x171.png": {
+  "w": 300,
+  "h": 171
+ },
+ "static/wp-content/uploads/2011/12/Selection_046-1024x345.png": {
+  "w": 1024,
+  "h": 345
+ },
+ "static/wp-content/uploads/2011/12/Weighted_A_star_with_eps_58.gif": {
+  "w": 210,
+  "h": 210
+ },
+ "static/wp-content/uploads/2012/01/11259239_fe6b60af02_m5.jpg": {
+  "w": 213,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAADQBACdASoUABcAPzmQvFgvKaWjqAqp4CcJZACdMswBqoj7CjF51CuTrTrC1p4gAAD9NVcfZ0clV7sslid80CUPPq+F5Zc0YSycp55WFH1UMy3Gnj2OjuaqP4QSeoHDvBR6QwI3GaNxMgQkAyPvoAAA"
+ },
+ "static/wp-content/uploads/2012/01/300px-1891_New_Orleans_Italian_lynching5.jpg": {
+  "w": 300,
+  "h": 421,
+  "lqip": "data:image/webp;base64,UklGRpwAAABXRUJQVlA4IJAAAAAQBQCdASoUABwAPzmMvFYvKSYjsBgIAeAnCWkAACEwe8BYRIsDJPkLW0d2UyGA0R0AAM4cGGAE68o1sa9D9X2ULkagWvKjOcy1m4EQcih+tzfE4wbfp6tVym+X4QixsSaBKTfhpmAm7FTUSr+NErqGkYMJD2yjTUJXuHu7OFA4HCxqV6870sD1LS4c1s9aAAA="
+ },
+ "static/wp-content/uploads/2012/01/300px-5-cube_scrambled2.png": {
+  "w": 300,
+  "h": 293
+ },
+ "static/wp-content/uploads/2012/01/300px-CollatzFractal4.png": {
+  "w": 300,
+  "h": 180
+ },
+ "static/wp-content/uploads/2012/01/300px-Kernel-panic6.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAACwAwCdASoUAA4APzmEuVOvKKWisAgB4CcJYwAAUfI+L5SfeEJwAAD+qIHR7f8yZxiKTsh1kkSer9RZ36gROt5eVXr75rsq0X0T/L83jO2WQHwN20lbu0ca8Wt69ABsHRPC2Jrg6o1Ua3DhCXgAAA=="
+ },
+ "static/wp-content/uploads/2012/01/300px-Lobbying_Data3.png": {
+  "w": 300,
+  "h": 184
+ },
+ "static/wp-content/uploads/2012/01/300px-Medieval_dentistry3.jpg": {
+  "w": 300,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAACQBACdASoUABQAPzmUwVmvKicjqAgB4CcJZgC7AA8/dMu94KjCyl9KS/QLI9wA+EB8NVgBGEwvUv/4AjnFfff0y93ERvVJucfMZErEsvPYcGkibZFF9l1iHjs3rsXAsfYIpuVAD3113LcrrRffqY320gZt/2z+vZ2nstOzjJDXKvflPjP80eFkAAA="
+ },
+ "static/wp-content/uploads/2012/01/300px-Safety6.jpg": {
+  "w": 300,
+  "h": 450,
+  "lqip": "data:image/webp;base64,UklGRsAAAABXRUJQVlA4ILQAAACQBACdASoUAB4APzmOv1evKaajqAqp4CcJQBkTAe0r9NE39FQhamYwPD0L5AAA/lpekAKPzgaBqzJJhLOr7cprwUUkbjvpacHWkyfWx455o4KKT6XytE7hDf8R+5kucL3zGq1jn01IB99gwl72+OT03k8Fs2R2Ziu+cJs9gOvwT4PIE6QzGSuU/tBHO4a1q6uzSSpZC+DoIc84AkGh9BOiwCSJwsa5UtSAGPBm1j1a1djlAAA="
+ },
+ "static/wp-content/uploads/2012/01/300px-Sheep1.jpg": {
+  "w": 300,
+  "h": 233,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAAAQBACdASoUABAAPzmGuVOvKSWisAgB4CcJZgC7ACPpcPfY3IpKTxvmkAD+xJjWKMEvpkFi1fUp2/ssK9YPmaDMuatSlHFJlaUEHWYJ5hVW+9ArRwN905x0QHPgAA=="
+ },
+ "static/wp-content/uploads/2012/01/300px-StateLibQld_1_1003481.jpg": {
+  "w": 300,
+  "h": 215,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAADwAwCdASoUAA4APzmEuVOvKKWisAgB4CcJaQAAXiAgO8D4h5ECtytgAP4ZGmjLjw6S27IlsR1SSMRxhPau08NdhBj/k8q77x596KEWvZLeAIExPReMnWBfFKL3jQIUQ+Q7Y/cXpEK55YxAAAA="
+ },
+ "static/wp-content/uploads/2012/01/300px-The_Hunt_of_the_Unicorn_Tapestry_71.jpg": {
+  "w": 300,
+  "h": 445,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAADQBACdASoUAB4APzmEuFOvKKUisAgB4CcJZQDJTB6SD8kV+ncpSHameRsPLyf24AD+y/fAlIoeg4UKc2Q/qG2GVdXYxSchsefKE+/BcafR0TjZ6HBu1bsbJnQdhFKlf9Avr5816AmGAuNvrQm9sP/Svs0DoP2hQAA="
+ },
+ "static/wp-content/uploads/2012/01/300px-University_of_Tokyo_Admittance_Celebrations_2011-03-10.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZwAIEAJ/UPqGlN6ng5wgAP5yAVr+EPHSI8dDeKh1v6oSt3NRj6NGtiMSYO+AbyJxkk+nH1YpUIvyX8y1l9aKoKeC8TIZLxJR41jpRD9YxhLt+UKAthgPAAA="
+ },
+ "static/wp-content/uploads/2012/01/300px-Van_Halen_-_Jump_2007-11-102.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJaADA3BMeQGZJcAf5HAAA/j30oI6dLnAKh2kPZkFsCsLuq5K9O0xxSW6lwS0kHYQbqG41xq6HDuMZrXNTKF06jh0tuFfZ3aUTus+mtTBlWkh9sFJQQAAA"
+ },
+ "static/wp-content/uploads/2012/01/300px-WillJamesMob4.gif": {
+  "w": 300,
+  "h": 190
+ },
+ "static/wp-content/uploads/2012/01/300px-Yushima_tenmangu_ema1.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwDA3BwyFeSHwiGTT+FAAP7Nhjus4bG4yyWaqRrolCNADjUB9peqgRTGRC5g2mCbgcfHEcfBLcvVMOojFBRDGJMtp4kwAAA="
+ },
+ "static/wp-content/uploads/2012/01/4956218218_903039baa1_m2.jpg": {
+  "w": 180,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAAAwBACdASoUABsAPzmQvlgvKaYjqAqp4CcJQBdmcdg1roDBq7r4lPRfDWAAy06alpd0CBnhjDZF0YZtJux1i/tJK1UxC8nz1t0cRSJfdWUqvtU1cv1FRHfNCcumhrbV4AAAAA=="
+ },
+ "static/wp-content/uploads/2012/01/4972036859_feeca3b936_m8.jpg": {
+  "w": 192,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRtwAAABXRUJQVlA4INAAAADwBACdASoUABkAPzmUwFmvKaajqAgB4CcJQBhmu4APOFyWI/UPXcBzGr7m6zxlQoAA/mtMNtKEaMUpCbYF6i0a87NS2nNAC5GUKElO9GCdnXm2edb6FYTkSKcHWXq8LBKm8QVDpL6dGoY5YBDggExkluYsuDKKBbS4bvkI0ENQ61E5L5odcnohKtcQLvH4oIYr7axFsVGQUbKIF7Sp9DSRHumIlv2tyRU7Yll1LDeVhLK06XQL2O/uwsEUTef5+SBf/am7YuvoeFrAi7mKy4AA"
+ },
+ "static/wp-content/uploads/2012/01/5638371774_324ec18c31_m4.jpg": {
+  "w": 240,
+  "h": 179,
+  "lqip": "data:image/webp;base64,UklGRowAAABXRUJQVlA4IIAAAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJYwAIEAKC6PgjT8PA4KiTHgAA/uTtLFL2OElOkiQ7+Z4mZjWQjUZiezvvAnwvAA3OppFXN+YfenbQdYqtL7O+tprvwutGRd2bCJaH5P3AsjtqDhxjPOoilQ6EdzG3kUpjE/Zxx0AAAA=="
+ },
+ "static/wp-content/uploads/2012/01/5764ba26406311e180c9123138016265_74.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRpQAAABXRUJQVlA4IIgAAABwBQCdASoUABQAPzmSwFmvKaajqAgB4CcJbACdMtCEIBTUDlwoM+eSU94Gg+ZTwNYiMe1gAP7i+vEZb/CSoCnbMFKT97hNRGWo9mmsWEUCZK+nQ+XsB0RmZtqMqbBy2uPESLxuGL9VnljaTi4MEYVWAMbItLgnk+KPcPHHxgbvshHSmK2YQAAA"
+ },
+ "static/wp-content/uploads/2012/01/5AVGVH1VUM5DXZFON5TXZN4EWVHI1EK5D5AMTZIUON1SQBHW1.jpg": {
+  "w": 537,
+  "h": 720,
+  "lqip": "data:image/webp;base64,UklGRqwAAABXRUJQVlA4IKAAAACQBQCdASoUABsAPzmMvFYvKSYjsBgIAeAnCWQAuwWwALnUPYkBPWAKW9zepGhri1cLWm7HgAD+nsQE3flIZubPpNS0tTjZqn9yOYDM+fnrzD+++25wLQ5QVPe9kkd2zT6aZhrrgUaPC/Ph2A6aV4a3h/9Xqe3XJwFcipZtIgQKqb2q4rm6PZpQroYlKyTJTMw90icjcOZg0VKgRe31WAAA"
+ },
+ "static/wp-content/uploads/2012/01/606491964bf311e1abb01231381b65e3_710.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4IJ4AAADwBACdASoUABQAPzmUwFmvKiajqAgB4CcJYwDA3BEzZSOaTstV6LE28mL+t2TCI9AA/gXMyNiVA4J3pf53aPWdBBmER9qM++9HT3j4Oc1GSzocXtSfKEflUmlxHEZjTebkujuKQ+01uxvVv/vZ8XbVQoXbrwMloDg8giOZeNl6fd5kSUdZEu1mrOSYih0rnuBup8fqLvaoWIDgxQAAAA=="
+ },
+ "static/wp-content/uploads/2012/01/Baden-Powell_family_(1917).jpg": {
+  "w": 271,
+  "h": 296,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAACQBACdASoUABYAPzmUwFmvKiajqAgB4CcJaQAAJ9hw9UWosGS/ch4IYKmbR1AA12tWE39/xLb7VXZxj9rvDD0CibbwBG9GSx3lDxfr5hQ3DdaW5nVkjf76raiM3mdV2tjl1oKtW6J89MVBorAhL3Nb7+QX0OnnLDEfcAAA"
+ },
+ "static/wp-content/uploads/2012/01/collatz_conjecture3.png": {
+  "w": 311,
+  "h": 452,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAADQBACdASoUAB0APzmQv1evKaajqAqp4CcJaQAAMX/ib45Hwea8nlHonR57Mel3GAD+1tapC8R4p2KXh5W1gK191dg3VInfNchtzz8CbPit8a0qr012l6dq9Ww9d5hPcLdjAR1woVngxC7XJgC8L/AagsZAAAAA"
+ },
+ "static/wp-content/uploads/2012/01/IMG_01763.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/01/Maldives-Island_1111082i1.jpg": {
+  "w": 620,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAADwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJZgCdMoACLDa77py+7ruwAMqSHtFhLclw2w3yoN5GB1okECchL1sXf/oXZZZSbRIMbriz8tmWzsnRJ/lmoqYkOwAAAA=="
+ },
+ "static/wp-content/uploads/2012/01/Passion_cover3.jpg": {
+  "w": 220,
+  "h": 333,
+  "lqip": "data:image/webp;base64,UklGRrQAAABXRUJQVlA4IKgAAACQBQCdASoUAB4APzmGvFavKCYjsBgIAeAnCUAXyYEAEa+OPv1zzUN92ncl4SV/V1Od7n/YAAD+6O5jhn3qNxaAz3CbYz4suWGkDOZ2+sdY4F8WQwEiuFU09x/gldrlYeXJRqVjvjbuqhXFWx6Gj4sdk5GLK0+ytNGZXqYg6Gg6IzQgNSf1hJeyIwizsW0G6s281IpMPxFQr3R/76j7+HgQuAM2nUV5gAA="
+ },
+ "static/wp-content/uploads/2012/01/savelife22.png": {
+  "w": 384,
+  "h": 458,
+  "lqip": "data:image/webp;base64,UklGRs4AAABXRUJQVlA4IMIAAAAQBQCdASoUABgAPzmOuVavKaUjqA1R4CcJYgAAF6LjLihC0+76qvXba02ZHj8SCURAAP7fhbpDsZ3D/3Vr0TzrXgUb6IBhDKq9CbWhVU1V/ENq4ICuN6Tq8ZVhcZF4zhLJYhNTC4MHOzG/XdSuvcLxGCtPYcqvbXhvqnHnS1Qo2vOMG6rlSCuOCjld5G2ACwoqRBPgQxwUbdQWmxS70MQxyb45yAjo7mw+aFmpcjEp+tTO8gqzBc5sUeu1u5QuO4AAAA=="
+ },
+ "static/wp-content/uploads/2012/01/Screen-Shot-2012-01-03-at-4.25.36-PM-300x214.png": {
+  "w": 300,
+  "h": 214
+ },
+ "static/wp-content/uploads/2012/01/Screen-Shot-2012-01-03-at-4.25.36-PM.png": {
+  "w": 1222,
+  "h": 872,
+  "lqip": "data:image/webp;base64,UklGRlAAAABXRUJQVlA4IEQAAACwAwCdASoUAA4APzmGulQvKSWjMAgB4CcJZwDCgCHhTFNfDdAxAAD9/Qnlg0fRtGELOgyWsYrx+gcGUg2PHf6AJg0AAA=="
+ },
+ "static/wp-content/uploads/2012/01/Screen-Shot-2012-01-31-at-11.18.29-AM.png": {
+  "w": 979,
+  "h": 424,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAABwAwCdASoUAAkAPzmGuVOvKSWisAgB4CcJZQAAXAjTCGf07YAA/pFq3LkCbqx36KjG3Pl0LOCGt3srlASeh7plp5LP4QhZbID/nWS8AAA="
+ },
+ "static/wp-content/uploads/2012/01/Selection_047.png": {
+  "w": 824,
+  "h": 431,
+  "lqip": "data:image/webp;base64,UklGRjYAAABXRUJQVlA4ICoAAACwAgCdASoUAAoAPzmGulOvKSWisAgB4CcJaQAAeyAA/u6bTxjlNpcgAAA="
+ },
+ "static/wp-content/uploads/2012/02/1074032723_aJTtC-M.jpeg": {
+  "w": 600,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRooAAABXRUJQVlA4IH4AAAAQBACdASoUAA0APzmEuVOvKKWisAgB4CcJbAC7AYwS4TpkjJ93/h6qAADMi6QoA2aC9PtxOa7Isidzw3Cw7wU94ZCnW/7nFufYqhOYyx5qhTlyLw+NJjAtJ+cV0oKZDj5/HtRC/Tlj573QgMaDQzd0KauuJ5A9K/6q4OkgAAA="
+ },
+ "static/wp-content/uploads/2012/02/11fdb5d3700d4fbd96b168de05ed2c21_77.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRrQAAABXRUJQVlA4IKgAAACwBACdASoUABQAPzmUwVmvKicjqAgB4CcJYwDKB3gAR5eqm6H7LZmltBNYfQeAAMoCYuld1CPgTgU1zgvuXnmN4XcbNQ+N42xBeA3I8gswWSOAT1HoXVJhuiJpZiq1ANOmiVjRoQSRq94BDp4NEz2B8ShMZx43ZZFZOg5twKBXklLZa+TwVKqcaUZohCSxCWlPepGfwcKVK3je0rzy/UF+FoAEIHgAAAA="
+ },
+ "static/wp-content/uploads/2012/02/1329559us-teslas-valvular-conduit-figure25.gif": {
+  "w": 500,
+  "h": 355
+ },
+ "static/wp-content/uploads/2012/02/2342478549_6175f46fd8_m13.jpg": {
+  "w": 240,
+  "h": 185,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQBdgBDtFTy4JhiFsAAD+rsDfuvh1YQghp9JUld0S9ivqYjDQw3DMOF10ruZEzFSISbRJs9niuJ+FgwAAAA=="
+ },
+ "static/wp-content/uploads/2012/02/2346288052_44b7311cf7.jpg": {
+  "w": 450,
+  "h": 302,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAADwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJQBOmUABpIeNI4tKw379AAP7oxHrF0Co1hF58pfl65R8mgCZlQldM7AaMl5lc6xN3/s4Rb2lrOJn6PfFBl49W8ZRdW8uUwbUzF7CqimBQ9YsAAAA="
+ },
+ "static/wp-content/uploads/2012/02/2921731384_72ed2e98da_m5.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAABwBACdASoUAA8APzmEuVOvKKWisAgB4CcJaACdACPPuh+cW+y1rtrzAlIaAADdx+beQ56fStIlwxqpee9RB1bWd+72kCxT/4d6I8084AThUMk5bvO4TzZQi1sRpcM76xbVWPoSjPQoqWfheM9YglTEThIjLhHWhH/JvQifpfshLAW2zHjxxBTZAAA="
+ },
+ "static/wp-content/uploads/2012/02/300px-Army_Camp-sml.jpg": {
+  "w": 300,
+  "h": 221,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZQAAW7WL7m1El8QkAAD+sHqBewQ0J3BFOJsSKvYmtxEA8gG07r8TTvaMapfqtOXmlDycqBMDqp5JfqsqmAAA"
+ },
+ "static/wp-content/uploads/2012/02/300px-DC_firefighter2.jpg": {
+  "w": 300,
+  "h": 336,
+  "lqip": "data:image/webp;base64,UklGRrYAAABXRUJQVlA4IKoAAAAwBQCdASoUABcAPzmUwFmvKaajqAgB4CcJZwAIGuF/vXwYnQJEYK1HswlG1IAczWwcAAD+gZ8J5G4ocgDzj/YlDc1lT71AR11dPUN/ieKUuOhvRkfVu1mndc1ToGQD9HRdQ9hgo44zmCNB2O97CgfDwjdI1tibGkZmby//qq+39/4QjFACYhx4ycfogY428ZphkRXqqDLtuZbtny9NOo9TiMq0Zf2/oNAAAA=="
+ },
+ "static/wp-content/uploads/2012/02/300px-Triplecrown_Video_Games.jpg": {
+  "w": 300,
+  "h": 120,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADwAwCdASoUAAgAPzmGulQvKSWjMAgB4CcJQBOmXnX/wHZ3dPCAcTeAAP7WGSiI6uOWCEsOnPi5UZ5Q9jJ3ojY2zs6wtZck1TgmY8GEVEM4dRGkK6Tv45Kv45oRZocU3dngAA=="
+ },
+ "static/wp-content/uploads/2012/02/400px-Machine-thermoacoustique8.png": {
+  "w": 400,
+  "h": 215
+ },
+ "static/wp-content/uploads/2012/02/4296232936_fb73460a56_m12.jpg": {
+  "w": 240,
+  "h": 180,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJaQAAW9MozEWUmuiFBAAA/sBNl1o23xMemDdno6/kcsn6/pyyrEsT6j3rkKVVfE5DiQo7B6vG5yi+TvdpFfcAAAA="
+ },
+ "static/wp-content/uploads/2012/02/chef1.jpg": {
+  "w": 181,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRqYAAABXRUJQVlA4IJoAAAAQBQCdASoUACIAPzmItVQvKSSjKq354CcJaQAAPa7HeHKVaTgIMbhTHVmScEEk4tsAAP7qjSE9uWOPtPiY4JXno3C4HR4O7op1wzefO025Ehk1uMq2wglsNaPg+9xD5bN/w2zLiOl9W1cRljAkM27IKr41kU5AGStiAAEcsR4if5QEXLlh+WaW0/8JVMEP1Ybaps55ngAmnsAA"
+ },
+ "static/wp-content/uploads/2012/02/fallen-building.jpg": {
+  "w": 519,
+  "h": 351,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJZwAASble9OnOmmT8CFAA+oO27qF+7qYPWpDpECQBMuwuKVlRYD4weoYjDj+Ykm0oCbpgEfwqmPWnot/9LVL7qwHS3bt5MdUCxuvwPAA="
+ },
+ "static/wp-content/uploads/2012/02/Funnel_of_the_Mauretania3.jpg": {
+  "w": 231,
+  "h": 400,
+  "lqip": "data:image/webp;base64,UklGRr4AAABXRUJQVlA4ILIAAABwBgCdASoUACQAPzmYv1kvKyajqrgIAeAnCWkAAGBWBafw18EKDhVZsvMUbzL6bhM8DcbXs5C/P03+0OAA/sNXA+8TY0d2yVgy3gOSYx33ghD8dFfMf86TXPE1ZXqyCtjL6JiTGEC7RGe5sdqXZnQaDTlU3ygOEl/QKXkUMpwgDueVL0aqprvOd/AbIdnbItrjg4bq/Z/Zjs08XcM56K6apDGCCWY9BuVs8HnrbgGagAAA"
+ },
+ "static/wp-content/uploads/2012/02/IMGP2951_thumb1.jpeg": {
+  "w": 502,
+  "h": 378,
+  "lqip": "data:image/webp;base64,UklGRjwAAABXRUJQVlA4IDAAAABQAwCdASoUAA8APzmGulQ+qSWjMAgD0CcJaQAAetCb/g2fgAD+7q36j0zPnUAAAAA="
+ },
+ "static/wp-content/uploads/2012/02/kaput.gif": {
+  "w": 360,
+  "h": 329
+ },
+ "static/wp-content/uploads/2012/02/Muhammad-Ali-Wallpaper-300x225.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRowAAABXRUJQVlA4IIAAAABQBACdASoUAA8APzmGuVOvKSWisAgB4CcJZgCdMoADTtgvN3YdaLwYvwLgAP2dEMkBitSuAS3LO9ve4GDqgetfEvXpT5GeMmpBGmLr3K+rUuG2Gf7moOe0f7H5fXviSgCZM+F+hTfODk7yGD1+xU6+ZFR9umxG3eiKMN2xsFQAAA=="
+ },
+ "static/wp-content/uploads/2012/02/photo-1-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZQC7ABo8uOY4JBSdqMgA/ftUMcR4RhtWfcw1c9h7X8zJV3Xwca06G7E1E3sbmj4GRsPAbEqTsAAA"
+ },
+ "static/wp-content/uploads/2012/02/photo-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwCw7BSEYzTtO962G1wAzdiC5Bk0wQDJO6hIMlnLFI7Yld+kMp7PtMV25nqBvPClu4/ikpsHUOIClZe1GyNpIDk1jnj2AV8ALHJnwAA="
+ },
+ "static/wp-content/uploads/2012/02/photo-11-300x224.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAAAQBACdASoUAA8APzmGulOvKSWisAgB4CcJQBdgboAJfZYxK09cBoXXAADNc5TEXqkcPJVjk7B4jVzlz4z0GEl6SjzFtX/Fk7XIC8II48b104OW8wVrSWZYyQqxzYLeF+IeioRasy6AAA=="
+ },
+ "static/wp-content/uploads/2012/02/photo-12-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAAAQBACdASoUAA8APzmGuVOvKSWisAgB4CcJZwDKACHUhkHoG0iyAI54AAD+GePuGopF4pWZ9hyXuf/rmxqtkktl7R8gBl0+11o+2yg5Mh0w1XPvPgyzRb4xMolcQAAA"
+ },
+ "static/wp-content/uploads/2012/02/photo-13-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJagCdMoABhYKeogJFaL1zaKAA/nyNh9AdJMNhqfGsbfwL/069T6h36cdtJS0gbwYqPoVyAptoIuzppFAZl1gJS9QoxCIaQAA="
+ },
+ "static/wp-content/uploads/2012/02/photo-2-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQBdj+ABfGXlyaGpsYgAA/sVub9nXiRIKuyxjgjzwQ6n3+iHsUKpsTp95zYO1pyiL036zpQTLC5clAAA="
+ },
+ "static/wp-content/uploads/2012/02/photo-22-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRuoAAABXRUJQVlA4IN4AAACQBgCdASoUABsAPzmKu1YvKSYjsBgIAeAnCWwAnTlBVFLbCZABX6oRUYj7YVCHiO+ewDUVsP1q3QoURPCAAPuN0vVNEANmcYgb5+qGkVdaMZ6hRVN38PR+jDDv2y3L32vNGNhO27Z7hSCE01R5DqAZyiP5fuy9dkIzLfPNaxUpkMeqwVBF5zRIZ1ZI5IxigVJ+oCCLwya5um0IyVJzDgpx891GyNp52NmqhI4GcOdY0upAI45ovDYu8u91hF4EUIbmKXonKsL7HmNj+KYSSC1I4j/S7DEjidFJgcIAAAA="
+ },
+ "static/wp-content/uploads/2012/02/photo-31-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAACQBACdASoUABsAPzmQulUvKqWjMBgIAeAnCUAABB9ax7+lXoHVcoQhzA8WD2AA/lP0QNILAZP9eZKknQZFdOMv63/VtLMG2b3J5Phl+zF3OFhep/qMA/XLUPQ7HIxrGYCQeKcjkd5ttnX7Hc2iSdueWwGKnCePAAA="
+ },
+ "static/wp-content/uploads/2012/02/photo-4-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAACQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwAAO/+DMF5VS3oAAP7e51ymD59uI9C0ZwHkiReeDvI38f9tvc/AaKpgw6vMUMz1xxI2AMFuMAAA"
+ },
+ "static/wp-content/uploads/2012/02/photo-51-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRqYAAABXRUJQVlA4IJoAAAAQBQCdASoUABsAPzmGuVOvKSWisAgB4CcJYwDLLCHAIRSuSoQfBIg/IU19fo50zcAAAP7Fb89Lk0SlpW6DvU03ytLp0bfuMOe4f6Gua/1zlZmRGSa4TgqKHfFcfKMqjLGNazY0CyQUL24qRE1GJp1PkXkXgHHlgmCohZyTcznUwEdJZrALKasuEJ5tA62ge6DdO73Re0YS8AAA"
+ },
+ "static/wp-content/uploads/2012/02/photo-6-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAADwAwCdASoUAA8APzmGulQvKSWjMAgB4CcJQBOkCYhgW/QPYAltEv/wAP3c7e4o0mlslj4lb2TukN3zAQlY6PoG1S2TKroiXBntNTgwAAA="
+ },
+ "static/wp-content/uploads/2012/02/photo-8-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZwAAYXfiSgjBSm1x3MYAAP6mkIfWIB6SsgVeD+CdcEf6GHCW24LZ3KB7EuffazV6A5YFDri9TzNhcr0ZsM5/8K8J3qwUAAA="
+ },
+ "static/wp-content/uploads/2012/02/photo-91-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAABQBQCdASoUABsAPzmMulYvKSWjsBgIAeAnCWUAzOH/4B6QNgwxeidwgURvSDt+RQkgPAgA/ucfIOgDKFq23ttLC+f7kSKNqAmaubeNEZICppa5fZlomMlRjMBmE4KHT4MRh5i4/O9iiTHYcXzI2KzBRmRxFZiAAAA="
+ },
+ "static/wp-content/uploads/2012/02/photo1-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRp4AAABXRUJQVlA4IJIAAADQBACdASoUAA8APzmEuVOvKKWisAgB4CcJbACdMoRwFf/gLakC+WxHQmZ6sEuj2AD6AuKNPfL4W3INKTepjV1HQ+KVJDL8XrAWHw7TnLUnWo/rZtM2u0de5qRRR28vm+OFcKsARdxM8ClQJMMajUZMRjlB+peXmY1NegqYf3HGofkUV4N/wGir78l60jzU1gf4AA=="
+ },
+ "static/wp-content/uploads/2012/02/savelife223.png": {
+  "w": 384,
+  "h": 458,
+  "lqip": "data:image/webp;base64,UklGRs4AAABXRUJQVlA4IMIAAAAQBQCdASoUABgAPzmOuVavKaUjqA1R4CcJYgAAF6LjLihC0+76qvXba02ZHj8SCURAAP7fhbpDsZ3D/3Vr0TzrXgUb6IBhDKq9CbWhVU1V/ENq4ICuN6Tq8ZVhcZF4zhLJYhNTC4MHOzG/XdSuvcLxGCtPYcqvbXhvqnHnS1Qo2vOMG6rlSCuOCjld5G2ACwoqRBPgQxwUbdQWmxS70MQxyb45yAjo7mw+aFmpcjEp+tTO8gqzBc5sUeu1u5QuO4AAAA=="
+ },
+ "static/wp-content/uploads/2012/02/Screen-Shot-2012-02-07-at-4.47.27-PM.png": {
+  "w": 734,
+  "h": 687,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAACwBACdASoUABMAPzmSvlmvKaYjqAgB4CcJQBZwAiHF3Lxd7oN0WoVemNuEqxdAAPfK2gii4SqBDtXYf4BmG9CCQP/rfAS4YGg2kcGLH4dkwUSLZOnap+g9wXhyx/xEb/HenEWu02+tSZAH7iAAAA=="
+ },
+ "static/wp-content/uploads/2012/02/Screen-Shot-2012-02-18-at-3.39.28-PM.png": {
+  "w": 737,
+  "h": 693,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACQBACdASoUABMAPzmMulYvKSWjqA1R4CcJYwDH5BEaBoZGcpHeeOnKt9q5hsAA/IoyEo9xLA9y3q/sjRFQJfHxW5mCHgVcZvzbJCGZw3G1ON5mXhaRPq3bgOrnqeVircqqNhKQAAA="
+ },
+ "static/wp-content/uploads/2012/02/Selection_050.png": {
+  "w": 791,
+  "h": 429,
+  "lqip": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4IDwAAABQAwCdASoUAAsAPzmQvlWvKqajMAgB4CcJZwAAUeNHa9F0AADc5PpM4cFaOlNoRe4coinckvD8miFAAAA="
+ },
+ "static/wp-content/uploads/2012/02/Selection_051.png": {
+  "w": 764,
+  "h": 462,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACwAgCdASoUAAwAPzmGulOvKKWisAgB4CcJaQAAeyAA/umsPTjf0Zy+zzz/AAAA"
+ },
+ "static/wp-content/uploads/2012/02/Selection_052.png": {
+  "w": 759,
+  "h": 291,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAADwAgCdASoUAAgAPzmKulQvKaWjMAgB4CcJaQAAetDDQAD+6VKp0agUGa0dcDiGhCAAAA=="
+ },
+ "static/wp-content/uploads/2012/02/Selection_053-300x174.png": {
+  "w": 300,
+  "h": 174
+ },
+ "static/wp-content/uploads/2012/02/Selection_053.png": {
+  "w": 762,
+  "h": 443,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAABwAwCdASoUAAwAPzmGuVOvKSWisAgB4CcJZ1TAADdBQu74HAAA/uFvuSaOtkXXzCucXYXLRYajgAAA"
+ },
+ "static/wp-content/uploads/2012/02/sissons_brewer_199710.jpg": {
+  "w": 432,
+  "h": 308,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAAAwBACdASoUAA4APzmEuVOvKKWisAgB4CcJYgCw7CLs7Dy6yD3W5oqCHcAA/suFxvD60MsEJ3lzOdNXB+5P8l792jDS5Z6ziX5d15CcPz2Vf7TS5iGXIxA9NYHoznqkTrO2yC4AAAA="
+ },
+ "static/wp-content/uploads/2012/02/Tube_de_Ranque-Hilsch9.png": {
+  "w": 1165,
+  "h": 359,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAABQAwCdASoUAAYAPzmKu1SvKaYjMAgB4CcJQAAKVRlDxEacAAD+523VT580AuNNQQKGikpPBOe4iZUGK+d76BWKvvht6bqAAAA="
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzpj40CCuq1qekjngo1_5005.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRsYAAABXRUJQVlA4ILoAAABwBQCdASoUABQAPzmMulYvKSWjqA1R4CcJbACdMoR6eP31kBkHPwiELZG0BsG782nAX15QAP1v7kJX2tX+zfHKZOvp3qlo1FqmMReaAzIfqH9UIHBiPwL31AU9xBwTM1l8hc5nYOIQFJl+cusjbAW53c+zFt7+TQZxPcY7odRcnCBzAKqyHUS/7mVEgj2kF7PuWfqvnEIuD9PLd0PP1/LOv/UeldIdwcrYH57ayEtmSfVhTWItuI6FKAA="
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzpnlcFYDv1qekjngo1_5004.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRqwAAABXRUJQVlA4IKAAAACQBACdASoUABQAPzmQvVgvKaYjqAqp4CcJbAC7ABGle3NFBtMVah5mas+tMAAA/ktohv0YZAnEtzOgHVusTePp0QGycy0E9DEkoGAKzKNSjOFVyFUvlwmtnzZdRQkt3jr3ibO/kGN/4fRn9NzJwObWlcecbr6Cy2OcAtRNHKPyTXseK4XVPsf2cMmHobpi0fabC4mV9DfFH1tyXgjYAAAA"
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzpv4nKIQy1qekjngo1_5004.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRq4AAABXRUJQVlA4IKIAAAAwBQCdASoUABQAPzmUwFmvKiajqAgB4CcJaACxHuI8ICFvve9GRp8LofkIpQFoBB0wAAD+VbVLk9GeYFDa8bAr/vzsTfF6ellTLuEUUkw2Dm6afAtUnLqM7w+KRdrdAAaZPufPTHHf7U5kX66r6U3FiIF7jnKTq5M8NfCJ1OirqSwYlaj5Kuh8/Elt2hBOvy093PVq91OZRJiBbV4k70EAAAA="
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzqox0thrJ1qekjngo1_5004.jpg": {
+  "w": 500,
+  "h": 669,
+  "lqip": "data:image/webp;base64,UklGRr4AAABXRUJQVlA4ILIAAABQBQCdASoUABsAPzmQu1gvKaWjqAqp4CcJbACsOUFWAAlmGI2qDX+0UoFNcST39SeYtAAA/nNEIqK7gxZOd26RNx8Zsc73d0ucFaOdwF4gEJ5tQuSm+LHlRCf02l/9uTfcHkJjwBMMth3whTTk/pJRZdQ899zmUu58w9aGrHt+auZ4f/pMJhv9NqEAK54wRA1wiw3G7aEcHdsF7+9JkCrZiIeBeyBfmcbg0MD7PF37wAAA"
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzqwrcTn2l1qekjngo1_5004.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAACQBACdASoUABQAPzmSwFmvKaajqAgB4CcJagCzgBEa1a66APj6fUhLJv7JnmAA9rk1O1bJZgUU+JzXGvferiaeCef6oqWQhiuBhr1S2drkZx+tjohnMv8pWnrLkFjWHcdO0PXY/2zUMyq3itSM9piQ58RlS1R3KdDHFbTjNjf82M+0pz72CcMAAAA="
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzr07u1kEI1qekjngo1_5004.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRpgAAABXRUJQVlA4IIwAAADwBACdASoUABQAPzmQu1ivKaWjqAqp4CcJYgAALoMfBx0DlYrBhaREnhXiglzR2sAA/s8mIOuZGC7hM36A4jJ4rODJHlFPzznHay299Lo73y32MdEsjxIi6af3d657224ZjS2o6A4Kcn2tEuyRDSHA31n0lShf3VlirABE6iQvAzWEhGrO7zI4nKAAAA=="
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzr4m789651qekjngo1_5004.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRowAAABXRUJQVlA4IIAAAADQBACdASoUABQAPzmUwFmvKiajqAgB4CcJQBYj8dg1K1ohmi1+0qjf2pQY6bNhAAD+UqXs8Y8aQbrFwoyeP4tVYH/FFCUs/4t/POqVi1FNLy117zxi5Gc8HzIZVx2fbS4SbHmVshbPxfz+i2f666LDmyV9PJF5AGPTmQSOciAAAA=="
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzr80yr3Lq1qekjngo1_5004.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRpwAAABXRUJQVlA4IJAAAADQBACdASoUABQAPzmUwFmvKaajqAgB4CcJZgCdMyTBcB20Q4Pn11A/TmjJUsl3QAD8p0TNe4cuCh5SxTrZ4Ezr9CyewvR7vy1sQ0sSearsW7rrp7NEtqaWvyN3sl164C+Y+NaCIIft61rvonbaLRVSbF3lnzuA05vBf/HLOiBhBi49gIvA1BnaQ3dET8XwAAA="
+ },
+ "static/wp-content/uploads/2012/02/tumblr_lzud2o2A4V1qekjngo1_5003.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4IJgAAADwBACdASoUABQAPzmUwVmvKicjqAgB4CcJbACdMt16Nb+AU3oX6033A8C8UgAGh+AA/tGaMPjR2h40VzQ+/UfCTff0K7RSNzPYmJ4zck2NAlBdsCEJXlxb2BzPgfQav+RJdF9x+pO4UP9F6cDLxovRrjH8AynPD1E4bdhircY/aSJljv2FYS/wd/N8I6EVMdCa0l2fSwAAAA=="
+ },
+ "static/wp-content/uploads/2012/03/11968304_gal3.jpg": {
+  "w": 462,
+  "h": 260,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAADwAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJZwAAWnSBNNXPhX+xBmmAAP7ZLgx601zlDwLbAbu0T2YcXzSeE0q2pvZHQ1FiK7507I1iblwysbybCnex8hGlYAO3Z055U7VWwEAA"
+ },
+ "static/wp-content/uploads/2012/03/119923039_1333cbbd02_m1.jpg": {
+  "w": 180,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRtAAAABXRUJQVlA4IMQAAADQBACdASoUABsAPzmEvVavJ6YjsBgIAeAnCWwAnQAKVdIUxKBJ6s5Hh6xFsBb5QAD64+qdb37LZ/EfxasSpzOKm/j+wF9kjbp8uu8c7VgN2BRdesL9VbG1KckKoqB9+xdsydw1YLkyo1yEb66uAhtdfLAJ7vKULi9TlFaF/zrCvFP1NbKNMWAzQWdoERY78b4uk49EUXyeQ1viFHE5fjzH9ovvkgAGKz2vjrn1/Js8r6ZMiIuShrSWCJWnsqWUnA6YAAAA"
+ },
+ "static/wp-content/uploads/2012/03/2576981899_fef76fd366_m1.jpg": {
+  "w": 240,
+  "h": 182,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJbAC7ACBS+vpPKO1+8tOAAPXRZJ6nzTNtDeH/2rCr4OC1/iMh2iwWtoAuULPqm0/ewNvofValpx2X41+po23yj42bpXw2M4mtQPv4AAA="
+ },
+ "static/wp-content/uploads/2012/03/300px-Allison_T56_mobile_test_unit_MCAS_Futenma_19823.jpeg": {
+  "w": 300,
+  "h": 209,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAABQAwCdASoUAA4APzmGuVOvKSWisAgB4CcJaQAAJ3VjWpz3MAD+eARpvaeoQLfnSgOfOHQzkDfXJ2r5/r1OWOWKNbkDAG8VX/mgKBLjAAA="
+ },
+ "static/wp-content/uploads/2012/03/300px-Ginsberg-dylan2.jpg": {
+  "w": 300,
+  "h": 203,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAADwAwCdASoUAA4APzmEuVOvKKWisAgB4CcJZQAAPIJIJlK2SenvksxAAPDP9EXXZV1E09ZlI8nASiO+/f+vRubNcoTP05qNHK6lTDMS+xNYFkLNr0Jf2DwFJDqUXiMbbhfaR9whs/Ilr7XCldheDx+plMX7oAAA"
+ },
+ "static/wp-content/uploads/2012/03/300px-Oscar_Wilde_portrait_by_Napoleon_Sarony_-_albumen4.jpg": {
+  "w": 300,
+  "h": 499,
+  "lqip": "data:image/webp;base64,UklGRrYAAABXRUJQVlA4IKoAAADQBQCdASoUACIAPzmKv1ovKCakKrgIAeAnCUAACUcjzFS49+WxY11OVcroSQu9ui8FUN9b/P4AAIaDB2YSyoOezNssolWwx1/RK0W3iYxnDoP/g2SDNr9Wk0c3okQ7lEUSoBaivo0iGpjxUSAuV+c5YeCZ0+PiMjmlScIyZoVl5giHiVp43KpXsT1UlGQ+bVFGGJsgZUQ/rRnhdVNn0NrD/4bukicAoAAAAA=="
+ },
+ "static/wp-content/uploads/2012/03/300px-Slovenska_lipa_srebrnik_reverz1.jpg": {
+  "w": 300,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRpQAAABXRUJQVlA4IIgAAADQBACdASoUABQAPzmSv1mvKaajqAgB4CcJZwDM0A02NqT+dONxFnZc0UKzqC4GQAD+F9JUpGBwZ9AGUfVZvGFGOoJLWLDlN/kusziwVv1yVXQ/0YRMrUmFUP0hbOkikdmuc9svPcb085cAbGDv8PnHUGStAuMTq5kDaCknaKwQdUh7ZbPygQAA"
+ },
+ "static/wp-content/uploads/2012/03/300px-Teaching-8001.jpg": {
+  "w": 300,
+  "h": 200,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAAAQBACdASoUAA4APzmEuVOvKKWisAgB4CcJbACdMoABOgps7o3NKM7+AAD+ohKcSePF2HX0i8nFlXpRXNsI0ssa/m9DmZUL4oS9vXo13RcyraSlLnjf+vbL9iORRflTmF7p43BNI8csUXhBoKSPWUgSWM4I3LyQAAA="
+ },
+ "static/wp-content/uploads/2012/03/3188032449_1e8783552a_m5.jpg": {
+  "w": 159,
+  "h": 240,
+  "lqip": "data:image/webp;base64,UklGRpgAAABXRUJQVlA4IIwAAABQBQCdASoUAB8APzmKu1YvKSYjsBgIAeAnCWMAxoN4ACSMga7/aoMROXyzsPcVEN7mJrgA/r80lu61hkLyWnjfhdu7J8M8QQfZpNtOeZCbiAmlnmy30xqfdcI9kgLqda2w+Es86qhCiNLqtih/jBNsmdwwMitl9KOzz85zzFIqC9JTzfjFZVFrKCAAAA=="
+ },
+ "static/wp-content/uploads/2012/03/3a11daa46cf911e180c9123138016265_74.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAABQBQCdASoUABQAPzmSv1mvKaajqAgB4CcJZAC7IP8BCrkWr10El20eOKNSTIgJj3tiBwAA/nyc9GXMFLg3U6vl1oMzIm91DZz00q8Wtu1sm3opzsYehWBEiVPFH4VuBSjhpMoEYTIbR8FRBHlImsNoOoaHcaNsp17tE4PXPpXtCIpcmKQXfoUQdVPhjR3h7FV7XuMIUoLrEBARHIv8TQlScGIWGZAA"
+ },
+ "static/wp-content/uploads/2012/03/4325726291_7535aa8037-300x199.jpg": {
+  "w": 300,
+  "h": 199,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAABwAwCdASoUAA0APzmEuVOvKKWsMAgB4CcJZACdMoACD96qRwgAlv3UYctNGNZkyh7fxLMYVbm6ge9EX0nLxJqoO02yhR6iEAA="
+ },
+ "static/wp-content/uploads/2012/03/450px-Google_London_UK_-_phonebox.jpg": {
+  "w": 450,
+  "h": 600,
+  "lqip": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4IJgAAADwBACdASoUABsAPzmUwFmvKiajqAgB4CcJZACo9BG2Rb7O/4MputG6K6VNwOcenIgA/ShLOJj8iTo9KwxhdevWg9agOftH25nZW095L8hinAsar0FDL+F3SvH5NPQmei4s76u4k3k3PAwftoWA+jylisAQXOQ2Rwx4OKlATlUK4sd2O6htzrDKrr8ngGV68q4l0FGx4QAAAA=="
+ },
+ "static/wp-content/uploads/2012/03/800px-Google_London_UK_-_Victoria-300x225.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZgC06BjXmysROJMN9PAA/mDYK98m+9gFTd7xHxPvMmt8Af+OxJWN+Q2R12HdYfd/HAA4Kv+4lqRmtLSFtBSPV5ZB7QOLVAnrZgBVN8AOuZGhK1C2o8R03fna3nRxV1ksTdK+OOYqGF5XizqAAA=="
+ },
+ "static/wp-content/uploads/2012/03/800px-Google_London_UK.jpg": {
+  "w": 800,
+  "h": 600,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAACwAwCdASoUAA8APzmGulOvKSWisAgB4CcJQBYdgqbqwYuz3S5OQAD5s6eF9jr37duGG6H2tTb2NLbzpLoVOTZma4TaSVhWXF75HTQ+fYSF3wTYAAA="
+ },
+ "static/wp-content/uploads/2012/03/a_stats.png": {
+  "w": 955,
+  "h": 185,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAAAwAwCdASoUAAQAPzmEulOvKKWisAgB4CcJZwDImC0H2AQgAP7t9JUospSsYG3xQgAAAA=="
+ },
+ "static/wp-content/uploads/2012/03/bFby6rsfkX34IGZEQa9Xb5xDFnKp00DGWdhLzDw4gmw5.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRrQAAABXRUJQVlA4IKgAAAAQBQCdASoUABQAPzmOvFgvKaWjqAqp4CcJbACxDOf6zAONgepWkimIFgLBWvhwhSwAAP6DmkvQyHdH2I+Mgmc8o9ZtDvpw3b3gScdJHzZhL/Jxlwf20SaghfjKcnPHgyGqZYh0jLvRiZ84oGSwkR8QvyEvdqHLtzOlt/vv4ZI1C20CeI+nSmo92wvP11SS06baj1HAcU+cdzgGzLtqK97QXhexlP4AAAA="
+ },
+ "static/wp-content/uploads/2012/03/Book_of_Knowledge2.jpg": {
+  "w": 155,
+  "h": 220,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAABwBACdASoUAB0APzmMulYvKSWjqA1R4CcJQBhmgiG0Ar+1mv0pesa6Ka5GAAD8bDg3Oxb5T7Ek/207+Wc38hyPO1bH2Xdv1fIGalKWhccP24i1eeVEAnBlB0nXxUznP9stAuUvVzkJtVeENalSYX7BgAA="
+ },
+ "static/wp-content/uploads/2012/03/fa00e838704a11e18bb812313804a181_72.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRpwAAABXRUJQVlA4IJAAAAAQBQCdASoUABQAPzmUwVmvKicjqAgB4CcJZQDKABEd86yP9W+YQJOeIh8BCIUMpYYAAP7QbffX1OZpO9Az2L7tUaTYwTXXT+V4+UA4HGMOk04IsP0+6JaKTJMGUU/0Spg3ewwEMyzojv/S8oHiusAD7Kj/ElILhhNziIr1Zh+FDFphitt7AimOYmrvVcQAAAA="
+ },
+ "static/wp-content/uploads/2012/03/G2XU3IIWNOBNXBYGGLNXKAEFFSZFOVK4HEPG0WFYTMA2FHCB2.jpg": {
+  "w": 612,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRrwAAABXRUJQVlA4ILAAAADwBACdASoUABQAPzmQvVgvKaYjqAqp4CcJbAA1AAqBAjC1mrRv8Hxy4UcuILAYfmAA/nUwfVyTEWtygFxOANrH3LcXqRqlT3obArRPepa7ACwIeh+ijPWhjtGFHkfpw1B32KrKsnZ+Alv9PRk0fD9ucAtw98+N1d1hnzGwHgTuRyIgRqEuqdcWG7onV/HxTxXf/AbyOQUMw6LtdaDLNMlrELy9jj4oUxyVoGuUSwAAAA=="
+ },
+ "static/wp-content/uploads/2012/03/Jim_Morrison_19702.jpg": {
+  "w": 289,
+  "h": 300,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAAAQBQCdASoUABUAPzmUwVmvKicjqAgB4CcJaQAAKgJYmnWAwrKrgiO7fMcekXfVUZQAAP6wcUH3QIaw9Lc3xQX7994vq7Xv3lfUwSPV2orw2Lg+zSaP37407u+YDX9ddsCLDS+Gtn5MQIGllsbpA49S54g5aHBcvgiIUAAA"
+ },
+ "static/wp-content/uploads/2012/03/Marveldarktower3.jpg": {
+  "w": 300,
+  "h": 459,
+  "lqip": "data:image/webp;base64,UklGRtoAAABXRUJQVlA4IM4AAACwBQCdASoUAB8APzmGuFOvKSUisAgB4CcJbAC1GySunNAB3iizOSAANZjxJuFrxw+oLRl8fcAA/q8iAcjSccFEZAldHWPUP4SLVzNb4+7hYkrMeQBmJz8sbE2Ivx7TZhls3/datQa+NoUANNZck9T5qK3B/RMuYR68cPyeqtZRGJugvqO/YQAoR8PnfeAO6iqTzUcmqL8i54sgIjSlIQj9TfZ1ZPuM7Gv/dLHLST7TYrBeX2TNcVrvBa2owPcBcbHYLI6qaLPgXz5GpUFkAA=="
+ },
+ "static/wp-content/uploads/2012/03/metre.png": {
+  "w": 399,
+  "h": 174,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACwAgCdASoUAAkAPzmGuVOvKSWisAgB4CcJaQAAeyAA/u6ZrIXRbcDMNRx2MaAA"
+ },
+ "static/wp-content/uploads/2012/03/Notepad_plus_plus2.png": {
+  "w": 256,
+  "h": 256
+ },
+ "static/wp-content/uploads/2012/03/photo-1-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAAAQBACdASoUAA8APzmGulOvKSWisAgB4CcJZAC+SCKHHEXXqeywbm+b4AD+jolsKozNtNF1t937nzh1f34YwVLy5TWKhrE+0CzEgDh1aPqzWGNSnHrzCBarkCay1AAA"
+ },
+ "static/wp-content/uploads/2012/03/photo-2-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJaACdH8AB6l1/slh7JetYAHulMAe6cc79GecdEWz4X0OxEogGjIlJwatwU9g/IEE3+/+TXQueM0ifnG5fVpx6UsQsJdAB0pPbpYAA"
+ },
+ "static/wp-content/uploads/2012/03/photo-3-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQBWABCqZaDicJVyzbHAA/syeVTXEsABHoOXs2bOa4f3ys5yXpX8+N7Am6chbANERXwXfFQV4AwSNAvZHIQhem0xiEzd0bW3eqWYdce0ietAsDCKLSMVh8IMV3GcIMW868v+T6Hi6e3c/LUAAAA=="
+ },
+ "static/wp-content/uploads/2012/03/photo-4-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRrIAAABXRUJQVlA4IKYAAACQBQCdASoUABsAPzmKulWvKSWjKA1R4CcJYgCvDA9naR/0+cQOvgzojTXr/J8sD8MsLfj5RAD+ueUpUPfw2q5pjF3eXnGMKo45PefQ7qb2hfuMM3qFukg4bIjbegMVpmb65I4oq7Gz8S10r4yYwNY8P2JHgnwq6XqPsw8U8/ofHrpVtdsP3BbERqJy66sDlslf9jt7/oKvO/uKyf5MjQL8NEpyTHgA"
+ },
+ "static/wp-content/uploads/2012/03/photo-5-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRq4AAABXRUJQVlA4IKIAAAAwBQCdASoUABsAPzmOv1evKaajqAqp4CcJYwDDcA8VAWJk4ZiJrq5NiPjVlFo6SUmXAAD+gsoHYl8Ib7f6LcLN97kcii0+6Ad0Wlun+j6a2ETAM1EC+c0uYIQ250yLit0fHyPYXWStdWgBN17IpY0pfZ/gnGHBilYu+lERgQq5IC1E/H8kf1S54u7o+7vOgMlQ9ZFDP051HXsTL69gGsHAAAA="
+ },
+ "static/wp-content/uploads/2012/03/photo-6-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRp4AAABXRUJQVlA4IJIAAADwBACdASoUABsAPzmOwVcvKaejqAqp4CcJZQCw/f/gUHxS6yCsQnNN42zlP/gM3gAA/n5HbJNVFRN6G+LObMrhuOheG98hMzahcH4bsl3QFYVfH7ES1R6Q+HAF5QI88ESZiGZnd5LszM4wpKi9RNLtXolqdCLBEakaAgRi1pk7VYxG5VFnhvOvaP3Y6RwOCQAAAA=="
+ },
+ "static/wp-content/uploads/2012/03/photo-7-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRqwAAABXRUJQVlA4IKAAAACwBQCdASoUABsAPzmMvFYvKSYjsBgIAeAnCWMAtRtkBKCi5quMXGCHqR5H2GkkBtJCW9O7wAAA9nL1Ty1QdwSHS1+xEqXi3TLwDMOvYfDJzG9EPrhA0ZB5qABqyq1kFNJd6puPbCSuzB456PELK/VWkgZDahCLXY/SjBPbSTiX4H5ZHj/6lN/qgvsNBnSjo4sBYTHdj6u+njNPKls8AAAA"
+ },
+ "static/wp-content/uploads/2012/03/photo-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRpwAAABXRUJQVlA4IJAAAABQBACdASoUABsAPzmUwVmvKicjqAgB4CcJZQAALqPOHWjSwEtPjmuKqeoAAP0iHRlOoZ+3ao5qroEiMFSNOLMutC7GeNbEiaj8tZ/TpN5LHXNySJ6vJUhlLsBEUvLZtD0+uMk2DM6vhyEp0IXQNMXqdWz9VYJUZaCHJ7KmgzfIjGRtTugvQJok5zfLGQ9bgAA="
+ },
+ "static/wp-content/uploads/2012/03/photo-8-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRpgAAABXRUJQVlA4IIwAAAAwBQCdASoUABsAPzmIvVavKCajsBgIAeAnCWUAxzALztcYV+pJQIkGKEH0pc+qUQBSAAD+ud6YQPCNAE5gnT5zpossTThpQn5bExPFicOGUrSME+dw7wzNeuSLur1ow68j+TszcooHCQXCsfNFycFKI3v2gLhn6DQQITz65CGr3i1Vee3BZElOeGgAAA=="
+ },
+ "static/wp-content/uploads/2012/03/Screen-Shot-2012-03-23-at-11.57.31-AM.png": {
+  "w": 790,
+  "h": 209,
+  "lqip": "data:image/webp;base64,UklGRjwAAABXRUJQVlA4IDAAAAAQAwCdASoUAAUAPzmIuVQvKSWjMAgB4CcJaQAAetETHywA/uzlKRTMt3Lg0aUgAAA="
+ },
+ "static/wp-content/uploads/2012/03/Screen-Shot-2012-03-23-at-12.34.24-PM.png": {
+  "w": 506,
+  "h": 230,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAAAQAwCdASoUAAkAPzmGuVOvKSWisAgB4CcJaQAAex//hQAA/u323Y5/Z8RQxjgffu2QAAAA"
+ },
+ "static/wp-content/uploads/2012/03/tumblr_m05svnQFWA1qznd83o1_500.jpg": {
+  "w": 500,
+  "h": 616,
+  "lqip": "data:image/webp;base64,UklGRpgAAABXRUJQVlA4IIwAAADwBACdASoUABkAPzmUwFmvKiajqAgB4CcJZwAALrhpbhsLdwyujUj8GMaYkm2NAAAA/rLfzWJzvn2ZBUD8dd/dQrX+ScZXIugWt3qUaTfmVO+6YX96o8S2vt0xtkGoerhA9GTRo1oQArYUprbXMIaFv54OgxkA0JFGXtjDj4I8lFLfwiIlSBydZUDgAA=="
+ },
+ "static/wp-content/uploads/2012/03/turbo_pascal_7_scholl_pack_13_640966.png": {
+  "w": 670,
+  "h": 453,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACwBACdASoUAA4APzmGuVQvKSWjMAgB4CcJagCxG12Mg5/8B5okoXudfiYJUZyAAP14EkiAi8C6+cRM34410ftxaAepDpwJw1LGqoLf12n5IhO1qPf0DljmKAT+Cv4GQJJDMfAAAAA="
+ },
+ "static/wp-content/uploads/2012/03/turbo_pascal.png": {
+  "w": 640,
+  "h": 454,
+  "lqip": "data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAADQAwCdASoUAA4APzmEuVOvKKWisAgB4CcJZACw7CHfYfYtHkfYaOAA/rxkblWwVi7XMeZj9a+bN2G4ideU/bQsTdTMeOzR1+gAAA=="
+ },
+ "static/wp-content/uploads/2012/04/383380_347698125278305_146707288710724_862402_1645891238_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJYwDKACPsf29rW8XJ4AD+u6husecVnRRmlDvectrJr9TzYEdEYJxwgwRyCUW/ekXsl1pTdy9uAA=="
+ },
+ "static/wp-content/uploads/2012/04/522486_351608958220555_146707288710724_872006_151528080_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAAAwAwCdASoUAA0APzmEuVOvKKWisAgB4CcJZAAACJvCWxbsAP2bFAgLGKeQg5opXUw0tuWJoo2+nU3AkVPvPvp/T3EjC5MTfAcxqPcuyE33FXwiLrj4AA=="
+ },
+ "static/wp-content/uploads/2012/04/523376_351613951553389_146707288710724_872114_1267428967_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAAAwAwCdASoUAA0APzmEuVOvKKWisAgB4CcJYwAAP/T88qQAAP5xYN9f9p0kf5Hv7uWUdVgSoG5JC4Yf8bhFCHz5wYhjizwLkwF+fVxA4AA="
+ },
+ "static/wp-content/uploads/2012/04/532741_347692488612202_146707288710724_862300_619788079_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAABwAwCdASoUAA0APzmEuVOvKKWisAgB4CcJZQDCgA1rtX4arAAA/Vrb8CDdG3NZjl4bJVmzNnzkK/AQ/JzZidhaCcmzkiW6veE7ugAA"
+ },
+ "static/wp-content/uploads/2012/04/534032_347697751945009_146707288710724_862396_809260405_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAADQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJZQDG9CHc9JbrwB1b64AA/Rs4aulImCWzRYhTFOzbqRNWkaAVt9VFvE5CKVYAAAA="
+ },
+ "static/wp-content/uploads/2012/04/535752_347700888611362_146707288710724_862446_973054401_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAACwAwCdASoUAA0APzmGuVOvKKWisAgB4CcJZgCdACII7D3AqI+YzAD2JZmaYSr2hbAMgF11QDcs1GJVQElTJuV9etSsrksL9aY4t+/bkxqXtWcx5yE8yzOuMTi9ZSEOB8yPzPGT1iLOBqJaUAA="
+ },
+ "static/wp-content/uploads/2012/04/536436_351614011553383_146707288710724_872115_1191131204_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAABwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJQAAKj28T7Ts/wDgA+eyixRvNu6df5aIAk5MVmn9tAbdDUpG7GK05uMoSQQJjn1jeMGvWrh5AAA=="
+ },
+ "static/wp-content/uploads/2012/04/539879_351613898220061_146707288710724_872111_696417144_n1.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAACQAwCdASoUAA0APzmGulQvKSWjMAgB4CcJQBfnAlPnrnQfehIAAP5xxqWQvKy3S4AZ6Q5Zr9yy8BtlvAz++IKotXkkIu37zfmS7hQlbCRk5TjmSLJnwAAA"
+ },
+ "static/wp-content/uploads/2012/04/542112_351614551553329_146707288710724_872132_517478043_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAABQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJQBhQApZ3YA0bUADid6mzjVRz4CoUvqHDrOWLUhxeQqZjLo0dmtYdAR1FfbmNOMb1dRALDj9rZ/YYv5R4JpApl1nmWMETk29QAA=="
+ },
+ "static/wp-content/uploads/2012/04/544490_347698501944934_146707288710724_862407_1345953820_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJZQDImCIiw2my7dIgAP6DRJEHlIKLH4tDzD9JKK9/RjJozkAa/3/ZMnxQTGnLm2u+LSNvAAA="
+ },
+ "static/wp-content/uploads/2012/04/554413_351614118220039_146707288710724_872118_401969108_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACwAwCdASoUAA0APzmIuVOvKSWisAgB4CcJYwAAXJI8x0wfysWiQAD+nmFFyl5PFQzrU9tIYhB/ZggQDM+Kw+Qn01R1657AbC++GuKl2AAAAA=="
+ },
+ "static/wp-content/uploads/2012/04/555476_347699688611482_146707288710724_862427_1778477533_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAACQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJZQAASCOi+xp4hcYAAPtyQqNgX34td4A6gsFN6tD0hRFH+4uMxByiJ8qo/XDyisBAAA=="
+ },
+ "static/wp-content/uploads/2012/04/558527_351610218220429_146707288710724_872053_1299898577_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAACQAwCdASoUAA0APzmMu1SvKaYjMAgB4CcJZwAAXfTpmTlvrPAAAP7Ntwm4UBhOETdzJ5AuxX6A8Y9gF/X3y5kAAAA="
+ },
+ "static/wp-content/uploads/2012/04/563573_351609458220505_146707288710724_872024_2059221382_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAACQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJZQAAUpgk1f2Yd7yAAP6hP9SNn3mnQLjFawK1V7OeGfbyJzvHGGHhbHjaKbjsqqBKKyAA"
+ },
+ "static/wp-content/uploads/2012/04/576025_347695228611928_146707288710724_862355_1226691061_n.jpg": {
+  "w": 960,
+  "h": 639,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAADQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJYgCsAB6EOwdJK0qlVAwA9x7k8pWr5RRXPkYnOHQMEH6aEhgRKiKjj589GF8e6SD3+DtaugA="
+ },
+ "static/wp-content/uploads/2012/04/Screen-Shot-2012-04-11-at-11.27.47-PM.png": {
+  "w": 1157,
+  "h": 846,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAABwBACdASoUAA8APzmEuVOvKKWisAgB4CcJZwBTAHAAPpdlPlQSTGZiALS9gAD43+YvChdtGVGDPF5WDDr5I/pRASi1bWuWN/4bvjLvz9IxiRQVqpn5NMK+y1LcIsncLVCr0cxbclyoJtpTLK3PQ+2ILu+hsSwA"
+ },
+ "static/wp-content/uploads/2012/04/Screen-Shot-2012-04-11-at-11.28.06-PM.png": {
+  "w": 1153,
+  "h": 843,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQBkTBDrxk9Y2LjnZAyAA/eOQ44hBLyW/YPe86tg7jamH8DAuRRQmxJsM19YPc62aI4lnpwFXYF+CnmZ58gTHQuY7H3zkk2YiC853/3bMAA=="
+ },
+ "static/wp-content/uploads/2012/04/Screen-Shot-2012-04-13-at-10.43.12-PM.png": {
+  "w": 950,
+  "h": 190,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAAAwAwCdASoUAAQAPzmGulQvKSWjMAgB4CcJaQAAW+o/2uAAAP7TSnwCaZp44cuBxOl5awAA"
+ },
+ "static/wp-content/uploads/2012/04/Screen-Shot-2012-04-21-at-11.24.12-PM.png": {
+  "w": 1440,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRkoAAABXRUJQVlA4ID4AAAAwAwCdASoUAA0APzmIulOvKSWisAgB4CcJZwAAeldrakYAAP7uVrvE69UMfTgxjeM+xzwPTidUbyvAGpdYAA=="
+ },
+ "static/wp-content/uploads/2012/04/Screen-Shot-2012-04-22-at-1.13.55-AM.png": {
+  "w": 1440,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAACwAgCdASoUAA0APzmGuVQvKSWjMAgB4CcJZQAAeyAA/u6zosjUTjf2OjQV2m+LnTgAAA=="
+ },
+ "static/wp-content/uploads/2012/04/Screen-Shot-2012-04-22-at-12.31.41-AM.png": {
+  "w": 1440,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAAAQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJYwDE2C0HagAA/u2j44JHRUpE6afxxafVpb0CYAA="
+ },
+ "static/wp-content/uploads/2012/04/Screen-Shot-2012-04-22-at-12.59.00-AM.png": {
+  "w": 1440,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAABQBACdASoUAA0APzmKulQvKaWjMAgB4CcJZgC7IBF6ABYrMcvZW0oxa3kAAP76XeS8Yx1CUm6ex6u8KGlDikYJpQsbWUpRn4a2mW9H2RJLXIEx7rnpRbORY1T8yW6g7e69wAAA"
+ },
+ "static/wp-content/uploads/2012/05/author-reviewer-model.png": {
+  "w": 721,
+  "h": 377,
+  "lqip": "data:image/webp;base64,UklGRjYAAABXRUJQVlA4ICoAAACwAgCdASoUAAoAPzmEuVO+qKWoMAgD0CcJaQAAeyAA/u3/ZZt8zrEVQAA="
+ },
+ "static/wp-content/uploads/2012/05/fp1.png": {
+  "w": 768,
+  "h": 370,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAAAQBACdASoUAAoAPzmGuVOvKKWisAgB4CcJZACdMoADSQChtQecsst2kAD9skeJb5fSoQByVDhu6wAvMWVCjfdrVef53ASJzDGz6sYJlgE5vd01sGDHXrw7EZvLP6w58TsInB2nsYn1qsumU+NKaCMxBAF/YAAA"
+ },
+ "static/wp-content/uploads/2012/05/NLG-architectures.png": {
+  "w": 381,
+  "h": 344,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAABwBACdASoUABIAPzmOuFavKaUjqA1R4CcJaQAAKf1jiKbTjgJimBDiqVdrAAD+50DmrbA2TUvF2Z1XlnfNrjFdatgMpuBZodx19LWeJl8wVe1bslmRuaEl3//3e4hhS0L88qHKNsYI5idsNNAYAAAA"
+ },
+ "static/wp-content/uploads/2012/05/Screen-Shot-2012-05-02-at-3.42.28-PM.png": {
+  "w": 1440,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAAAQBACdASoUAA0APzmIulQvKSWjMAgB4CcJZwDLLCHfHWaYoNXiWA4rQAD947xGFYUli4zPrN14hxp5P6CNwzo8PsZym1a4sLu2X6NAS64OEIEfhkAAAA=="
+ },
+ "static/wp-content/uploads/2012/05/Screen-Shot-2012-05-04-at-1.04.49-PM.png": {
+  "w": 850,
+  "h": 440,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAADwAwCdASoUAAoAPzmEuVOvKKWisAgB4CcJQBdgA9I9UnJRgljM8zrAAP6yEzlNmatMLGaASoYsgShAjEcrbOPj2WCsB3a8Ov4wHEimjQWN/R9BQ6c/oVaZzAgpxLfECm3m/YXQmp+RY0AAAAA="
+ },
+ "static/wp-content/uploads/2012/05/Summer_Glau_as_River_Tam_in_Serenity_Wallpaper__yvt2-300x225.jpg": {
+  "w": 300,
+  "h": 225,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAACQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZwAAW488opOIF2ngAP7Y7rpd00GbG+56fMMhpUmSeH7uWMDqu02Aj6BW0HAAAAA="
+ },
+ "static/wp-content/uploads/2012/05/three-reiter-pipeline-architecture.png": {
+  "w": 567,
+  "h": 121,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAAAwAwCdASoUAAQAPzmGulQvKSWjMAgB4CcJaQAAetv98FAAAP7tOmqYy3ZyAAAA"
+ },
+ "static/wp-content/uploads/2012/05/waterfall-of-data.jpg": {
+  "w": 500,
+  "h": 333,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAACwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJZgCdABdfzrblBlRkgAD+n7tWdDpR2Pe1YMTkt9CU86msM417+OyPBLQfxVXYII0MBBldWzuCl4b2Sne0mqYyaY69yQaZQUoyKMVd5nVUAA=="
+ },
+ "static/wp-content/uploads/2012/06/4sq-explore-topics.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/4sq-explore.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/4sq-explore2.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/4sq-home-screen.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/4sq-profile.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/4sq-user-tips.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/4sq-venue-tips.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/4sq-venue.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/cubismjs-shiny-timeseries.png": {
+  "w": 959,
+  "h": 314,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAAAwAwCdASoUAAcAPzmEulOvKKWisAgB4CcJQBadBH/up2rQAP6Riwr5t5/2NkKOd/+st2+NePMH9t7M26V+9MA5eMREaZd4AAA="
+ },
+ "static/wp-content/uploads/2012/06/dianhong-buds-1024x682.jpg": {
+  "w": 1024,
+  "h": 682,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAADQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJZgCdMoRwAAPLEErYQEAA/tC5UsvEjKpHzPYdZI9Pi4x0ErlHeUAHfkmnKO+m24w4vlBsn8ORN/z3ckjJoAR0Maf99xSvhrFleBI3Hj5skbMJAgHIAyBB0jZreYAA"
+ },
+ "static/wp-content/uploads/2012/06/gongfu-tea-1024x682.jpg": {
+  "w": 1024,
+  "h": 682,
+  "lqip": "data:image/webp;base64,UklGRpAAAABXRUJQVlA4IIQAAABQBACdASoUAA0APzmEuVOvKKWisAgB4CcJaACdMoKP/bf4CcuP90YjEVQwAP7c1PQ+E3msjnpbiic2qTDZRnjfvC6JbNY5EsZn3pWZ+kK9bRVsal+9r5VYRAxwCAZ2O1C3xa8A/yi43nMBc62pxqiS45BpG89htEiyemtS+P2WGPfXgAA="
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-done-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJbACdMoADFVyZjGmNl3QA/CS52zVTtggDQFUPzIq5K2+sciUuw4KYuZjQxorSaIy0EnWl7k2bjxFsQzJA2Rz/kua15pj/qXso4EEBEIjXGfVDHyeJLotRI3zJAwMTD1XORUAA"
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step0-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAABQBACdASoUAA8APzmEuVOvKKWisAgB4CcJZgCdMoADKuUqImgRNCuOu5gAAODU1Em3Z2Agz/rL8UqJbLM1V5ACBZEu9Y6ZAgSGGLFC4qfWrjJbzQyJZ0WqAN/3/aCk3M/jWqdbgen9JG2AfB1XJu4iQSJFlSNq4AA="
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step1-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZgCdMoAAvhJLtMSWIADL4GZHP0k18UWJW5HK+EtUtHrHlgrks1N2M0I03nM3bcyPslCu5I0+wE3UI+5P3Oq/OGOgAA=="
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step2-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAABQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJbACdAAy/U/5SsAD4JjcsdLhb5QQ/pUYdft/gA0bmyHEkmXytiHYf+/GK4O9kzVxBHUuL9bGjwLK4CZN9W2A3U4wPzHmT7azJwbFkAAA="
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step3-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAABwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZACdAAg4wGonmUAAzgbbUwLLP5ORtG3NnWSgAt/obhmpsZaB3M8rUsDQBm9kp2GsTc0lLtm2V6FQolHpdGWVG0UCqqkB6AE8nPC+/dB7zUJKfwAAAA=="
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step4-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJbACdACE4n7TxAN72W1pgAN40N7qpD3FAO7iHrjcEbr8CjyJUcdetNIhwBO0dX3EEpsYC8rAVJgLUn5TOH+LyoYpilCMv8cmUZTAQrfVS1+h/Lgi9ke2YyJFbVmiqIAA="
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step5-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJbACdMoACD/McNTDz7zLhAADyZwzmNj0btwa2ek18JZa7BjmWr4QZsA39V0BByoou1brrGfNrs4V0asQ52NRSp/t4P3RkOCHM3+NtK7AAAA=="
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step6-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJbACdMoABXeuXlPq8oAD7GEx2z/nEm75qZ1QbMX4s/vKFGrbxUv6nV3Hj5jiRXIMQhqVny7XPIL7afYnS15OeJbX1dNk97QKsL5Vb6AFo4AAA"
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step7-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJbACdMoACfYB8MJLTVgAAzZLPycJOREpmXiTIVLdutch2pqScPFaI7tOdPKARl8q3zk1CTkAzrFFi6zc/ex8ZIw1jiokgAAA="
+ },
+ "static/wp-content/uploads/2012/06/lego-ipad-stand-step8-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZgCdACESy8kpCxEkXCYAAP5SyYiUg5fy1/utR1vgsPSOnptDZ+WO7Tyxl8cDcr8Rmq0EbfG2QucYbgmfituLBkAAAA=="
+ },
+ "static/wp-content/uploads/2012/06/photo-1.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/photo.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-01-at-2.41.59-PM.png": {
+  "w": 792,
+  "h": 306,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAADwAgCdASoUAAgAPzmGuVOvKSWisAgB4CcJZwBTAAonAAD+7MdKYCl7MTcZs4jlqUqIGAmj0wAAAA=="
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-01-at-2.42.12-PM.png": {
+  "w": 818,
+  "h": 314,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAAAwAwCdASoUAAgAPzmEuVOvKKWisAgB4CcJZQC7ADKLenqAAP7scFsIHY1SAsgFlFhxWgWJQAA="
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-01-at-2.42.31-PM.png": {
+  "w": 461,
+  "h": 606,
+  "lqip": "data:image/webp;base64,UklGRooAAABXRUJQVlA4IH4AAAAwBQCdASoUABoAPzmAuFSvJyUjMBgMAeAnCWgAwzR7b/HqoZsKnObR5hBpaWvM8fpAHAD+9pv36pP/S4z8b/hgGZdAJQsQ5Oj/bG1CNOQVnNXICMA4y+td62B1qhK3jIB5H4JQ6yaxR9ZagVrYmq9ACTaw8Pm6h7QOndeBQAA="
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-01-at-2.46.31-PM.png": {
+  "w": 948,
+  "h": 552,
+  "lqip": "data:image/webp;base64,UklGRkoAAABXRUJQVlA4ID4AAACQAwCdASoUAAwAPzmGuVOvKSWisAgB4CcJZwAAXE37oiZgkygAAP7nDoTh7qsfFVDhw8qXo6Z66VKRPEAAAA=="
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-01-at-2.46.53-PM.png": {
+  "w": 980,
+  "h": 680,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAABQAwCdASoUAA4APzmGulQvKSWjMAgB4CcJaWR5ADcAlp0SIAD+7jQjTSSbDaHK/FEUSPpAgbSN/cAA"
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-01-at-2.58.02-PM.png": {
+  "w": 604,
+  "h": 419,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAABQAwCdASoUAA4APzmEuVOvKKWisAgB4CcJZwAAetHQCiwTKAD+7mWjJVX5I2jwzlpqG9RwAAA="
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-01-at-3.03.35-PM.png": {
+  "w": 1005,
+  "h": 662,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAAAQBACdASoUAA0APzmGuVQvKSWjMAgB4CcJYgC1GoADUiNm4YCxl+ax4AD+4FAK/BRWrlAlgGBQPu51V5XmwuyJ3RRlvD5yTHJBrHAA"
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-11-at-12.04.45-AM.png": {
+  "w": 579,
+  "h": 470,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAADwAgCdASoUABAAPzmGuVOvKSWisAgB4CcJaQAAetCIAAD+7ml1PBL4ivpapq7nttI/sNEAAAA="
+ },
+ "static/wp-content/uploads/2012/06/Screen-Shot-2012-06-11-at-12.24.32-AM.png": {
+  "w": 631,
+  "h": 322,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAADwAgCdASoUAAoAPzmGulOvKKWisAgB4CcJaQAAetEDAAD+7phgpHip/Rc+sBY9eTgAAA=="
+ },
+ "static/wp-content/uploads/2012/06/tibetan-monks-and-tea-1024x683.jpg": {
+  "w": 1024,
+  "h": 683,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJagCdMoABkCnUc8fPgDAAAP7M+z8aB3TmGlDf+weAZEBw0pztDnX6h/cVMimoJVB0KKKtIsfhi4IyYKhDNVWO0RKhD10rpywAAA=="
+ },
+ "static/wp-content/uploads/2012/07/2012-07-14_04-38-44_67-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJYwDE2CHmj+ZNCa0DEDebAAD6kizlTV/Hx5YnIuJX2fEDtTsfvRx8csDoT8ZDcyWnl7fbkFSs3lyXjbkbNHNNsn89N6uoAAA="
+ },
+ "static/wp-content/uploads/2012/07/amanda-palmer-want-it-back.png": {
+  "w": 852,
+  "h": 465,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJbACdMoACXZijz/1i6gAA/q0iJuKk1ukdNWhK2cpP5bneGkwioyKXdRYkjd/XvcCfvl00XY6bqmzMw2JKLzhYJnzWFFvaVoEAAA=="
+ },
+ "static/wp-content/uploads/2012/07/glava.jpg": {
+  "w": 816,
+  "h": 612,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJaQAATAu5RBTPXfoe+IAA/tpzmOkjqDPwDKmc6arOmELkQq3TdzLUEo4A6YWHcyslga0gAAA="
+ },
+ "static/wp-content/uploads/2012/07/IMG_1438-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRr4AAABXRUJQVlA4ILIAAAAQBQCdASoUABsAPzmMvFYvKSYjsBgIAeAnCWMAyNcsAMlYUJNdYwYg/c1V91T51IwAAOJcDj2GKhYa++IHPPnJQbKwG2kcw5JFDncy3vX30TtYKrp2oEREyey9qkAVdr7uQGB4ULqLrSjLNQqJzo98llq275JyMMlv+0x8B3/U8mh516w1vhP3lfi3XZbFBofQMVsU2gZ041HbW/WZPovhdP/R2piIuGhWzDTaqqZyEAAA"
+ },
+ "static/wp-content/uploads/2012/07/IMG_1452-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAACwBACdASoUABsAPzmQvVgvKaYjqAqp4CcJYwC3uA/dTgo43BMR5GvEusOjxMfAAMwKXaox/Cio9H3i9eYJWbkbsXti5nCaKzW/BjYw2OWB6CA7hMzdD27g9VsaGLnZllJ6oW7VSzFZ5kwQT7Ppg1Gnr5fb8ejIyo68klnGMyGu8UZBvk7ZEYnpAAA="
+ },
+ "static/wp-content/uploads/2012/07/IMG_1559-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRs4AAABXRUJQVlA4IMIAAACQBQCdASoUABsAPzmKvVYvKSYjsBgIAeAnCWMAxNgRdVyEdVKnG9l2uqEaECAAJ2+bnCgJAAD+zA+DXcmH09Go5bids4u8SbqAjF/3Rc3WlJ4H3PFDAUpODoYhgZcg6wfZ/aSU25zKF6LM3b8knwkBeESyamX+jrgZVY+mVknGhFr+i5YMi0fdCTBaqy6eQbU74JH8+WT1Ts65fBTUkKwMMYjtG/sAp3NjaoJ/NkTzJ1i64YGJK4ERM5rGqwA38WZ4AA=="
+ },
+ "static/wp-content/uploads/2012/07/IMG_1565-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZACw7BuvIpBKXzOgAN9TZoh5VEAfCJHbKymuAoS2RpCC2JPYzqzQuHacbwTCJVt3+I2iiAA="
+ },
+ "static/wp-content/uploads/2012/07/IMG_1646-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZACdABuVuMWxZOJ99WlAAN2bFPoPEpWzpJ2oigcFg9SbnDA41qcBMygc++1strbcfDzLYe/rCc+m4cTOkELEOh4rhvwAAAA="
+ },
+ "static/wp-content/uploads/2012/07/IMG_1727-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRoYAAABXRUJQVlA4IHoAAADwBACdASoUABsAPzmCulQvKCWjMBgMAeAnCUAXYAIcygWbriiQFfk34JwpV8HwgAAA/c5jrL3x1cqsMOt9ntmRU42Y/NI49QwJUjripPiYymnvDjseqpwan2a1xljAUAZOhypap+/jgp60kwd5rNlVJTuKFFkJmjQAAA=="
+ },
+ "static/wp-content/uploads/2012/07/IMG_1756-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAABQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwC06AMtzLlgwAD+wACi8zRnKlJxL+5nA+zIN1l4upOGGj2M0msdh8H5FcF5maoRpS6QAAA="
+ },
+ "static/wp-content/uploads/2012/07/IMG_1826-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAACwAwCdASoUAA8APzmKulQvKaWjMAgB4CcJZQAAW+NMY2Ra7TiuFAD+w0NHn4beUHAYpQ+I8m6hzJSW2r9HzTN0FYlDKk/pWHpU65zVbeyEDUea4e7az8AA"
+ },
+ "static/wp-content/uploads/2012/07/IMG_1830-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYgC/OBwobA35MTbUsAD7XdEEzbes4CR1pLinaZSs7zhB5/gjjXIyC8BN/fdO2AmGGAlBod8O7yDpQmeN0VwAAAA="
+ },
+ "static/wp-content/uploads/2012/07/IMG_18541-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAADQAwCdASoUAA8APzmGulQvKSWjMAgB4CcJZwDCgCHXEmN8yFeX/0AA/t6q3q+iQokhQHejcmqCNrL4+hDnPujp+0xDdU/irrwYUEDoz+eyTSuoAAA="
+ },
+ "static/wp-content/uploads/2012/07/IMG_1872-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQAAKLJeY5bal4WpTp4AA/uNFi8NC0vUw7uePskn5UTApbGIyIfuLauJG0uelofle9v4S7TcuB/GxFeuuUAui3pnHwQAA"
+ },
+ "static/wp-content/uploads/2012/07/IMG_20120726_183936.jpeg": {
+  "w": 720,
+  "h": 720,
+  "lqip": "data:image/webp;base64,UklGRo4AAABXRUJQVlA4IIIAAABwBACdASoUABQAPzmSv1mvKaajqAgB4CcJQBhmgaUKJO/EfDHfiweKTX1eAAD+2VIzTzsTm6/MK7muEdvbRALyHbzvRBdgXupQ4RYr7upJqWysxutHHPwHfYkjlh5cohC/EXWsTS8jygaMwKtxxPWDt3m8vBmimbg7z6qCzr6wITAA"
+ },
+ "static/wp-content/uploads/2012/07/macro-lens-e1341492483119-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRuAAAABXRUJQVlA4INQAAACQBQCdASoUABsAPzmOwFcvKacjqAqp4CcJagDE2zF456BtuIO+1OWeykDYFHJBc4cVbvEcAADh8gXqz6ojtz7nBMGrSwjz4YQAvXpmmM/1WVGK8iRLM+BHVWU1Lo/c4zB6ezM3qrdh4jUxqr6SfkM6c8dVWIW70EwEknBFk8Tg8SQMI/55zQZtTEMM8TyloX8HfGvdRCc/UfYDPedY5S6D9Nc9WD2+7aGjck+onvI2JEIOE09PDBLZxdV9tat3A9ATdUx1lcNV02CdwA2QNqyzhAAAAA=="
+ },
+ "static/wp-content/uploads/2012/07/mala-panorama-omis-blog.jpg": {
+  "w": 965,
+  "h": 288,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAACwAwCdASoUAAYAPzmIuVOvKSWisAgB4CcJQBdgBEM1zAKVP/jGLgD8j5PCu9VVvOmtAW7K0oYb19D2k8jhd1QyR5ZvO1NU+1lYIAAA"
+ },
+ "static/wp-content/uploads/2012/07/photo-1-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJQBYdgyS1/SjCLRFE3JVLtAAA8iJRcINylkpDf7cCdAPlq3stGepfbhZjxGmkhntLUTI/dFKJJRbEnxxDhX0dH4UMGSs1QhaBK9ERcr03WsqqAAA="
+ },
+ "static/wp-content/uploads/2012/07/photo-11-e1342179362322-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAABwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJaQAAWrCGt+5R7AAA/uvjqEY4MuDfVejVNlaaCAdv+1tbNE8wOwAA"
+ },
+ "static/wp-content/uploads/2012/07/photo-12-e1342473433868-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAACQAwCdASoUAA8ALvmczmclLy8vDwD4SzAGFAIGxfEcFLeRFVfoAP7ys9zvOrIpgDi9lyouYd5TfLwk6DRh72tG/B/AvUDniuy8fGjkyYq5DJ3VuAA="
+ },
+ "static/wp-content/uploads/2012/07/photo-13-e1343393002368.jpeg": {
+  "w": 1296,
+  "h": 968,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJbACdAA8k67eqJ9h41fDIAPoPvPnfzC9OEqnDZ7AB5SQ/EjyzwbRNYI9Ikm+S4EtJl/GcEZYlmnRBE4/nJObFEadB55kL1nkFX3OPuvLO1KJqTATwpgEIt0AAAA=="
+ },
+ "static/wp-content/uploads/2012/07/photo-2-e1342179272780-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAACQBACdASoUABsAPzmMulYvKSWjqA1R4CcJZl2ATKAGWGtr2L07XAA2Q2x/mIAA/mVOfLHAtwRmkDaWzRU8W/6KP9eQs2hGnLRIJ5r8eOKrvzUuzuc2ZVfHo59HfOa+EeGUuQk440aEMp/OtQ3RQHoB3WstG0EeJYoMAAAA"
+ },
+ "static/wp-content/uploads/2012/07/photo-21-e1342368872701-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQBACdASoUABsAPx18slOtKCSit+gBoCOJZADDNDI6bCdK4ujMoE7w9+QKTPrgAAD+nQWUPRmxMPuUuQw/EciVYBo3AXIKw4qXVHonhKREjOHGQvwXsKEbC4Vi40cvqoAAAA=="
+ },
+ "static/wp-content/uploads/2012/07/photo-22-e1342473749555-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZQDLLBeH9Bs/2NUoVNAA/uvwUZK2GySabophRgBbDqYmpcVVBYRf6nbm8h6U0jMc3ggA"
+ },
+ "static/wp-content/uploads/2012/07/photo-23-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZgC06CKC9k8A5sQuvAD+cc6lNssrQ6rvpe1OA8FV7yDm0CM4BOnbp9HPfuVUJ0Q7s+OAbjW+63OVHeu8YELIAAA="
+ },
+ "static/wp-content/uploads/2012/07/photo-3-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAACQAwCdASoUAA8APzleyV8vI6qmGAHgJwliAAEd6jM0vcPMLzUAAP74S4cACKEhK8ZIMEyAtJEZhX6HHCUFZPwlrsoAKzThFhYAAAAA"
+ },
+ "static/wp-content/uploads/2012/07/photo-31-e1342283685189-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAABwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJaAC/OCHfj60nkQAA/uvQWuYu/6hkChzF36YqeDnP/ZaHowML1QAEbrwBZGjM8SIARagl6q+rFVCkc7iwAA=="
+ },
+ "static/wp-content/uploads/2012/07/photo-32-e1342369052888-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAADwAwCdASoUABsAPzmOuVWvKiWjMBgIAeAnCWQAAI91lC83ytqk40PQAP7ucoeBCyGlECMoOnMPsoyzZyc+3hqxbbzZ3LIpmbgRsAXxaZYvpWamv7QAAA=="
+ },
+ "static/wp-content/uploads/2012/07/photo-33-e1342474026158.jpeg": {
+  "w": 1296,
+  "h": 968,
+  "lqip": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4IEYAAABQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwAAXKdHpsLZ4AD+6+5Y1Qqh3IFaXxxRqTeNDQVpgXeZeJCBZoejE2n0AAAA"
+ },
+ "static/wp-content/uploads/2012/07/photo-4-e1342283814117-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAAAwBACdASoUABsAPzGAslOuqCQisAwB0CYJQAAI9lXTW67rwNocqDamy1AA/Kssr4FcUQjCcHKVjUDJIYrvSKd9r7dYpPvg/oHnVRdKPnAqIbuqu+vZbzEK2MVpxQYipYiH0/w6efrOgIhMkmlex7wcN/sAAA=="
+ },
+ "static/wp-content/uploads/2012/07/photo-41-e1342368973262-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYgAAWlNdMCNvoZDElAAA/ujaBUOe6eHS888BWMRlOCRYjwTms54yPZczJMgzylrNpfOY8irQdR5ZlXUWKckHXvxJAAAA"
+ },
+ "static/wp-content/uploads/2012/07/photo-42-e1342473520987-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQBbZA4kJ/A2a20O6oYsAAP6fjNHNWN689HRMptBrBkOjuJrUGY5RFLsWpemnf9MGEDWnACAzMzUf/hjD5VRgAAA="
+ },
+ "static/wp-content/uploads/2012/07/photo-43-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJaACdMoACsVGnuFp/iTl+CAD+jhuyEIqv9kD18jfpNPZLbD3/OF5YycYK9Sp/p/bwY87CMEVfA/jqkxbve7p1g9yAXGz/9SaU38AA"
+ },
+ "static/wp-content/uploads/2012/07/photo-5-e1342283895969-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAADQBACdASoUABsAPzmIvFSvKSYjKA1R4CcJZgC+SEXEodAH7nvePLXYxKUnP4lTAAD+6hRIzU1H4o3T2BnGXjbwEXaA9LCbS0VVACvZPT0kOKnauQnvQrVpXXdHolD2rcJ0yZ5whKUJwNpxuKHT0aK6oAA="
+ },
+ "static/wp-content/uploads/2012/07/photo-51-e1342474564398.jpeg": {
+  "w": 1296,
+  "h": 968,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAAAwBACdASoUAA8APzmGuVOvKSWisAgB4CcJYwDLLCG8mpTfocFnDRZF0IAA/uvi1GNr3qRLMHozb64P4X0Wf8qA1SC5gM4CZkYoKVdWWYXF2fVq6AA="
+ },
+ "static/wp-content/uploads/2012/07/photo-52-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRo4AAABXRUJQVlA4IIIAAABQBACdASoUAA8APzmEuVOvKKWisAgB4CcJYgCdMoAC7lQdXzPiPLjyB79AAP5r6/y9LyI9+/Wcx+aNDNFDk/lgVYL15jd5PeTRgGaymB2k6LKOvWWu48AF89nNbjEE92XKcfjRPJ0egNPopjRPiXDzRBGHskXkjSGFis6NdaouMUQA"
+ },
+ "static/wp-content/uploads/2012/07/photo-6-e1342283964423-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACwAwCdASoUAA8ALvmczmclLy8vDwD4SygABc6qzte9N24jZcF4AAD+8pg7ThUEnlQutVVHIrpaslBQ4r34Hkz+l3ZFFFkp4vNhbxcAAAA="
+ },
+ "static/wp-content/uploads/2012/07/photo-61-e1342473595626-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACwAwCdASoUAA8APzmGulQvKSWjMAgB4CcJZwAAXK+Vuc5Y7LigAAD+6/AYZjVsrQirrHqmEan00vB3KF3fh4SxPv/iA5zQUD6qxpQCS7rAAA=="
+ },
+ "static/wp-content/uploads/2012/07/photo-7-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBhQBECZhc4NX39FehBAAP7MaFkuc92dWq9GioZMsskiqRcmbixTROIXGEKP+w2PVMnnM3+VSkfWYmnp44aDrMgAAA=="
+ },
+ "static/wp-content/uploads/2012/07/photo-e1342095294595-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAADQBACdASoUABsAPzl8uFOvJyUit/VYAeAnCWUAyRBFX4jgO7vaGydTsqEEXW6aAAD+8po1foQkFEDseatVDmu4e224CMYHukPV/fBZKnvNW6wVAQeAywy9qsf7OZBtFN24fIcc0Dmzap8i4KWsP4D3k0PfaZQp5s4dnWAA"
+ },
+ "static/wp-content/uploads/2012/07/photo1-e1342179158689-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4IJgAAAAwBQCdASoUABsAPzmQulgvKaUjqAqp4CcJbACsAAyNdKTvzLXtl79uINIaojlUg+cDwAD+6/8+Pt3hhe/IMR+sjXtfJGpfSHr7uiMpmcX6SjcXGIIg+dQBDNxtiGm11id8oSmD17nhsRTxakI6/dfeXsOL1qAhctXkZJaUpviwb//muyTQy9RHsDV0UPiUNhVn6J5iry6AAA=="
+ },
+ "static/wp-content/uploads/2012/07/photo2-e1342284117905-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZADG9CFxD/PwWD9NEIAA/kKJfyK2G6NKUzIeaBLv40Ej4zQZcupMEeRX/eKaKofPzAEr7eDp7f9S8ing9slkQqH1PeQvxk6awAAA"
+ },
+ "static/wp-content/uploads/2012/07/photo3-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4IEYAAABQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZwAAG4mhaSTFAAD8XZ1mN67sQnfIkELDwc9nfvxsNwGUx/eVmT4GgVGlmAAA"
+ },
+ "static/wp-content/uploads/2012/07/photo4-e1342473839169.jpeg": {
+  "w": 1296,
+  "h": 968,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJagCxDKnCrv8mWCi4vfkAAP7r4wQ4+V3AXTdpHA7og6pcuaTZAqqGJ6wbgJIeHOi7kOo0WMaQNiewAAA="
+ },
+ "static/wp-content/uploads/2012/07/photo5-e1343743830702-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRqgAAABXRUJQVlA4IJwAAAAwBQCdASoUABsAPzmGt1QvKSUjMBgMAeAnCWIAuwA0XeE6BMwdM6yJDhRtvTYuO4gbgAD+8MkjTRmmyRPotph8FsGfzRplBCWBu9gc2OmRQdOTSrtZgS/hh21UMED15NTfqXhl02jB1rX+bmJV7iqsAkt2mZIsm1g6slYIkMJ0Fp+d2FbMWGwmG0zbH0DG3HMeEozWroY6hUY7wAA="
+ },
+ "static/wp-content/uploads/2012/07/pretty-house-telelens-300x224.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRooAAABXRUJQVlA4IH4AAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJYgCdAywBviMmKsw+biE0QADh6mOeZ1pQA4HLkyBuZvp6m8ymiFCXv4ZAd+GLKZOZYY56eh4rHRUYHpAC55JAT1yYSMIoO2YhUySm3nFE9L0dlQuiPOcG2vtDGEbD3nXmgcTUgAA="
+ },
+ "static/wp-content/uploads/2012/07/pretty-house2-e1341492265181-300x224.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAACQAwCdASoUAA8APzmIulQvKSWjMAgB4CcJQBadA9T0IPWUyJSAAP6M6XOu0d5AFbhQDhHnkgaq6T7qq4ISz89jMsoshFEYWMzLLL90woX1u1GmNB+pgZAA"
+ },
+ "static/wp-content/uploads/2012/07/zipline-e1342369138635-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAAAQBACdASoUAA8APzmGuVQvKSWjMAgB4CcJZACdMoADTV0dQPCMoqdogAD9HC2xKMi2OSOFNY0pYQHzYaNSyK40QZb1eqzi6LIuqoSS10dxJ5M6l8AcdyMLAAA="
+ },
+ "static/wp-content/uploads/2012/07/zurich-beach-e1341492660981-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZgC06CHWNKVqbb7hcAD+5zSud+8LT8iZPExseByByrV8V2WmtoR8BUtdrsd7inQ9fsYrXXZ/huhV2vQdA/h+Es3YsYmLUBDUj/ggAjhSXsHAJgCbtZkZHoAAAA=="
+ },
+ "static/wp-content/uploads/2012/07/zurich-beach.jpg": {
+  "w": 1296,
+  "h": 968,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJZgC06CHXIG+fcjgsC3Z64AD+5x42XV/Gn9FKX158M2S3y8CFtU7e7kcYenp60G5e4fZUiPgTJXoxpRolyMUjqiOXS96L8d466P77mxYz88BcTTaOtoCa3a0CGwAA"
+ },
+ "static/wp-content/uploads/2012/07/zurich-river-300x224.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwAAUpx/8/GntU4QAAD9zmSe516zSKYsme3uGBzrN7qMdTtMJl7I0uHfi0LAb2On60P4wAA="
+ },
+ "static/wp-content/uploads/2012/07/zurich-river-fisheye-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAACwAwCdASoUAA8APzmGu1QvKSYjMAgB4CcJYwDImBN4nnvib97LAAD8H8mftayBM5ABvPTIyOQrNwi1R3ujewdDLd029r603fzuEINsX5Zh4IIbYv8pN/NWXMQTBGe/LDRCm1gkIwAAAA=="
+ },
+ "static/wp-content/uploads/2012/07/zurich-river-fisheye-300x224.jpg": {
+  "w": 300,
+  "h": 224,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAABQAwCdASoUAA8APzmGulOvKSWisAgB4CcJYwAANzTPbVOQIAD2uOCQLpP0HgfkPPd+knq3YaUXTVbvuzOIbHyCEaHifewf7iochCDFPGEG1ggt9JLfGVACxXG/+Xk2t0s83ihQAAA="
+ },
+ "static/wp-content/uploads/2012/08/202505_10150999892841267_1541795793_o-1024x256.jpg": {
+  "w": 1024,
+  "h": 256,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAAAwAwCdASoUAAUAPzmIulOvKSWisAgB4CcJaQAAUcbvKeQAAP6DoWBsTe/zbTEx7wPhIRr95S4G8QP2H+ghQAAA"
+ },
+ "static/wp-content/uploads/2012/08/202505_10150999892841267_1541795793_o.jpeg": {
+  "w": 2048,
+  "h": 512,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAAAwAwCdASoUAAUAPzmIvlSvKSajMAgB4CcJaQAAUcbvKGWAAP6DoWL4eySgxpNMe8Da7OjyM9dBBDVmaD8B4AAA"
+ },
+ "static/wp-content/uploads/2012/08/association-list.png": {
+  "w": 370,
+  "h": 148,
+  "lqip": "data:image/webp;base64,UklGRjwAAABXRUJQVlA4IDAAAACwAgCdASoUAAgAPzmGulQvKSWjMAgB4CcJaQAAeyAA/u5lQb53gyogMn+yTKmwAAA="
+ },
+ "static/wp-content/uploads/2012/08/dubrovnik-panorama2mini.jpg": {
+  "w": 1012,
+  "h": 312,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACwAwCdASoUAAYAPzmGuVOvKSWisAgB4CcJYwAAV48ro0tAI6idoAD3TNGoB8dYhs7i6LozBbwotoRjLYrxkmR/MokVFEp8ms/x2wCAAAA="
+ },
+ "static/wp-content/uploads/2012/08/example-list-structure.png": {
+  "w": 165,
+  "h": 167,
+  "lqip": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4IDwAAAAQAwCdASoUABQAPzmAulOvJ6WisBgMAeAnCWkAADzaPYAA/u3wBxQyE2zq83MphH6W29hvKtGENxwAAAA="
+ },
+ "static/wp-content/uploads/2012/08/IMG_1650-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAACwAwCdASoUAA8APzmGulOvKSWisAgB4CcJQBYdg4V22x9ayP9tHAD3HuL7fDxmpNup253gB3K96JE/9g5P1nFwCDIewGIYS2yQQtBSBvRYBEcRlDtLDDAA"
+ },
+ "static/wp-content/uploads/2012/08/IMG_1652-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAABQBACdASoUAA8APzmGuVOvKSWisAgB4CcJZACdH8GJ/gNsNmoTD8S0o37QAP3VN+a4cmptxtl6Am9DxgtcabfRfny6c/8LolZkKmjaMkgw8XpaMW8UlLp0Hf4+8hQ2Hx+PLeoMgm78BbXVItroTPgA"
+ },
+ "static/wp-content/uploads/2012/08/IMG_1813-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAADwAwCdASoUAA8APzmEulOvKKWisAgB4CcJYgCw7CHYdMkuUPqfeZcAAP5RWEsGeVUk2FRx8tQDZiXCbPXJMsRG2FAhvwqdkqzGsF1eUsagBXyAOCgAAA=="
+ },
+ "static/wp-content/uploads/2012/08/IMG_1821-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJQBOkH+BgYjuQDpdJXtHjYAD+i2wg0C7Ssxp009Ja9HkwrB7AETTZZUktzqOAce4JvxXo397QAA=="
+ },
+ "static/wp-content/uploads/2012/08/IMG_1854-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAADQAwCdASoUAA8APzmGulQvKSWjMAgB4CcJZwDCgCHXEmN8yFeX/0AA/t6q3q+iQokhQHejcmqCNrL4+hDnPujp+0xDdU/irrwYUEDoz+eyTSuoAAA="
+ },
+ "static/wp-content/uploads/2012/08/IMG_1932-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAADQAwCdASoUAA8APzmGulOvKSWisAgB4CcJZQAAW/GBlIyqpnrpOIAA/uvYm1jYAp0vAnJOdu17RHXIG3DTOw6jai9vtiaJdRX8llnt/PodFQAA"
+ },
+ "static/wp-content/uploads/2012/08/IMG_1932.jpg": {
+  "w": 1632,
+  "h": 1224,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAABwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZQAAW9OB6EZnGFAA/ujHbNxbOwEftz7r30h8fzIm8ohXaDbnsK/5DYdtiREBeq37nTIhZvYzwAAA"
+ },
+ "static/wp-content/uploads/2012/08/IMG_1947-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAAAQBQCdASoUABsAPzmEvVavJ6YjsBgIAeAnCWMAAClA7bA5qIN48zznWw9TB7/x9YHAAP7evtx4wbUQxtNoL6dDLpXkCt4lKuD5BRUiu/GZ4T/s2rpvI1pDG6swyPajNwFCXfpHGqipmHmo+paCg6A8AAA="
+ },
+ "static/wp-content/uploads/2012/08/IMG_1954-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAADQBACdASoUABsAPzmSu1gvKiWjqAqp4CcJZQDE2A9hfdCDlPxjU7zUkD5eccX9pAD+E/rAcFpsWhRW1RfksiKsNs69wmkBwJzJ9Je6dA/6v13NcKKpmfCyViIKEzD3rXaA0dIG0rTLNVR8QjFO4pkNlKC1q6BTaYU5HwUhj1BDGgYzihtTLglAAAA="
+ },
+ "static/wp-content/uploads/2012/08/IMG_1978-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBOiP/wEMQZRwYSg5tbYAO/9q0+eaB92vY62kVlPCIxN7pX6ceehM301T04HKzqors8JhJxQQHuQA0EBEAeqBWwiA0vhMHYAAA=="
+ },
+ "static/wp-content/uploads/2012/08/IMG_2003-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJaQAAS9rnDHM6MQ516AD8VRB/1loKl8RztsKlsLxNWdQIiu7UtmYL9quK7Ays5KV8QANBhDFoesAAAAA="
+ },
+ "static/wp-content/uploads/2012/08/IMG_2028-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAABwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZACw7AvohCj0cwAA4Y2kLA4Lo9C6Oqk/M1cN4LSKgmMnSgBZ1DReB//UxO0K8ljE33D4/FwAAA=="
+ },
+ "static/wp-content/uploads/2012/08/IMG_2050-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwBUfobb9uU4auDBgAD+53vtEIeeHLZBTxCBHLWtyiRIDnrkd9+6lAMfkxqlggyVwBS4NmZX+CqktgC2KwjbqgCuwlbb0pYeNEAA"
+ },
+ "static/wp-content/uploads/2012/08/list-structure.png": {
+  "w": 465,
+  "h": 309,
+  "lqip": "data:image/webp;base64,UklGRjgAAABXRUJQVlA4ICwAAACwAgCdASoUAA0APzmGuVOvKSWisAgB4CcJaQAAeyAA/u5rqFdkxTrwUQAAAA=="
+ },
+ "static/wp-content/uploads/2012/08/photo-1-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwDKABbfKgaV3rfuoQAA/o9OSoT6VokDJXUw/Mh4i5Qp5e97uRCuaNkqm1hHYPZuVYxOOBh8ZJWZRfH9uazjVNWjGbkNL2awAA=="
+ },
+ "static/wp-content/uploads/2012/08/photo-11-e1344249171498-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwAAN9yNG8Pbdky5kXAAAP7jTz518V7F+ZVZhAuPmsFS7T5nmkDHmTBmUyaDvqnAEzf4v2h4WrNzPMhSwzTqyAWiwRNuA1YDBcuOrRzvkHfWq4Gy2Tr+6ZwTeAAA"
+ },
+ "static/wp-content/uploads/2012/08/photo-2-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQAALYxcfuzdkOffZLAD+w1j9mPPHvO1IKWyIoUZwPpMJdxjGdqG42AOjcwyVoHPT/6QIN28pZRh4yW+G+rZFfaOiU22qGkCKyoVbQAAAAA=="
+ },
+ "static/wp-content/uploads/2012/08/photo-21-e1344249234790-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRo4AAABXRUJQVlA4IIIAAADwBACdASoUABsAPzmGu1avKCWysBgIAlAnCWQAt7gQ4mt46JnzjI+WHnH+hraaLzAA/crL3wX7MSic4h6T2Yi/QWuklR7qDt+muOnU4hzdjcSz9w8PupvSrNWxtM4UsZdQNvqYYxCbxIdwBcnPKQtA1wYwlJY3DCvAHyTe4MzqgAAA"
+ },
+ "static/wp-content/uploads/2012/08/photo-e1344104367841-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAADwAgCdASoUAA8APzmGuVOvKSWisAgB4CcJZ2llADe2AAD+7lRR/YZqprNZkoAOgrGfjIAAAAA="
+ },
+ "static/wp-content/uploads/2012/08/photo1-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmgAAABXRUJQVlA4IFwAAACwAwCdASoUAA8APzmGulQvKSWjMAgB4CcJZwAAW/GtlV+RWMiGmAD+5x8XAkiBH0hTyU5XxSmjDYgMARumC5pMUb8fpfwHwtjffvz+PrWhgqMmf3NitfEb8sAAAA=="
+ },
+ "static/wp-content/uploads/2012/08/photo2-e1344249415170-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRoYAAABXRUJQVlA4IHoAAAAQBQCdASoUABsAPzmIu1UvKKYjKA1R4CcJZQDE2A8+ztHmfHxG1yxPq0t5+1O+wZAAAP21xbIZ7tXLghxyI2NIl8ppg4mWuywuDspZf5KVseL4wX29SjvtHVSKZmcScQLq3pUjPNuvckhdd/y1aKDVs+BTUmDEHLwgAA=="
+ },
+ "static/wp-content/uploads/2012/08/photo4.jpeg": {
+  "w": 964,
+  "h": 779,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAACwAwCdASoUABAAPzmEuVOvKKWisAgB4CcJQAq6AMqze812DF+5wAD+W0lhzpJjCL6LlRnHuQ5L0DeFQ8HzCbPR7yvFe1L7C+tCQ4Qhunwu1O9oWBmdUfpIF45+COmVJ/WaYxKzYz7aYqAA"
+ },
+ "static/wp-content/uploads/2012/08/Selection_068.png": {
+  "w": 591,
+  "h": 318,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAADwAgCdASoUAAsAPzmEuVOvKKWisAgB4CcJZwDA3C0kAAD+5DhYs/9/GJrXtTekEeILAAAA"
+ },
+ "static/wp-content/uploads/2012/09/graph1.png": {
+  "w": 640,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACwAgCdASoUAA8APzmGulOvKSWisAgB4CcJaQAAeyAA/u6+5FRTwgAA"
+ },
+ "static/wp-content/uploads/2012/09/nothingproductiveallday.gif": {
+  "w": 500,
+  "h": 281
+ },
+ "static/wp-content/uploads/2012/09/notinventedhere.png": {
+  "w": 278,
+  "h": 282,
+  "lqip": "data:image/webp;base64,UklGRrAAAABXRUJQVlA4IKQAAAAQBQCdASoUABQAPzmWwlmvKqcjqAgB4CcJYwAAJt1yChyq1cG6qsKR2FbVVZHgfCTgAPz4j46j7Tp88V9eEZ477Bk1ENLJJnCDYb7eGPev4A2eEx4cNMuL8i7R9kMzIr5NhSDhf4yr8slpsne833z2UlKXgSeuqNVbla5gMZ7kcL+4v0sFATm9uiS20T9Tci+D6iuy8IpcrD4V+UnB8cWK0ZgAAA=="
+ },
+ "static/wp-content/uploads/2012/09/scatterplot-finished.png": {
+  "w": 938,
+  "h": 312,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAADwAgCdASoUAAcAPzmGulQvKSWjMAgB4CcJaQAAetEDAAD+7pB5/57mucfkIHOTjAAAAA=="
+ },
+ "static/wp-content/uploads/2012/09/scatterplot-finished1.png": {
+  "w": 938,
+  "h": 312,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAADwAgCdASoUAAcAPzmGulQvKSWjMAgB4CcJaQAAetEDAAD+7pB5/57mucfkIHOTjAAAAA=="
+ },
+ "static/wp-content/uploads/2012/09/scatterplot-labeled-axes.png": {
+  "w": 929,
+  "h": 302,
+  "lqip": "data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACwAgCdASoUAAcAPzmEuVOvKKWisAgB4CcJaQAAeyAA/u67rbYXAAAA"
+ },
+ "static/wp-content/uploads/2012/09/scatterplot-loading.png": {
+  "w": 932,
+  "h": 295,
+  "lqip": "data:image/webp;base64,UklGRjQAAABXRUJQVlA4ICgAAACwAgCdASoUAAYAPzmGulQvKSWjMAgB4CcJaQAAeyAA/u67pYCYAAAA"
+ },
+ "static/wp-content/uploads/2012/09/scatterplot-simple-axes.png": {
+  "w": 880,
+  "h": 307,
+  "lqip": "data:image/webp;base64,UklGRjIAAABXRUJQVlA4ICYAAACwAgCdASoUAAcAPzmGulQvKSWjMAgB4CcJaQAAeyAA/u7nF8AAAA=="
+ },
+ "static/wp-content/uploads/2012/09/Screen-Shot-2012-09-20-at-4.13.10-PM-1024x695.png": {
+  "w": 1024,
+  "h": 695
+ },
+ "static/wp-content/uploads/2012/09/Screen-Shot-2012-09-25-at-12.43.58-PM.png": {
+  "w": 966,
+  "h": 238,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAADQAgCdASoUAAUAPzmGuVOvKSWisAgB4CcJZwAAfEEAAP7txSRsLh7wSE6c4KulwdLaFgAA"
+ },
+ "static/wp-content/uploads/2012/09/teleportation_0129.jpeg": {
+  "w": 525,
+  "h": 294,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAAAwBACdASoUAAsAPzmGuVOvKSWisAgB4CcJYwDG9CL262tjVgO+wNzsxAAA/icK/MeyZX7nwgjq69wiBEC89Yc6xL2Kzh9TweYmSTI54gw5/xRO3aKta8s79TdeNbxtqrTBQAAA"
+ },
+ "static/wp-content/uploads/2012/10/2012-Aston-Martin-Vanquish-8-1024x602.jpg": {
+  "w": 1024,
+  "h": 602,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAADQAwCdASoUAAwAPzmGulQvKSWjMAgB4CcJYwDE2B6KCrASBwofOcAA/qf2h+N7nrWIZI6KwVN0gnslmcVmuV9vse67A2t3XwTAQTYXllWKbyGPQAA="
+ },
+ "static/wp-content/uploads/2012/10/2012-Aston-Martin-Vanquish-8.jpg": {
+  "w": 1280,
+  "h": 753,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAADwAwCdASoUAAwAPzmGuVOvKSWisAgB4CcJYwDE2B6KCrHL3UwK7UQAAP6n9ofje561iGSOisFTdGI3Fk0KKyNW3ZQOXElMO8WSO36Fim8hj0AA"
+ },
+ "static/wp-content/uploads/2012/10/aho-corasick-algorithm.png": {
+  "w": 423,
+  "h": 547,
+  "lqip": "data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAABwAwCdASoUABoAPzmUwlmvKicjqAgB4CcJaQAAL3iFVvoEgvAA/t6YuZCcieO0WfzdkM0Nk/1jy2QuSL+opy2Govi0koMbVAAAAA=="
+ },
+ "static/wp-content/uploads/2012/10/arc-triomphe-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAABwBACdASoUAA8APzmGuVOvKSWisAgB4CcJbACdMoR3ACAz6+QqntnMbwqvgAD+6OuvXaCo/mGbf5/LplWtexY4DKs8f1Pe9Zp7HeS4k/r6xsfKNrl7BukZblQZ9kZTuBh2Ixb1hsiSBa2b4gTpgqU8yql0xsHKgAA="
+ },
+ "static/wp-content/uploads/2012/10/area-explored.png": {
+  "w": 507,
+  "h": 68,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAADwAgCdASoUAAMAPzmEuVOvKKWisAgB4CcJZwDA3C0kAAD+68cN+3VOjAZN4O6yqXshl2iwAAA="
+ },
+ "static/wp-content/uploads/2012/10/carousel-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYgCw7Bc8PjHgSmsBKJAAAP6J0z+lbS+dLiZgV+xX1AxG6PhWB7EUMfy6XiWMaiivkHva91HFo8j+oo2D/1589hqu8kfy2V7k58gtg+4WRFohomgq6qLg12VFgOhS3pMr1aAA"
+ },
+ "static/wp-content/uploads/2012/10/cbs-sherlock-holmes-1024x583.png": {
+  "w": 1024,
+  "h": 583
+ },
+ "static/wp-content/uploads/2012/10/communst-hq-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4IFQAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJZwAAUTOJo5/Fb7sh56XcAAD+Ru4KMZd0CehnkBlz8FFH7Ehmfn/q5GN47AQEiDzGfdILhaIXP3reEAA="
+ },
+ "static/wp-content/uploads/2012/10/downtown-ljubljana-fog.png": {
+  "w": 508,
+  "h": 750,
+  "lqip": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4IJ4AAAAwBQCdASoUAB4APzmGuVOvKSWisAgB4CcJZwDD6CHRtrUX5C0r1Jh/J0+G63LdnzgkMAD+W+vWHX9oytjV5Rjfuqsqk41CQiZZlP5SMHDpy2ux1oHWPMtDKz985bEV38PrjA6G5GsWe2mVSUImZZEgkaZL9oeaAUlT2rQUbMM4uW2F/Die4KTg7oMoV9KatLUlPTDQzk8sAv36sAAAAA=="
+ },
+ "static/wp-content/uploads/2012/10/dream-of-pixels.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/10/eiffel-tower-dark-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAADwBACdASoUABsAPzmIvFavKKYjsBgIAeAnCWcAACnCllX79b2rTKMSrP2hCXh58AAA/sBjdbv2plr3i85yX8w40XDY7dzXXQgKX4TZDal4Srgac1qJyf1qkGk8oRuphsVP9D0ovUDkfi4lhnwKZNU2LtVgfmZzX3YF21pxI1y7CDyf8C5uzguAAAA="
+ },
+ "static/wp-content/uploads/2012/10/eiffel-tower-night-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAADwAgCdASoUAA8APzmGuVOvKSWisAgB4CcJZwDKAC0kAAD+7g30ogcCxQJInb5JS4OmdMAA"
+ },
+ "static/wp-content/uploads/2012/10/elementary-title-scene-1024x576.png": {
+  "w": 1024,
+  "h": 576
+ },
+ "static/wp-content/uploads/2012/10/elementary-title-scene.png": {
+  "w": 1438,
+  "h": 810,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAACQAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJQBOgAvRLZxe+w7YQAM2lpMfVk/iSbdpTbsaJvX+J11eG25xQO/EJc+JJh/wwlW4YP8mTsL34prfTzX5AAA=="
+ },
+ "static/wp-content/uploads/2012/10/le-group-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAACQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZQAAUHVFTV/wn0mAAPqcEi0TXME6wxMatqBblqi2D6U5z0OyBzbcCpjnRKvtxuhckWv5jZ/uKt1AJrUmz9xMP17wdqZCSwAAAA=="
+ },
+ "static/wp-content/uploads/2012/10/lecorbuisier-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJZQAAWsVdJ3iUT03RecAgAAD+rAQMJIWQGmKKqeKP8fZlZ5Sr32Nid29KkjiaLF4sfAnjWUwjX4HSf1ldbP+BCsNGdedjlnTAAA=="
+ },
+ "static/wp-content/uploads/2012/10/ljubljana-fog.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/10/loeb-car-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJbACsABJtEDgNSNPD/8hqgAD76q7AFzCwGPVhcAHQIciSmqFgKnPjUkFGd4AT/rMmsy0C1fiAuTzE5ih5O4yScs+0mKYrIZQo/bq9PuhxUoxieYWFkiSuAAA="
+ },
+ "static/wp-content/uploads/2012/10/many-doors.jpg": {
+  "w": 500,
+  "h": 333,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAADwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJYgCsIMgChVQzhtPEDd1wAP5AkmZp/nl18VoxM57SrXRymT6ILHlgPg6Qg/TJ/Ec2rKxU5y9hz9nCnQHNPsXenHUcpZ5KnJf1L0lIpesAAA=="
+ },
+ "static/wp-content/uploads/2012/10/mocha-testing.png": {
+  "w": 625,
+  "h": 950,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAAAQAwCdASoUAB4APzGGs1OuqaUisAwB0CYJZwAAeOiHTQAA/uC1L1bEdxgCe4ZDRhwAAA=="
+ },
+ "static/wp-content/uploads/2012/10/national-bibliotheque-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAABQBQCdASoUABsAPzmMulYvKSWjqA1R4CcJYwDKtEfss6C0wP0e4QaPw6BHdHqbKtF9gAAA/uf5t+8H85jcvO/yE18Q3TZhi1rm/CNI0++3ks7joqWc8bX8QGZJ64H7Kow3vTeEXQNN9bGYvSKw6hB991DC6WrInSm2XjAA"
+ },
+ "static/wp-content/uploads/2012/10/paris-panorama-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4IEYAAADQAwCdASoUAA8APzmGulQvKSWjMAgB4CcJZQDGfCHYIKZbxrnx9QAA/sMc85srorsSU2J2ZSmT9q9aSVw9A8Ity/z5oAAA"
+ },
+ "static/wp-content/uploads/2012/10/percentage-explored.png": {
+  "w": 506,
+  "h": 70,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAABQAwCdASoUAAMAPzmGulQvKSWjMAgB4CcJZwDLLCIftKNxQAD+xI29VvB10l3lonuqpXpYSy8gAAAA"
+ },
+ "static/wp-content/uploads/2012/10/pere-lachaise-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAACQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJYwAAP1zdjkH/MzQAAP0rcNkAj/oqYqI236wQSTYHLjXfx9MMaSOr2sb4CKXhZKmiOe/IxJ9QZD5hoEp1DS3VHPs0ZiCzhDUagAAA"
+ },
+ "static/wp-content/uploads/2012/10/photo-3.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/10/postcards-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAADQBACdASoUABsAPyl6tFOuJ6Uit/qoAcAlCWQAsR8mAUggIVdScl87j2XPEdy38AD+OLkcsgdwMorlosCR8dzGolgJtAQtaagclwJ+23CtyR7NZBmLzn7nGonAkOqSNKoNMV5AbJY8qKLfEApznwkAAAA="
+ },
+ "static/wp-content/uploads/2012/10/ricer_civic_2.jpg": {
+  "w": 640,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAADQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJbACo9CKeKKN+BhpI5IgA4gG77Q5hmm7hJC+FL9ElsQl+UbydllcjrIRGmV5MgCEVJTMAaCqZkQxpLE5U6YLFsv0F9AAA"
+ },
+ "static/wp-content/uploads/2012/10/sherlock-title-scene-1024x577.png": {
+  "w": 1024,
+  "h": 577
+ },
+ "static/wp-content/uploads/2012/10/sherlock-title-scene.png": {
+  "w": 1439,
+  "h": 811,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAADwAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJZQCdAB6M2PT/Yy/CeBsgAP7D8N8CaEJAj5SGYRaUNK3fFRr+FEB1sKJQYMzghmODEppXl4Ie4NVVWrbyMAAA"
+ },
+ "static/wp-content/uploads/2012/10/water-park-thing-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAACQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZQAAW72SHHxdbDRwAP6198rLkeaAaUjuyUXdbAJvfBWkQHmk2s5YVOXd3k20CylPKjF5aabgt99yUEneTj3BuKP+pvPvQ5WNkvvX6pl8qwAA"
+ },
+ "static/wp-content/uploads/2012/11/alertify.js-1024x232.png": {
+  "w": 1024,
+  "h": 232
+ },
+ "static/wp-content/uploads/2012/11/app-like-bootstrap-example.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/11/default-bootstrap-example.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/11/hellosign-1024x443.png": {
+  "w": 1024,
+  "h": 443
+ },
+ "static/wp-content/uploads/2012/11/hellosign-ipad-signing.png": {
+  "w": 768,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2012/11/hellosign-ipad.png": {
+  "w": 768,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2012/11/ia-writer-ipad-landscape.png": {
+  "w": 1024,
+  "h": 768
+ },
+ "static/wp-content/uploads/2012/11/ia-writer-ipad-portrait-clean.png": {
+  "w": 768,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2012/11/ia-writer-iphone.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/11/ia-writer-macos-1024x640.png": {
+  "w": 1024,
+  "h": 640
+ },
+ "static/wp-content/uploads/2012/11/ipad-pocket.png": {
+  "w": 1024,
+  "h": 768
+ },
+ "static/wp-content/uploads/2012/11/iphone-pocket.png": {
+  "w": 640,
+  "h": 960
+ },
+ "static/wp-content/uploads/2012/11/leanpub.com_-1024x390.png": {
+  "w": 1024,
+  "h": 390
+ },
+ "static/wp-content/uploads/2012/11/log-messages-1024x235.png": {
+  "w": 1024,
+  "h": 235
+ },
+ "static/wp-content/uploads/2012/11/nightowls-histogram.png": {
+  "w": 598,
+  "h": 368,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACwAgCdASoUAAwAPzmGulOvKSWisAgB4CcJaQAAeyAA/u6SVevAKUOJCD3uGgAA"
+ },
+ "static/wp-content/uploads/2012/11/nyan-cat-testing.png": {
+  "w": 774,
+  "h": 196,
+  "lqip": "data:image/webp;base64,UklGRjwAAABXRUJQVlA4IDAAAABwAwCdASoUAAUAPzmGuVOvKSWisAgB4CcJZwAAW7V6JSeH0AAA/r+LpMbnn8IrAAA="
+ },
+ "static/wp-content/uploads/2012/11/old-alert.png": {
+  "w": 632,
+  "h": 422,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAACQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJZwAAUyi/VhrSO15CAP7e3Ivn2kaxT8V98jri2RDxRpmLlnvqYycoi9q1hecdmYqZjNOGFWwKbVKcKB+2AAAA"
+ },
+ "static/wp-content/uploads/2012/11/pocket-macos-raw+sharing-1024x741.png": {
+  "w": 1024,
+  "h": 741
+ },
+ "static/wp-content/uploads/2012/11/pocket-macos-readability-1024x789.png": {
+  "w": 1024,
+  "h": 789
+ },
+ "static/wp-content/uploads/2012/11/Screen-Shot-2012-11-19-at-8.55.30-PM-1024x737.png": {
+  "w": 1024,
+  "h": 737
+ },
+ "static/wp-content/uploads/2012/11/Screen-Shot-2012-11-19-at-8.55.30-PM.png": {
+  "w": 1033,
+  "h": 744,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAACQAwCdASoUAA4APzmIvlOvKScisAgB4CcJZwBUfobodO1xof+AAP6Rsfd0hfnMv/PBJVh0h4pf9gGNkhWnSU2Y3mXjgjcAAAA="
+ },
+ "static/wp-content/uploads/2012/11/swizec-750words-stats.png": {
+  "w": 806,
+  "h": 101,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAAAQAwCdASoUAAMAPzmGuVOvKKWisAgB4CcJQBdgBaDzVcQA/uk4KZhxupbDCYJvB581UegizfYQAAAA"
+ },
+ "static/wp-content/uploads/2012/11/text.png": {
+  "w": 512,
+  "h": 512
+ },
+ "static/wp-content/uploads/2012/11/writeroom-screenshot-1024x640.png": {
+  "w": 1024,
+  "h": 640
+ },
+ "static/wp-content/uploads/2012/12/hemingway-gellhorn-movie1.jpg": {
+  "w": 600,
+  "h": 338,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAACwAwCdASoUAAsAPzmEuVOvKKWisAgB4CcJQBYdhDwALLRN83UrsAD+y4xkd8+jH/K4s1+LQ1pU3wMWYu6lE1NjseT6ZsLE5NZN/OxGV5sY1ianjYAAAA=="
+ },
+ "static/wp-content/uploads/2012/12/Screen-Shot-2012-12-04-at-12.47.42-PM.png": {
+  "w": 901,
+  "h": 598,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAADwAwCdASoUAA0APzmEuVOvKKWisAgB4CcJQBOkJABNUBF4RjwqymAAAP7N8J7UoqMI7bWqn6Sd9mN8MzdgdqjY1dPP5Wmp3GoteDjlNj11/i+5QyawJaac+wK0ZOh0c4vlvFjzd40GiX6nve+UvHI2VPOzXTKIcAKqSumSXNEtQcb7sgoE0ZQAAAA="
+ },
+ "static/wp-content/uploads/2012/12/Selection_084.png": {
+  "w": 827,
+  "h": 428,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAADQAgCdASoUAAoAPzmGuVOvKSWisAgB4CcJZwAAhAwAAP7uZP5dJNTHLQSDgAAA"
+ },
+ "static/wp-content/uploads/2012/12/Selection_085.png": {
+  "w": 820,
+  "h": 474,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAADwAgCdASoUAAwAPzmGulQvKSWjMAgB4CcJZwAAetEDAAD+7jAkk5pUwKr6+X4nD2mONhU+BygAAA=="
+ },
+ "static/wp-content/uploads/2012/12/Selection_090.png": {
+  "w": 713,
+  "h": 358,
+  "lqip": "data:image/webp;base64,UklGRjYAAABXRUJQVlA4ICoAAADwAgCdASoUAAoAPzmGuVOvKSWisAgB4CcJaQAAetCIAAD+7pzOp/muAAA="
+ },
+ "static/wp-content/uploads/2013/01/belgrade-train-back-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJQBfLP/wHuPxEVlHZlczuugAA/sIqSgAOADGl/Sd809dgZtN418V7PNnURSoO8xuQUY+5QtqhrMQBD8lhv//P6tPzKtHt75PGQGiNlgRT37bxEXWwk9KGbEk6SDoYOVE6PM83nZHiGkL2fLI0LEcjIAA="
+ },
+ "static/wp-content/uploads/2013/01/belgrade-train-back.jpg": {
+  "w": 1296,
+  "h": 968,
+  "lqip": "data:image/webp;base64,UklGRpYAAABXRUJQVlA4IIoAAABwBACdASoUAA8APzmEuVOvKKWisAgB4CcJYgC+YuAt/9tgAMgb6iyFZspPwAD+wipKBpRACOG1KsBi5InFd7JYjZrlS9xbF1tcBx0FJ2g9+I2E77u1tEnG4nTski4hROdrqXPBMZY2ZIRShrSnWXHUTAzfQymaBqfiC0xgt8wpV1Kln8aZ/GgkAAA="
+ },
+ "static/wp-content/uploads/2013/01/belgrade-train-back2-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRrwAAABXRUJQVlA4ILAAAAAQBQCdASoUABsAPzmOwFcvKacjqAqp4CcJQBhQgQAQ/IqVbBO+LEIag09f6ezfEbgAAP6X+At9D6fst2vgTuczy+OW361zO/5YrwDEzefZ6hoA7Ral6rBYCbenO8EL8gh0kLv5oXqJx+tK9J+ekgHBrB9XtBSkS/ryEeMkHO0kj8l7yB0Dgm2jjkkUs0QKw/7SJBvgjvchjl0PmI6U4BxNhRZKIZDJRBuxkoogY9AAAA=="
+ },
+ "static/wp-content/uploads/2013/01/commit-histogram.png": {
+  "w": 926,
+  "h": 296,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAACQAwCdASoUAAYAPzmGuVOvKSWisAgB4CcJZgCdABk/b9apUR1AAP7fdkPW+MzmijaW/zgcSYz/H9IV+KxDpOEr7PjxpcKfaW20yV6dsJZpGiepuU8RgyAKH4VAgAAA"
+ },
+ "static/wp-content/uploads/2013/01/d3.js.png": {
+  "w": 991,
+  "h": 482,
+  "lqip": "data:image/webp;base64,UklGRkoAAABXRUJQVlA4ID4AAACQAwCdASoUAAoAPzmGuVOvKSWisAgB4CcJZwAAXBscnyUrs0oAAP7UkoF0QRH/RDceHfaL2eHKBlE84QAAAA=="
+ },
+ "static/wp-content/uploads/2013/01/github-edit-octotip.png": {
+  "w": 934,
+  "h": 91,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAACwAwCdASoUAAIAPzmGulQvKSWjMAgB4CcJZQC/OCKUc0R1fr+qAAD+w/AqgaLDHcajJQAA"
+ },
+ "static/wp-content/uploads/2013/01/github-editing-step1.png": {
+  "w": 948,
+  "h": 471,
+  "lqip": "data:image/webp;base64,UklGRjgAAABXRUJQVlA4ICwAAACwAgCdASoUAAoAPzmEuVOvKKWisAgB4CcJaQAAeyAA/u4BNRa2MgvXmgAAAA=="
+ },
+ "static/wp-content/uploads/2013/01/github-editing-step2.png": {
+  "w": 939,
+  "h": 387,
+  "lqip": "data:image/webp;base64,UklGRkYAAABXRUJQVlA4IDoAAABwAwCdASoUAAgAPzmMvlUvKaajMAgB4CcJaQAAW+n810XoLQAA/fA6y5KVUpecGQHSVj/Op8MzgEAA"
+ },
+ "static/wp-content/uploads/2013/01/github-editing-step3.png": {
+  "w": 933,
+  "h": 304,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAAAwAwCdASoUAAcAPzmYvlYvLCajsAgB4CcJaQAAW+9rPVAAAP7Hdb9RFJvsmX5Ed+OfAAAA"
+ },
+ "static/wp-content/uploads/2013/01/github-editing-step4.png": {
+  "w": 940,
+  "h": 611,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAAAQAwCdASoUAA0APzmGuVOvKSWisAgB4CcJZwAAW+ll+wAA/tSalL18KHEGkxXFSim6mWjwoAA="
+ },
+ "static/wp-content/uploads/2013/01/github-editing-step6.png": {
+  "w": 951,
+  "h": 532,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAABQAwCdASoUAAsAPzmGuVQvKSWjMAgB4CcJZwBTAAoiwrKMAAD+7mzaBt4ZaUbbeXtg40YDQhg08Gg4MDBpAAAA"
+ },
+ "static/wp-content/uploads/2013/01/Selection_093.png": {
+  "w": 629,
+  "h": 126,
+  "lqip": "data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAAAQAwCdASoUAAQAPzmIu1QvKSYjMAgB4CcJZwAAW+n8A8AA/tR35McmqG/QNgAA"
+ },
+ "static/wp-content/uploads/2013/01/swizec-punchcard.png": {
+  "w": 929,
+  "h": 304,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAAAQAwCdASoUAAcAPzmEuVOvKKWisAgB4CcJaQAAetEFCAAA/u6RX4R19sBgZiu/ei91xAAA"
+ },
+ "static/wp-content/uploads/2013/02/da-vinci-art-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRmwAAABXRUJQVlA4IGAAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwAAXe6kf4uAuYwu4AD925ySswIBcMk9U1891S9XZrZPd1QX6soCd88fmoR/iiVf1u0Xhi/0PZIGbdUI+jk4ZzFUF1C+IAA="
+ },
+ "static/wp-content/uploads/2013/02/da-vinci-entrance-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAADQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwDImCB7sucwi/qKigAA/mESOLwGXxoFqUpqlhE97NaasG3kniKHIwGWauDzg9BtUE7MKpri9LaMg0uErKgQ9vz4WhczWbaK+6fuJYbtO/Z726ogAA=="
+ },
+ "static/wp-content/uploads/2013/02/da-vinci-entrance.jpg": {
+  "w": 1296,
+  "h": 968,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwDImCBrvhlnwpGOphwAAP5hEji8Bl8aBalKeNJ95gK55OnZBPEUORgMxlFe/K0fEnLZS+Ct5jy7U9/w3TEt+fC0OUzUZPxMSfi5M7z2U2uhqlBgkgAA"
+ },
+ "static/wp-content/uploads/2013/02/da-vinci-robot-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRrQAAABXRUJQVlA4IKgAAAAwBQCdASoUABsAPzmIu1avKCWjsBgIAeAnCWoAsR8vxQ/zzOWjGvA1ISt/PO1K/W9DAAD9m47FllZLpdiz2tRzPMkmRUtl4k4h6lQvRHlkQwonnQXx7nfuJUoIupDzMBXBMr3ylC3+3XZwPrZHSCCc8qAlo544CUZnCNA8qoSXRtT7fJ+L7wSosZONUPImG69AVvk/05VqNtGKJN4No8wdKWuZpmEPAAA="
+ },
+ "static/wp-content/uploads/2013/02/da-vinci-vertical-takeoff-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRpwAAABXRUJQVlA4IJAAAABQBACdASoUABsAPzmEuFOvKKUisAgB4CcJQBjPg8eqJmT94pzuu3f0D69IAPlNlyV1IXU6jg7GpkgTjUdgz9ya841If6zflghX39htRiLu7A6R14yIQDP6C4h+Gyr+Ajv1mS6Q7W5jKXgDn5vezONgzaoXt1Vq+9V+mMxlcGuvT8hwwaLGW7Fw6hmxf52NAAA="
+ },
+ "static/wp-content/uploads/2013/02/longboard-glass-app.jpg": {
+  "w": 1024,
+  "h": 574,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACQAwCdASoUAAsAPzmIuVOvKSWisAgB4CcJQBhQBH2UHaWj/04AAPYDYLGZoRGXTVOY0Z6ltrj21bleF42xLpyq/6qw6dgKLA9Q8rIAAAA="
+ },
+ "static/wp-content/uploads/2013/02/longboard-glass-app1.jpg": {
+  "w": 1024,
+  "h": 574,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACQAwCdASoUAAsAPzmIuVOvKSWisAgB4CcJQBhQBH2UHaWj/04AAPYDYLGZoRGXTVOY0Z6ltrj21bleF42xLpyq/6qw6dgKLA9Q8rIAAAA="
+ },
+ "static/wp-content/uploads/2013/02/medulin-car-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRnoAAABXRUJQVlA4IG4AAAAwBACdASoUAA8APzmEuVOvKKWisAgB4CcJYwAATBI7WTaX1Axah0JEXgAA4eIIsRiul9r+q0DhSvO9a55CxneVsuZ2qNGWH74+LqxDa4I+M87N7CpYB3iUqlASu766rhByaDZhLn93sbopFyagAA=="
+ },
+ "static/wp-content/uploads/2013/02/medulin-surfboards-764x1024.jpg": {
+  "w": 764,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRqAAAABXRUJQVlA4IJQAAAAwBQCdASoUABsAPzmGvVavKCYjsBgIAeAnCWwApxQR/kZJ1g8Wmt6Z5CaWj7UPXVjkgAD9T4K9q+ZlaFFhNyCgG0TDrRtrNeY5O2QyHBtK8DsKIVGixhOhnL54xErIQuY9c4wO8TomL6LLcSwt6x53qZ+DCKdnfxjMRrh54LhrWp6sSxMuYQ1JYGAEpEePfM7RAAAA"
+ },
+ "static/wp-content/uploads/2013/02/medulin-swell-1024x764.jpg": {
+  "w": 1024,
+  "h": 764,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBgbg8m9RARfrBT6AAD+jO4OJNLVUtUW3tplbvQV8z6aOyqVaZiEpYHmdrz64hciN5ULRrhiRAAA"
+ },
+ "static/wp-content/uploads/2013/02/Selection_152-1024x587.png": {
+  "w": 1024,
+  "h": 587
+ },
+ "static/wp-content/uploads/2013/02/Selection_153-1024x576.png": {
+  "w": 1024,
+  "h": 576
+ },
+ "static/wp-content/uploads/2013/02/Selection_154-1024x558.png": {
+  "w": 1024,
+  "h": 558
+ },
+ "static/wp-content/uploads/2013/03/0007_04_04.png": {
+  "w": 607,
+  "h": 442,
+  "lqip": "data:image/webp;base64,UklGRjIAAABXRUJQVlA4ICYAAACwAgCdASoUAA8APzmGuVOvKSWisAgB4CcJaQAAeyAA/u7t1pgAAA=="
+ },
+ "static/wp-content/uploads/2013/03/0007_04_05.png": {
+  "w": 555,
+  "h": 443,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAACQAwCdASoUABAAPzmEuVOvKKWisAgB4CcJYwDA3B4iGAr8Y4AAAP7qlua/BeILAranI5/On4zfjcLCevAFHrURXwKZ6QgAAAA="
+ },
+ "static/wp-content/uploads/2013/03/diablo-characters.png": {
+  "w": 800,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRlwAAABXRUJQVlA4IFAAAACwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJYgCdABnRVFVtiYAmkAD+ufK1ynhBGabRzKt4x813k/iHPewlPnCpFvYfbl8mLfxAQjEhQRgAAA=="
+ },
+ "static/wp-content/uploads/2013/03/diablo-massacre.png": {
+  "w": 800,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRkIAAABXRUJQVlA4IDYAAAAwAwCdASoUAA0APzmGu1QvKSYjMAgB4CcJZQAAg++FxTYAAP7tlN8or5MBgr6VfDb7ItcvAAA="
+ },
+ "static/wp-content/uploads/2013/03/glitchy-spirograph.png": {
+  "w": 910,
+  "h": 890,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQAwCdASoUABQAPzmKvFUvKSYjKA1R4CcJYwDH5A0bKsgCkq0C1fAA/uqXaRnwRvC1dlcgAXi9+ZT5YMZV30RcTL8ha4AQJdcapDqr7Or1ljtBDjSCWKWe16DKsBp4IQAAAA=="
+ },
+ "static/wp-content/uploads/2013/04/bear-statue.jpg": {
+  "w": 359,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRqYAAABXRUJQVlA4IJoAAADQBACdASoUABsAPzmGuVOvKSWisAgB4CcJQBdgA8d+vuaGL1oYN/qL4l0ePqVYAAD8XmDHt+RBfbVILAu6weWvh8jRZAB+RfGeZAwbSf41LpH5kzpbgX1lkgEhzH1nAxRytBrKKOiA+0KYnTweWpnIJ6bfyP/nAjzx33+DKW44xwwxEHDuhLPMfeE7QkiEI0eHijDbKPSUjgAA"
+ },
+ "static/wp-content/uploads/2013/04/canada-parliament.jpg": {
+  "w": 640,
+  "h": 478,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAAAQBACdASoUAA8APzmGuVOvKSWisAgB4CcJbACdLwJ6TS/wAvadoMcSQAC6z3ar2FS5IYi0hWA+Y8NWBQjobRH3pJJg9J0xQeSMj7u+Wflcb95jl1L+ggpZbSW3RirDi/OI7K1YILAYUi1GAAA="
+ },
+ "static/wp-content/uploads/2013/04/confluence-of-rivers.jpg": {
+  "w": 640,
+  "h": 478,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZQAATrG29q0+ANE67tT0AP5T/qyqtCA7iJvI0RDSsBYw1AX4+Nrnc8ErTcK8GKXZuoXi5DQqtXCB5ludkouy/n4QzzXINjyHWh1UAAA="
+ },
+ "static/wp-content/uploads/2013/04/elevator-welcome.jpg": {
+  "w": 359,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRtgAAABXRUJQVlA4IMwAAABQBgCdASoUABsAPzmGvVavKCYjsBgIAeAnCUAXYLUEpnkgCWK3aIU+D9xVyetFE7bo/9L0bROElQNKAADcDr7F5PVqhj+HETmn+1qkzwg2l0M6I8HSuIG6YYVc4xuXAb8UIBWVNoWMrMMjDvkuEvlbuHTNoj/LYTpzBfHA0F4hqhNj60met4q8SdRz/flbnUCoDhCA9eFn4U+K2cEWzKLlsgb725mbqsS6jpEjwywLNi6abwH3ibyU6q+PyBddN1VwGdHSom6YIRtgAAA="
+ },
+ "static/wp-content/uploads/2013/04/housey1.jpg": {
+  "w": 359,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAAAQBQCdASoUABsAPzmSu1gvKiWjqAqp4CcJQBhuAiOVEvnsrbpD2CpmLmtAEfZrNHaAAP6LpG83tGxUe+HQFvhxZcealjU+a4HL7ey5rwGuNgkNWcVkeWMWsGwMlFRwIaBn/bOOozJ5iKzbkE/4Y4n5a6lmg92umlv9NWsYPukLClqoQ4AAAA=="
+ },
+ "static/wp-content/uploads/2013/04/jetfighter.jpg": {
+  "w": 640,
+  "h": 478,
+  "lqip": "data:image/webp;base64,UklGRn4AAABXRUJQVlA4IHIAAACQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJQBYdgGhL3PaI1BwAAP1pOhARYuS4djnwH0Tq8UOXSXXQsA8MyErYxKM/pX9qs/38EXOSQhAoy+LdlNbkMIdTwv5H/SxH13McJNGkbbCa+Qg9/avbR8dFQAA="
+ },
+ "static/wp-content/uploads/2013/04/lounge-mural.jpg": {
+  "w": 640,
+  "h": 478,
+  "lqip": "data:image/webp;base64,UklGRowAAABXRUJQVlA4IIAAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZQDHJn8AX8KpX25aFWiQAMwkUGGN6xWX0i6y64PVxOGL4hmyFDO7DZMIlvGFJqHs6uvma//iQsPQVPMmOY6QrIXfqRnX6Qbw7HMtkzGmeafzLYvL9RVI7x0yPqUgROgMBAp9nDQAAA=="
+ },
+ "static/wp-content/uploads/2013/04/lounge.jpg": {
+  "w": 359,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRsAAAABXRUJQVlA4ILQAAAAwBQCdASoUABsAPzmQvVgvKaYjqAqp4CcJZgDDd3gAL/Qovaloe8MetpeUoYj5yW8oAAD+2htYJsGMP0vO031NYLGyQSJ9HoYxoar3wVImFPPc5nEEBMRUweB3RTG7Tsv1c9EhEzLCH5+ZtZ4Nhw6WFfDSvUVLkvbF/6qqQJgRo1TFPaYA94caErkAOM/ZGT37oZ6EhrQ7jGvb4aJ4zqT7V6hDq/HtqerTrI+I98/svpeQAAA="
+ },
+ "static/wp-content/uploads/2013/04/museum-of-civilizations.jpg": {
+  "w": 640,
+  "h": 478,
+  "lqip": "data:image/webp;base64,UklGRpQAAABXRUJQVlA4IIgAAABwBACdASoUAA8APzmEuVOvKKWisAgB4CcJbACdLwGUAAkyZtaBD14qP5ZwaAD5Az0vqY5JkhQl9bVOgYnX1Vw/ojkNL12h55sZbLIFc9iwMrHX25rP5IShfRRmrhyLX9ajgqg8chr1WNMZdAlquIov9TBIo+0Ur0dWb+6G355eo7NuXRfv4AAA"
+ },
+ "static/wp-content/uploads/2013/04/totems.jpg": {
+  "w": 640,
+  "h": 478,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZwAAK5qHMrye8DO7AAD97rLYU+77AEtMjdDunzf0PItkGpSYo1jnUaTuWvCBSJAwkQ0vXj0CyO8QQVjbLkzZQJKzdY/DFo72Jjlm8/9j2CgAAAA="
+ },
+ "static/wp-content/uploads/2013/04/victory-bonds.jpg": {
+  "w": 359,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRtQAAABXRUJQVlA4IMgAAAAwBQCdASoUABsAPzmSu1gvKiWjqAqp4CcJQBgBmggmM3fka5MxxU/PUjAp/DDkaoBRYAD+2nbunYGUuEFAakHgJZKqtWeJChSSsOfll5Yvaa8KJ5tMgvZJEA81jM3gV2CA4NBzdd7UNviNE07VXBFEGKsk9ARxJfQNss9HvpQXHjcw0ejGi8ObckRqP5LEUr2ctsfKWTFbpLN7f6OdVb1AhP9g09Fm3Yth1awp7E33w0Sd3ZjLnnMfyIQnHWUxcDUfBVBXs9HAAA=="
+ },
+ "static/wp-content/uploads/2013/04/voodoo.jpg": {
+  "w": 359,
+  "h": 480,
+  "lqip": "data:image/webp;base64,UklGRpwAAABXRUJQVlA4IJAAAABwBQCdASoUABsAPzmOwVcvKaejqAqp4CcJQBlAAhotTHZ5BpbLyXzjHaA5nzUK92gtveoAAP5/6v0lkspN1QjMxOQ1fjMVz95yGLQgIlMSdeyy781ogKBZwgtmG6xSorzqIWPjARGIHHPRBVvzVAhu26akm6dfsH8YfVjkwv4ZvqdGIZNE1AvkBUpyONIpgAA="
+ },
+ "static/wp-content/uploads/2013/05/a-day-of-coding-1024x363.png": {
+  "w": 1024,
+  "h": 363
+ },
+ "static/wp-content/uploads/2013/05/a-day-of-coding.png": {
+  "w": 1280,
+  "h": 454
+ },
+ "static/wp-content/uploads/2013/05/Workspace-1_193-1024x363.png": {
+  "w": 1024,
+  "h": 363
+ },
+ "static/wp-content/uploads/2015/05/Screen-Shot-2015-05-07-at-14.14.47.png": {
+  "w": 600,
+  "h": 284
+ },
+ "static/wp-content/uploads/2015/05/Screen-Shot-2015-05-15-at-00.12.14.png": {
+  "w": 600,
+  "h": 281
+ },
+ "static/wp-content/uploads/2015/06/PPOWER.jpg": {
+  "w": 945,
+  "h": 509,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADQAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJZgCw7BxJJTbE4EjrIAAA/sXSnXce0pi4odFXxQf1iiBKQKoMV/INF6oNNi7gsWF8yqDQEkhe4RwGtX/T3h061LF1wKnBF+9AAA=="
+ },
+ "static/wp-content/uploads/2015/07/Screen-Shot-2015-07-31-at-00.37.39-1017x1024.png": {
+  "w": 1017,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2015/10/IMG_0795-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZQDG9CEz9+Dhv19R6AD8VAj7cBnQfR9rvUplFn7634xfHIBK8pqEYOZKulSVGzeO+UBndbIAZsbe/QmkaTWCZuwcsAAA"
+ },
+ "static/wp-content/uploads/2016/03/particles-step-5.gif": {
+  "w": 832,
+  "h": 678
+ },
+ "static/wp-content/uploads/2016/04/alphabet_2.gif": {
+  "w": 915,
+  "h": 519
+ },
+ "static/wp-content/uploads/2016/04/Screen-Shot-2016-04-12-at-02.08.11-300x122.png": {
+  "w": 300,
+  "h": 122
+ },
+ "static/wp-content/uploads/2016/04/Screen-Shot-2016-04-12-at-02.08.26-300x118.png": {
+  "w": 300,
+  "h": 118
+ },
+ "static/wp-content/uploads/2016/05/landmark-bridge-cliff-california-1024x476.jpeg": {
+  "w": 1024,
+  "h": 476,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAADQAwCdASoUAAkAPzmGu1QvKSYjMAgB4CcJZQDG9CFssZ3gKBYW8AAA/sNHlJy0YflhRBs15qCqK4yPzDGWJAAA"
+ },
+ "static/wp-content/uploads/2016/06/livecoding-12-1-1024x551.png": {
+  "w": 1024,
+  "h": 551
+ },
+ "static/wp-content/uploads/2016/06/livecoding-12-2-1024x521.png": {
+  "w": 1024,
+  "h": 521
+ },
+ "static/wp-content/uploads/2016/06/livecoding-12-3-1024x185.png": {
+  "w": 1024,
+  "h": 185
+ },
+ "static/wp-content/uploads/2016/06/Screen-Shot-2016-06-01-at-23.25.55-1024x469.png": {
+  "w": 1024,
+  "h": 469
+ },
+ "static/wp-content/uploads/2016/06/Screen-Shot-2016-06-02-at-00.31.34-1024x468.png": {
+  "w": 1024,
+  "h": 468
+ },
+ "static/wp-content/uploads/2016/08/bug-network.gif": {
+  "w": 671,
+  "h": 314
+ },
+ "static/wp-content/uploads/2016/08/chrome-eats-objects.gif": {
+  "w": 458,
+  "h": 272
+ },
+ "static/wp-content/uploads/2016/08/fetch.gif": {
+  "w": 671,
+  "h": 314
+ },
+ "static/wp-content/uploads/2016/08/firefox-works-too.gif": {
+  "w": 458,
+  "h": 272
+ },
+ "static/wp-content/uploads/2016/08/glider.gif": {
+  "w": 990,
+  "h": 495
+ },
+ "static/wp-content/uploads/2016/08/menu.png": {
+  "w": 488,
+  "h": 234
+ },
+ "static/wp-content/uploads/2016/08/purer-bug.gif": {
+  "w": 671,
+  "h": 314
+ },
+ "static/wp-content/uploads/2016/08/safari-does-not.gif": {
+  "w": 458,
+  "h": 272
+ },
+ "static/wp-content/uploads/2016/08/Screen-Shot-2016-08-14-at-23.13.04.png": {
+  "w": 313,
+  "h": 314
+ },
+ "static/wp-content/uploads/2016/08/Screen-Shot-2016-08-16-at-23.41.01-1024x486.png": {
+  "w": 1024,
+  "h": 486
+ },
+ "static/wp-content/uploads/2016/08/Screen-Shot-2016-08-17-at-00.06.19-1024x360.png": {
+  "w": 1024,
+  "h": 360
+ },
+ "static/wp-content/uploads/2016/08/Screen-Shot-2016-08-21-at-17.32.42.png": {
+  "w": 631,
+  "h": 277
+ },
+ "static/wp-content/uploads/2016/08/sideways-pins.gif": {
+  "w": 602,
+  "h": 344
+ },
+ "static/wp-content/uploads/2016/08/success-wrapper.gif": {
+  "w": 671,
+  "h": 314
+ },
+ "static/wp-content/uploads/2016/08/superagent-bug.gif": {
+  "w": 671,
+  "h": 314
+ },
+ "static/wp-content/uploads/2016/09/traffic-1.png": {
+  "w": 1348,
+  "h": 191
+ },
+ "static/wp-content/uploads/2016/10/ama.jpg": {
+  "w": 900,
+  "h": 1200,
+  "lqip": "data:image/webp;base64,UklGRroAAABXRUJQVlA4IK4AAAAwBQCdASoUABsAPzmIvFSvKSYjKA1R4CcJZAAAuYR7Ey0KfSQ+Fc7dZL3LjlFbor3CAAD2vhediFOffKcdTI0BhfVX+T5loXm8/sq220yV32SAceUxvz/44ysoWUeYFflOvKJt2BeIiZMBJPsnO+lVPZgjD35HAJX3nwSjwRjjH/iNoaXTzh460PeW8e7xXlYOMMzWYZDnEnjHWQCLcTvNwOBjRHrXQg39+F+gAAA="
+ },
+ "static/wp-content/uploads/2016/10/ljubljana.jpg": {
+  "w": 2000,
+  "h": 1114,
+  "lqip": "data:image/webp;base64,UklGRmYAAABXRUJQVlA4IFoAAABwAwCdASoUAAsAPzmEuVOvKKWisAgB4CcJZACdABZllYS8rAAA/lP6fGF39f39UNKTFObio1n7TdFjY8cteH1pAuITiXWgSHWTrkXKvfVMLONvGYQgpKk8AAA="
+ },
+ "static/wp-content/uploads/2016/10/mobx-debugging.gif": {
+  "w": 764,
+  "h": 204
+ },
+ "static/wp-content/uploads/2016/10/modal-inception.gif": {
+  "w": 662,
+  "h": 448
+ },
+ "static/wp-content/uploads/2016/10/oauth-dance.gif": {
+  "w": 956,
+  "h": 717
+ },
+ "static/wp-content/uploads/2016/10/photo-1461632830798-3adb3034e4c8-1024x684.jpeg": {
+  "w": 1024,
+  "h": 684,
+  "lqip": "data:image/webp;base64,UklGRoYAAABXRUJQVlA4IHoAAAAQBACdASoUAA0APzmEuVOvKKWisAgB4CcJbAC7ACBvjDyyQV4i1Rr/gAD+qTAbllNQz61V/TbO30tuguoJufIbZnAopKG5bsRsL4uhgS8eJNqpORsvtGRrt0/5QLpeMoIvbM4MeOvdbtWl8U5QclUW8BsxqgQ65PIAAA=="
+ },
+ "static/wp-content/uploads/2016/10/photo.png": {
+  "w": 4032,
+  "h": 3024,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAADwAgCdASoUAA8APzmGuVOvKSWwsAgCECcJZwC7AC0kAAD+5LN3iiXh7xjxxnfc6sQL4AAA"
+ },
+ "static/wp-content/uploads/2016/10/react-eject.png": {
+  "w": 460,
+  "h": 114
+ },
+ "static/wp-content/uploads/2016/10/sanfrancisco.jpg": {
+  "w": 2048,
+  "h": 1316,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAACQAwCdASoUAA0APzmEuVOvKKWisAgB4CcJYwDE2AVBuOEnoEoAAP7o6ars/FvZYRdgJJGUKAVR43EllBCzZnUEnozewK5yTKUQBDFvrkzHRtVFnyTnsE0EwLxCgAAA"
+ },
+ "static/wp-content/uploads/2016/11/3_hours_later.jpg": {
+  "w": 800,
+  "h": 600,
+  "lqip": "data:image/webp;base64,UklGRoIAAABXRUJQVlA4IHYAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYgC7ACHgTKs3dM/ZWNoAAP7QcK2fsXhGoylnRp6LjxZePQlZpf8WNrOgyAnmf0VNjGxPJ1v7qdKoRPdWlGNWKiPLf1pVI//jpLjd8vTcCnTz7rNlLajTeIJAAAAA"
+ },
+ "static/wp-content/uploads/2016/11/andrew-hoyer-tree.gif": {
+  "w": 786,
+  "h": 484
+ },
+ "static/wp-content/uploads/2016/11/broken-tree.gif": {
+  "w": 786,
+  "h": 484
+ },
+ "static/wp-content/uploads/2016/11/broken-tree2.gif": {
+  "w": 786,
+  "h": 484
+ },
+ "static/wp-content/uploads/2016/11/clicker.gif": {
+  "w": 470,
+  "h": 241
+ },
+ "static/wp-content/uploads/2016/11/clicker2.gif": {
+  "w": 470,
+  "h": 241
+ },
+ "static/wp-content/uploads/2016/11/clock-actions.gif": {
+  "w": 432,
+  "h": 258
+ },
+ "static/wp-content/uploads/2016/11/clock-example.gif": {
+  "w": 432,
+  "h": 151
+ },
+ "static/wp-content/uploads/2016/11/decorations.png": {
+  "w": 589,
+  "h": 640
+ },
+ "static/wp-content/uploads/2016/11/giphy-2.gif": {
+  "w": 480,
+  "h": 360
+ },
+ "static/wp-content/uploads/2016/11/growing-pythagoras-tree-1.gif": {
+  "w": 786,
+  "h": 484
+ },
+ "static/wp-content/uploads/2016/11/growing-pythagoras-tree.gif": {
+  "w": 786,
+  "h": 484
+ },
+ "static/wp-content/uploads/2016/11/react-virtualized-select.gif": {
+  "w": 526,
+  "h": 345
+ },
+ "static/wp-content/uploads/2016/11/Screen-Shot-2016-11-21-at-13.40.35-1024x539.png": {
+  "w": 1024,
+  "h": 539
+ },
+ "static/wp-content/uploads/2016/11/Screen-Shot-2016-11-29-at-00.29.37.png": {
+  "w": 851,
+  "h": 517
+ },
+ "static/wp-content/uploads/2016/11/Slack-for-iOS-Upload-1-1.jpg": {
+  "w": 3024,
+  "h": 3024,
+  "lqip": "data:image/webp;base64,UklGRmoAAABXRUJQVlA4IF4AAADQBACdASoUABQAPzl+ulSvJ6WjMBgMAeAnCWcAzYav8Gzrn1wFdrDGzGXvHdifAAD+uirGHUR/5oGNjkNpolE72rfSpnlIv7d84t5SNcYFhRanEq3yXN4TJig/oAAA"
+ },
+ "static/wp-content/uploads/2016/11/Slack-for-iOS-Upload-1.jpg": {
+  "w": 3024,
+  "h": 3024,
+  "lqip": "data:image/webp;base64,UklGRp4AAABXRUJQVlA4IJIAAADQBACdASoUABQAPzmGulavKKWjsBgIAeAnCUAW2QFt3m7RAVbmKWgQUOeefFTfpAD+ZFBSoHerp2UlgXBUWFRXKHNGc0Hijzrp2RUlJ60YrBvT4DEcWqyy3D++7XGpF/PTtAiNQdiq3UoRmFuDc+tkCdtocDr/ZUkxnS0Wa8JOGQQ0HBrGrQEO+CvSFAcGVgAAAA=="
+ },
+ "static/wp-content/uploads/2016/11/vanilla-dropdown.gif": {
+  "w": 526,
+  "h": 345
+ },
+ "static/wp-content/uploads/2016/12/1282786204310.jpg": {
+  "w": 522,
+  "h": 399,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZAAAW7jAJIINvR6WAAD+5yuL4pAH+0mIoKmWpCcW+vbOzsbkG2/ADnB4SUR6cA7Tn+Cov1wutfVRX/Q1YNY79QzKBEt3tX8UbYHMgAA="
+ },
+ "static/wp-content/uploads/2016/12/corners-match-up.png": {
+  "w": 169,
+  "h": 100
+ },
+ "static/wp-content/uploads/2016/12/cyclejs-tree-small-1.gif": {
+  "w": 852,
+  "h": 395
+ },
+ "static/wp-content/uploads/2016/12/dancing-tree.gif": {
+  "w": 959,
+  "h": 631
+ },
+ "static/wp-content/uploads/2016/12/for-engineers.png": {
+  "w": 1093,
+  "h": 792
+ },
+ "static/wp-content/uploads/2016/12/i-built-a-sfaehy.jpg": {
+  "w": 600,
+  "h": 542,
+  "lqip": "data:image/webp;base64,UklGRrAAAABXRUJQVlA4IKQAAAAwBQCdASoUABIAPzmUwVmvKicjqAgB4CcJbACxH3JBY6YrZv/nWIw8gwCEXv+4lVY7gADJs2LPbT2J1e3eFpll+0YHSpqrpPiIkCIW8GhZddMkvYEvJoeJzLOSsywwDYoaIombDiJrh5NIBKTin9NjA8yKGts/J/0Gtm2dTC204fXreC/rYL+tsTbMR/WXkbKtGpVcyfEYVItvzt/iB+LAvZ4AAA=="
+ },
+ "static/wp-content/uploads/2016/12/inferno-tree-small.gif": {
+  "w": 852,
+  "h": 395
+ },
+ "static/wp-content/uploads/2016/12/new-page.png": {
+  "w": 1205,
+  "h": 648
+ },
+ "static/wp-content/uploads/2016/12/ng2-tree-small.gif": {
+  "w": 852,
+  "h": 395
+ },
+ "static/wp-content/uploads/2016/12/old-page.png": {
+  "w": 1156,
+  "h": 796
+ },
+ "static/wp-content/uploads/2016/12/optimized-rendering.gif": {
+  "w": 661,
+  "h": 632
+ },
+ "static/wp-content/uploads/2016/12/preact-tree-small.gif": {
+  "w": 852,
+  "h": 395
+ },
+ "static/wp-content/uploads/2016/12/react-tree-small.gif": {
+  "w": 852,
+  "h": 395
+ },
+ "static/wp-content/uploads/2016/12/sales-chart.png": {
+  "w": 1031,
+  "h": 502
+ },
+ "static/wp-content/uploads/2016/12/Screen-Shot-2016-12-02-at-07.59.53.png": {
+  "w": 724,
+  "h": 304
+ },
+ "static/wp-content/uploads/2016/12/Screen-Shot-2016-12-02-at-08.21.44.png": {
+  "w": 989,
+  "h": 531
+ },
+ "static/wp-content/uploads/2016/12/Screen-Shot-2016-12-05-at-00.44.43.png": {
+  "w": 846,
+  "h": 344
+ },
+ "static/wp-content/uploads/2016/12/Screen-Shot-2016-12-07-at-00.15.52.png": {
+  "w": 740,
+  "h": 71
+ },
+ "static/wp-content/uploads/2016/12/Screen-Shot-2016-12-09-at-09.49.38.png": {
+  "w": 1358,
+  "h": 431
+ },
+ "static/wp-content/uploads/2016/12/unoptimized-rendering.gif": {
+  "w": 661,
+  "h": 632
+ },
+ "static/wp-content/uploads/2016/12/vue-tree-small.gif": {
+  "w": 852,
+  "h": 395
+ },
+ "static/wp-content/uploads/2016/12/why-love.png": {
+  "w": 1207,
+  "h": 777
+ },
+ "static/wp-content/uploads/2017/01/default-app.gif": {
+  "w": 606,
+  "h": 387
+ },
+ "static/wp-content/uploads/2017/01/desert-roads.jpeg": {
+  "w": 800,
+  "h": 450,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAACwAwCdASoUAAsAPzmGu1OvKSYisAgB4CcJZwDG9BZNXjDg1uAbAACZ8LEMQbjKZdjihCy2hLx37lOU1O6DBWlAAAA="
+ },
+ "static/wp-content/uploads/2017/01/doctor_who_quote.jpg": {
+  "w": 450,
+  "h": 485,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAABwBACdASoUABUAPzmUwVmvKicjqAgB4CcJZwDBkBIo4hg/PsV2MLA/ravAAAD+5zmbRxNk3fPQmSDTcgMU1mNd4M/KmhhraJ1WPn9F6p8JH0mzNQB0mKQrmqBhkfzHRVanz+FLgt/Z7hzwHlghfsw/qFBLuzftdiIKAAAA"
+ },
+ "static/wp-content/uploads/2017/01/error-screenshot.png": {
+  "w": 878,
+  "h": 408
+ },
+ "static/wp-content/uploads/2017/01/exam-timer.gif": {
+  "w": 348,
+  "h": 73
+ },
+ "static/wp-content/uploads/2017/01/expenses_growth.png": {
+  "w": 767,
+  "h": 588
+ },
+ "static/wp-content/uploads/2017/01/flights-diagram-screenshot.png": {
+  "w": 1094,
+  "h": 854
+ },
+ "static/wp-content/uploads/2017/01/Image-uploaded-from-iOS-1.jpg": {
+  "w": 1512,
+  "h": 1512,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAADQBACdASoUABQAPzmSwFmvKaajqAgB4CcJZAAALH6xsuW5K/6nK0kpP/RV3v08AAD+y9WdUzECDawwVpqNwWuyWCMX5ETyAzb/8YsURbQygP1vPXfQjw7kcKRE8BuvFJOMG8k248SHuIRLFcHD5XIcpgY6qY9y8iVXGHstjst2WYGBcAAAAA=="
+ },
+ "static/wp-content/uploads/2017/01/initial-simulator-screenshot-1.png": {
+  "w": 751,
+  "h": 1355
+ },
+ "static/wp-content/uploads/2017/01/life_growth.jpg": {
+  "w": 990,
+  "h": 954,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAABQAwCdASoUABMAPzmQvVgvKaYjqAqp4CcJaQAAKdU1oBg+AAD+4G7MTpBJBwXKq431T9+wPdqHxFNtoFKHHIUAAAA="
+ },
+ "static/wp-content/uploads/2017/01/my-first-react-native-app-4.gif": {
+  "w": 629,
+  "h": 807
+ },
+ "static/wp-content/uploads/2017/01/official-docs-screenshot-3.png": {
+  "w": 1174,
+  "h": 700
+ },
+ "static/wp-content/uploads/2017/01/react-packager-screnshot-1.png": {
+  "w": 810,
+  "h": 420
+ },
+ "static/wp-content/uploads/2017/01/reactnative.com-screenshot-2.png": {
+  "w": 1222,
+  "h": 753
+ },
+ "static/wp-content/uploads/2017/01/Screen-Shot-2017-01-11-at-00.37.00.png": {
+  "w": 775,
+  "h": 311
+ },
+ "static/wp-content/uploads/2017/01/Screen-Shot-2017-01-11-at-00.38.28.png": {
+  "w": 446,
+  "h": 117
+ },
+ "static/wp-content/uploads/2017/01/time-diagram-1.jpg": {
+  "w": 600,
+  "h": 800,
+  "lqip": "data:image/webp;base64,UklGRlQAAABXRUJQVlA4IEgAAADQAwCdASoUABsAPzmItlQvKSSjMBgMAeAnCWcAzFgQra0eCXrs3YAA/tMw3NfayY3jYMISY86M6Asey1IdaxsKJDHj1YAAAAA="
+ },
+ "static/wp-content/uploads/2017/01/time-diagram-2.jpg": {
+  "w": 600,
+  "h": 800,
+  "lqip": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4IEYAAABwAwCdASoUABsAPzmAu1OvJ7+isBgMA/AnCWcAADqrBXN+9gAA/ugAvF7qbkca6Xwx/IHx0kr9uMF/ya8k2TGjjH3AQAAA"
+ },
+ "static/wp-content/uploads/2017/02/bouncing-marbles-1.gif": {
+  "w": 1030,
+  "h": 710
+ },
+ "static/wp-content/uploads/2017/02/bursty-map-1.gif": {
+  "w": 1291,
+  "h": 564
+ },
+ "static/wp-content/uploads/2017/02/colored-grid.png": {
+  "w": 569,
+  "h": 569
+ },
+ "static/wp-content/uploads/2017/02/colorful-dots.gif": {
+  "w": 573,
+  "h": 564
+ },
+ "static/wp-content/uploads/2017/02/colourful-map.gif": {
+  "w": 1108,
+  "h": 557
+ },
+ "static/wp-content/uploads/2017/02/drag-1.gif": {
+  "w": 921,
+  "h": 516
+ },
+ "static/wp-content/uploads/2017/02/map-screenshot.png": {
+  "w": 1024,
+  "h": 566
+ },
+ "static/wp-content/uploads/2017/02/map-with-all-curves.png": {
+  "w": 873,
+  "h": 457
+ },
+ "static/wp-content/uploads/2017/02/map.gif": {
+  "w": 1108,
+  "h": 557
+ },
+ "static/wp-content/uploads/2017/02/midpoint-screenshot.jpg": {
+  "w": 799,
+  "h": 449
+ },
+ "static/wp-content/uploads/2017/02/sprite.png": {
+  "w": 800,
+  "h": 600,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAAAwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZgAAW+sbrGhYAP7qjqFxIBTyFXFC1buhuKO7dm9k3I/NbG6W68iW/s7lmAGmqwGhAQBEr1QScAAA"
+ },
+ "static/wp-content/uploads/2017/02/uk-migrations.gif": {
+  "w": 1291,
+  "h": 564
+ },
+ "static/wp-content/uploads/2017/02/weird-color-scale.png": {
+  "w": 1140,
+  "h": 1154
+ },
+ "static/wp-content/uploads/2017/03/algorithm-pic.png": {
+  "w": 747,
+  "h": 420
+ },
+ "static/wp-content/uploads/2017/03/base-collision.gif": {
+  "w": 616,
+  "h": 589
+ },
+ "static/wp-content/uploads/2017/03/better-collisions-1.gif": {
+  "w": 958,
+  "h": 773
+ },
+ "static/wp-content/uploads/2017/03/better-collisions.gif": {
+  "w": 958,
+  "h": 773
+ },
+ "static/wp-content/uploads/2017/03/breakdown-screenshot.png": {
+  "w": 1694,
+  "h": 882
+ },
+ "static/wp-content/uploads/2017/03/dotproduct-collision.gif": {
+  "w": 616,
+  "h": 589
+ },
+ "static/wp-content/uploads/2017/03/drip-screenshot.png": {
+  "w": 2646,
+  "h": 1124
+ },
+ "static/wp-content/uploads/2017/03/gumroad-screenshot.png": {
+  "w": 1023,
+  "h": 487
+ },
+ "static/wp-content/uploads/2017/03/iterative-application.gif": {
+  "w": 958,
+  "h": 773
+ },
+ "static/wp-content/uploads/2017/03/mass-collision.gif": {
+  "w": 699,
+  "h": 647
+ },
+ "static/wp-content/uploads/2017/03/quadtree-collision.gif": {
+  "w": 616,
+  "h": 589
+ },
+ "static/wp-content/uploads/2017/03/Screen-Shot-2017-03-12-at-23.41.01.png": {
+  "w": 1075,
+  "h": 925
+ },
+ "static/wp-content/uploads/2017/03/screenshot1.png": {
+  "w": 537,
+  "h": 763
+ },
+ "static/wp-content/uploads/2017/03/swizec-with-lighting.png": {
+  "w": 544,
+  "h": 508
+ },
+ "static/wp-content/uploads/2017/03/swizec-without-lighting.png": {
+  "w": 550,
+  "h": 512
+ },
+ "static/wp-content/uploads/2017/03/together-screenshot.png": {
+  "w": 1299,
+  "h": 703
+ },
+ "static/wp-content/uploads/2017/03/traffic-chart.png": {
+  "w": 1154,
+  "h": 214
+ },
+ "static/wp-content/uploads/2017/03/users-screenshot.png": {
+  "w": 913,
+  "h": 375
+ },
+ "static/wp-content/uploads/2017/03/why-read-emails-1.png": {
+  "w": 798,
+  "h": 636
+ },
+ "static/wp-content/uploads/2017/04/gumroad-screenshot.png": {
+  "w": 1031,
+  "h": 510
+ },
+ "static/wp-content/uploads/2017/04/pexels-photo-348323-1024x576.jpeg": {
+  "w": 1024,
+  "h": 576,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAADQAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJYgCdMoBxfwYw+TAWjQAA/F3Ny69zsexrMv6SDb6IzqdLRLV7lweJ784kW/rIS8Maz1/fQ8D+vwf4D6Sd2W4K20YdLELfJeceQ6vl8X/E8AAA"
+ },
+ "static/wp-content/uploads/2017/05/histogram_screenshot.jpg": {
+  "w": 1217,
+  "h": 539
+ },
+ "static/wp-content/uploads/2017/05/localstorage_screenshot.png": {
+  "w": 2434,
+  "h": 222
+ },
+ "static/wp-content/uploads/2017/05/thishelps.jpg": {
+  "w": 4032,
+  "h": 3024,
+  "lqip": "data:image/webp;base64,UklGRkwAAABXRUJQVlA4IEAAAADQAwCdASoUAA8APzmMvlUvKaajMAgB4CcJaQAAXfEQJ73pINPmxQAA/kC3bFxHzdZH0i8JrbO/dlblyN6CF0AA"
+ },
+ "static/wp-content/uploads/2017/06/barchart-screenshot.jpg": {
+  "w": 1104,
+  "h": 790
+ },
+ "static/wp-content/uploads/2017/06/better-files-screenshot.png": {
+  "w": 1152,
+  "h": 678
+ },
+ "static/wp-content/uploads/2017/06/big-files-screenshot.png": {
+  "w": 1192,
+  "h": 664
+ },
+ "static/wp-content/uploads/2017/06/corp-screen-1.png": {
+  "w": 1904,
+  "h": 1550
+ },
+ "static/wp-content/uploads/2017/06/corp-screen-2.png": {
+  "w": 1878,
+  "h": 1540
+ },
+ "static/wp-content/uploads/2017/06/corp-screen-3.png": {
+  "w": 1756,
+  "h": 1548
+ },
+ "static/wp-content/uploads/2017/06/cubes-1.gif": {
+  "w": 792,
+  "h": 755
+ },
+ "static/wp-content/uploads/2017/06/dom-screenshot.jpg": {
+  "w": 724,
+  "h": 195
+ },
+ "static/wp-content/uploads/2017/06/email-screenshot.jpg": {
+  "w": 1082,
+  "h": 554
+ },
+ "static/wp-content/uploads/2017/06/fileprogram1.png": {
+  "w": 800,
+  "h": 449,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAADwAgCdASoUAAsAPzmEuVOvKKWoMAgB4CcJZwAARRqqAAD+0dwToH5SuXZUpEkVE0PgAA=="
+ },
+ "static/wp-content/uploads/2017/06/google-form-screenshot.jpg": {
+  "w": 1248,
+  "h": 1584
+ },
+ "static/wp-content/uploads/2017/06/image2.png": {
+  "w": 800,
+  "h": 449,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAAAwAwCdASoUAAsAPzmGulQvKSWjMAgB4CcJZwDE2Bn+hia4AP47I2MojJd8rxIVU3MAAA=="
+ },
+ "static/wp-content/uploads/2017/06/starbucks-salary.png": {
+  "w": 650,
+  "h": 287
+ },
+ "static/wp-content/uploads/2017/06/travel-app.gif": {
+  "w": 554,
+  "h": 982
+ },
+ "static/wp-content/uploads/2017/06/webpack-chart.png": {
+  "w": 2944,
+  "h": 1804
+ },
+ "static/wp-content/uploads/2017/07/chart.gif": {
+  "w": 672,
+  "h": 378
+ },
+ "static/wp-content/uploads/2017/07/fitbit-screenshot.png": {
+  "w": 2294,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2017/07/good-shit-stays.jpg": {
+  "w": 900,
+  "h": 900,
+  "lqip": "data:image/webp;base64,UklGRooAAABXRUJQVlA4IH4AAABwBACdASoUABQAPzmUwVmvKicjqAgB4CcJZQAAH7zC102RJhOiwSfC3IZFAADODLgaQb+9Nvf87pk/gLVGNBEGBkseHcTAGotqbmIR+beHlGLQW1dqJ5FnTDEbpJ+kc4p8g3UJm189xTXxmHffC6cZmCK4OmuBQVSatQMAAAA="
+ },
+ "static/wp-content/uploads/2017/07/heartrate-screenshot.png": {
+  "w": 1002,
+  "h": 478
+ },
+ "static/wp-content/uploads/2017/07/IMG_7860-1024x575.jpg": {
+  "w": 1024,
+  "h": 575,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAADQAwCdASoUAAsAPzmGuVQvKSWjMAgB4CcJYgDG9BVG8zrWhMf4YAAAojD1jPlD4WebWs592DDMhg58phy3KF841L6KBy+hqtdi1NtMH+A/jc3GJgAAAA=="
+ },
+ "static/wp-content/uploads/2017/07/swiz-face.png": {
+  "w": 1008,
+  "h": 584
+ },
+ "static/wp-content/uploads/2017/07/YT-screenshot.png": {
+  "w": 1236,
+  "h": 86
+ },
+ "static/wp-content/uploads/2017/08/2017-08-31-at-3.17-PM.png": {
+  "w": 947,
+  "h": 500
+ },
+ "static/wp-content/uploads/2017/08/code-screenshot.png": {
+  "w": 2160,
+  "h": 1598
+ },
+ "static/wp-content/uploads/2017/08/login-request-screenshot.png": {
+  "w": 2366,
+  "h": 1394
+ },
+ "static/wp-content/uploads/2017/08/login-screenshot.png": {
+  "w": 327,
+  "h": 139
+ },
+ "static/wp-content/uploads/2017/08/mr-robot.jpg": {
+  "w": 900,
+  "h": 506,
+  "lqip": "data:image/webp;base64,UklGRlAAAABXRUJQVlA4IEQAAABQAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJZQAAWlai2C5I4AD+6+KWtd62AkXDxb1DXR/WS8/bzLXww/JRhhysMgAAAA=="
+ },
+ "static/wp-content/uploads/2017/08/preserve-logs.png": {
+  "w": 850,
+  "h": 212
+ },
+ "static/wp-content/uploads/2017/08/two-different-zooms.gif": {
+  "w": 948,
+  "h": 496
+ },
+ "static/wp-content/uploads/2017/08/upvote-request-screenshot.png": {
+  "w": 1019,
+  "h": 745
+ },
+ "static/wp-content/uploads/2017/09/ar-stuff-1024x576.jpg": {
+  "w": 1024,
+  "h": 576,
+  "lqip": "data:image/webp;base64,UklGRm4AAABXRUJQVlA4IGIAAADwAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJQBbZBA/OSXdm9mWsp7wAAM0vEMQfvoAxJ4LxV6l1jjP+2OcVx6M1DzphlV3ykh2OG6vMQ6S3boG9iMm/N9sr7KGoWZ+DPQAAAA=="
+ },
+ "static/wp-content/uploads/2017/09/DJoDVIiVYAAOcPs.jpg-large.jpeg": {
+  "w": 470,
+  "h": 383,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAADwAgCdASoUABAAPzmEuVOvKKWisAgB4CcJZ2kfADe2AAD+7i832FUkvui5XsWV1HK+qakq9YAAAA=="
+ },
+ "static/wp-content/uploads/2017/09/gpu-particles-system-1024x687.gif": {
+  "w": 1024,
+  "h": 687
+ },
+ "static/wp-content/uploads/2017/09/ljubljana.jpg": {
+  "w": 740,
+  "h": 494,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAACwBACdASoUAA0APzmGuVOvKSWisAgB4CcJbACdMoMxrIBz6oDyCrmiwRvCwu2AAP5bewKKZRfiWkFYI36tmDD2WB7jm5rM36+f6UKIDOCuUZ3siFthkxV4cxAmtFcdYCjdXYWHyNAouNIFCs5QM1Ja6iyM0ihoAAA="
+ },
+ "static/wp-content/uploads/2017/09/not-all-slovenians.jpg": {
+  "w": 334,
+  "h": 302,
+  "lqip": "data:image/webp;base64,UklGRqAAAABXRUJQVlA4IJQAAADQBACdASoUABIAPzmUwFmvKiajqAgB4CcJYgC06BG0cVgxZNdrS3NrDn/T9utpAADiQwthWVoeg/qDFZP73gRw4mZ8SARkLSGyXDMMj/4bRL7A4xK/XRgR+zTC+93lqnoizySG0k0brvljmwBUA+HZja+QQts62dFdHjUa95f3aD8IXBWZxUn6Cdr2B5l2scHIIAAA"
+ },
+ "static/wp-content/uploads/2017/09/particles-1.gif": {
+  "w": 821,
+  "h": 520
+ },
+ "static/wp-content/uploads/2017/09/Screen-Shot-2017-09-03-at-19.25.21.png": {
+  "w": 544,
+  "h": 488
+ },
+ "static/wp-content/uploads/2017/09/Screen-Shot-2017-09-08-at-00.18.33.png": {
+  "w": 550,
+  "h": 425
+ },
+ "static/wp-content/uploads/2017/09/server-side-d3-no-flash.gif": {
+  "w": 824,
+  "h": 641
+ },
+ "static/wp-content/uploads/2017/09/server-side-d3.gif": {
+  "w": 824,
+  "h": 641
+ },
+ "static/wp-content/uploads/2017/10/backed-up-queue.png": {
+  "w": 958,
+  "h": 540
+ },
+ "static/wp-content/uploads/2017/10/batched-queue.png": {
+  "w": 958,
+  "h": 542
+ },
+ "static/wp-content/uploads/2017/10/DLeFQVjU8AAPDrb-1-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRpoAAABXRUJQVlA4II4AAACwAwCdASoUAA8APzmGuVOvKSWisAgB4CcJQBdgAkST1M1OHzuMQAD8yyN9JhREBBeASKBNj3qawPk0xuH3b122EW9CDt406zk36UHA/5Dc4Av44Zc2jjOaHow3pdJcfGR0GvPm+Q/LUjCiAAzUFq/yWYOH/nd7Bpwfy7fmQweJ498dTxG1JYHzizACB1AA"
+ },
+ "static/wp-content/uploads/2017/10/DLfgfdUUEAAk9xJ.jpg": {
+  "w": 720,
+  "h": 540,
+  "lqip": "data:image/webp;base64,UklGRooAAABXRUJQVlA4IH4AAACQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYgAAUoWcdv4yI2O8AP6WsKfHj6/2o5yx7a1NMFkFEN0Z1pMzXQm/TNJmW48kEKdLThzx2eL/Kbgh07DLtNxyvGn7wiCVbJQeloRwQ1OhJ/InVUxI8UuNq53lm7R1qnwfATSUsAA="
+ },
+ "static/wp-content/uploads/2017/10/l1ghtsab3r-partyparrot.gif": {
+  "w": 320,
+  "h": 229
+ },
+ "static/wp-content/uploads/2017/10/mortystill-1024x577.png": {
+  "w": 1024,
+  "h": 577
+ },
+ "static/wp-content/uploads/2017/10/quote.jpg": {
+  "w": 2560,
+  "h": 1340,
+  "lqip": "data:image/webp;base64,UklGRloAAABXRUJQVlA4IE4AAACwAwCdASoUAAoAPzmIulQvKSWjMAgB4CcJYwDG9CHglKv9ML15AAD+0M7yR+9hkrP6SxZChpkvbIfTsSbzZFD6ijNKGjpfX24FhY48IAA="
+ },
+ "static/wp-content/uploads/2017/10/Screen-Shot-2017-10-04-at-09.21.58.png": {
+  "w": 1017,
+  "h": 507
+ },
+ "static/wp-content/uploads/2017/10/This-subreddits-reaction-when-asked-how-we-make-our-gifs-look-so-damn-good-Imgur.gif": {
+  "w": 700,
+  "h": 393
+ },
+ "static/wp-content/uploads/2017/11/2017-11-02-at-10.13-AM.png": {
+  "w": 1033,
+  "h": 830
+ },
+ "static/wp-content/uploads/2017/11/cosby-facepalm.gif": {
+  "w": 400,
+  "h": 271
+ },
+ "static/wp-content/uploads/2017/11/emacs-1.png": {
+  "w": 656,
+  "h": 957
+ },
+ "static/wp-content/uploads/2017/11/new-fav-prettier.gif": {
+  "w": 630,
+  "h": 249
+ },
+ "static/wp-content/uploads/2017/11/Pokemon-celebrate.gif": {
+  "w": 500,
+  "h": 280
+ },
+ "static/wp-content/uploads/2017/11/prettier-magic-2.gif": {
+  "w": 630,
+  "h": 249
+ },
+ "static/wp-content/uploads/2017/11/prettier-magic.gif": {
+  "w": 630,
+  "h": 249
+ },
+ "static/wp-content/uploads/2017/11/Screen-Shot-2017-11-16-at-09.37.29.png": {
+  "w": 349,
+  "h": 105
+ },
+ "static/wp-content/uploads/2017/11/Screen-Shot-2017-11-20-at-09.16.40.png": {
+  "w": 1133,
+  "h": 715
+ },
+ "static/wp-content/uploads/2017/11/Screen-Shot-2017-11-28-at-23.44.45.png": {
+  "w": 713,
+  "h": 439
+ },
+ "static/wp-content/uploads/2017/11/screenshot-1.png": {
+  "w": 738,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2017/11/screenshot-2.png": {
+  "w": 408,
+  "h": 140
+ },
+ "static/wp-content/uploads/2017/11/tired-at-computer.gif": {
+  "w": 500,
+  "h": 373
+ },
+ "static/wp-content/uploads/2017/11/vscode-1.png": {
+  "w": 922,
+  "h": 955
+ },
+ "static/wp-content/uploads/2017/11/vscode-2.png": {
+  "w": 925,
+  "h": 954
+ },
+ "static/wp-content/uploads/2017/11/vscode-3.png": {
+  "w": 289,
+  "h": 286
+ },
+ "static/wp-content/uploads/2017/11/vscode-4.png": {
+  "w": 317,
+  "h": 156
+ },
+ "static/wp-content/uploads/2017/11/vscode-5.png": {
+  "w": 328,
+  "h": 140
+ },
+ "static/wp-content/uploads/2017/11/vscode-6.png": {
+  "w": 657,
+  "h": 457
+ },
+ "static/wp-content/uploads/2017/11/yuploader.gif": {
+  "w": 370,
+  "h": 260
+ },
+ "static/wp-content/uploads/2017/12/advent-of-code-day-24-graph.jpg": {
+  "w": 800,
+  "h": 600,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAADwAwCdASoUAA8APzmGulOvKKWisAgB4CcJQBOgA3SwjicflXGRQkAAAPzLCZYP6wsi94Ol3LVYsI2s+FES3TTL7yKNLgSNz/+kwAAA"
+ },
+ "static/wp-content/uploads/2017/12/advent-of-code-day20-particles-1024x575.jpg": {
+  "w": 1024,
+  "h": 575,
+  "lqip": "data:image/webp;base64,UklGRlAAAABXRUJQVlA4IEQAAACwAwCdASoUAAsAPzmMu1SvKaYjMAgB4CcJZQCw7CHgaAXV+/5sAAD+jCF4d3FsZbw+c/eq+Wc/6qYoh2Kd6wIEEhwAAA=="
+ },
+ "static/wp-content/uploads/2017/12/carbon-2.png": {
+  "w": 1634,
+  "h": 1226
+ },
+ "static/wp-content/uploads/2017/12/carbon-blockchain.png": {
+  "w": 1404,
+  "h": 1124
+ },
+ "static/wp-content/uploads/2017/12/carbon-day14-star1-1024x602.png": {
+  "w": 1024,
+  "h": 602
+ },
+ "static/wp-content/uploads/2017/12/carbon-generator.png": {
+  "w": 1172,
+  "h": 580
+ },
+ "static/wp-content/uploads/2017/12/carbon-interpreter.png": {
+  "w": 1356,
+  "h": 920
+ },
+ "static/wp-content/uploads/2017/12/carbon-spinlock.png": {
+  "w": 1528,
+  "h": 512
+ },
+ "static/wp-content/uploads/2017/12/image.png": {
+  "w": 968,
+  "h": 762
+ },
+ "static/wp-content/uploads/2017/12/screen_shot_2017-12-14_at_08.50.05.png": {
+  "w": 898,
+  "h": 252
+ },
+ "static/wp-content/uploads/2017/12/Screen-Shot-2017-12-03-at-11.06.58.png": {
+  "w": 1068,
+  "h": 788
+ },
+ "static/wp-content/uploads/2017/12/Screen-Shot-2017-12-13-at-08.14.34-inline.png": {
+  "w": 800,
+  "h": 711
+ },
+ "static/wp-content/uploads/2018/01/carbon-feature-parity.png": {
+  "w": 1506,
+  "h": 1462
+ },
+ "static/wp-content/uploads/2018/01/carbon-firebase-blockchain-sharing.png": {
+  "w": 1606,
+  "h": 2326
+ },
+ "static/wp-content/uploads/2018/01/christine-roy-343235-1024x685.jpg": {
+  "w": 1024,
+  "h": 685,
+  "lqip": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4IEwAAAAQBACdASoUAA0APzmEuVOvKKWisAgB4CcJZACo9BhoNDNrI5Lqhek3AAD+OOpW6lvlujF2Poebu3+8ioizbtsG2nu9bpbjHmjohzAA"
+ },
+ "static/wp-content/uploads/2018/01/gif.gif": {
+  "w": 860,
+  "h": 483
+ },
+ "static/wp-content/uploads/2018/01/revenue-chart.jpg": {
+  "w": 1092,
+  "h": 792
+ },
+ "static/wp-content/uploads/2018/01/Screen-Shot-2018-01-03-at-01.16.17.png": {
+  "w": 1068,
+  "h": 812
+ },
+ "static/wp-content/uploads/2018/01/Screen-Shot-on-2018-01-23-at-141356-1024x577.png": {
+  "w": 1024,
+  "h": 577
+ },
+ "static/wp-content/uploads/2018/01/ship-every-day-1.jpg": {
+  "w": 1024,
+  "h": 575,
+  "lqip": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4IFIAAACwAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJZQAAXFQKzmu77zzoAAD9TVSG7kx0d+y8FKqmOpnr0yvloEs5Z6a4hFScW13dyTr++KKE9QNQAAAA"
+ },
+ "static/wp-content/uploads/2018/01/strategic-plan.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACwBACdASoUABQAPzV+t1OvJ6Uit/VYAeAmiWIAzjgQ7/6yI+WiF2b2PBu4SixAAP7qaF+R7a3GCUOdkoTwaHif1GKgr3mbfH09WHDY8cUX7XbqmSatmLb4gSc452G237cVAa1SQAA="
+ },
+ "static/wp-content/uploads/2018/02/barchart-dom.png": {
+  "w": 600,
+  "h": 637,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAABQAwCdASoUABUAPzmMulYvKSWjqA1R4CcJaADA3BdP99lTuAD+7YJ3JEu7iyYrwW64Ul4PgDbkLCj4xsgiw1dI5YRKy/N9CJjZkDO2NXSQTgilQAAAAA=="
+ },
+ "static/wp-content/uploads/2018/02/barchartcode-data.png": {
+  "w": 600,
+  "h": 637,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAABQAwCdASoUABUAPzmUwFmvKiajqAgB4CcJYmrDWeAJ4vbogAD+7cVFXbPgOrf/XFl+JV/pN/n8CuuKMHThZyLEEsIvCH5X0nNWW5wpBtZmhBPV93FcSoAA"
+ },
+ "static/wp-content/uploads/2018/02/barchartcode.png": {
+  "w": 600,
+  "h": 637,
+  "lqip": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4IEIAAACwAwCdASoUABUAPzmUwFmvKiajqAgB4CcJaQAALnh3EtHllwJrwAD+4El+Qwu8D3jUhf45D5gnn/aPoHR49tA2AAA="
+ },
+ "static/wp-content/uploads/2018/02/carbon-2-1024x1013.png": {
+  "w": 1024,
+  "h": 1013
+ },
+ "static/wp-content/uploads/2018/02/change.jpg": {
+  "w": 1024,
+  "h": 923,
+  "lqip": "data:image/webp;base64,UklGRogAAABXRUJQVlA4IHwAAACQBACdASoUABIAPzmUwFmvKiajqAgB4CcJYwDLpAqeCT0cIekByJW8nrdK4AAA/TzNS1KDFF2+O5ZBQozAx4hLV/HoTPFn+lCNSkCgRKkkY/OMa14s4+ZGzQGOxfV5vvfoPrLiOX6G4+Qrq18hcac/wOCfAk3pmKBX6gAA"
+ },
+ "static/wp-content/uploads/2018/02/Image-uploaded-from-iOS-1-1-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRkoAAABXRUJQVlA4ID4AAABQAwCdASoUAA8APzmMu1SvKaYjMAgB4CcJZQDG9DJv3lzOwAD+6LolCf/hTN34YqWHxmn2i2C96KUgMwAAAA=="
+ },
+ "static/wp-content/uploads/2018/02/naive-js-dom.gif": {
+  "w": 772,
+  "h": 495
+ },
+ "static/wp-content/uploads/2018/02/preact-dom.gif": {
+  "w": 772,
+  "h": 495
+ },
+ "static/wp-content/uploads/2018/02/react-dom.gif": {
+  "w": 772,
+  "h": 495
+ },
+ "static/wp-content/uploads/2018/02/react-wrap-preact.png": {
+  "w": 1290,
+  "h": 1138
+ },
+ "static/wp-content/uploads/2018/02/shia-labeouf-do-it-1.gif": {
+  "w": 618,
+  "h": 340
+ },
+ "static/wp-content/uploads/2018/02/smart-js-dom.gif": {
+  "w": 772,
+  "h": 495
+ },
+ "static/wp-content/uploads/2018/03/continuous-scales.png": {
+  "w": 1434,
+  "h": 224
+ },
+ "static/wp-content/uploads/2018/03/demo-screenshot.png": {
+  "w": 862,
+  "h": 528
+ },
+ "static/wp-content/uploads/2018/03/finished-svgblackbox.png": {
+  "w": 1328,
+  "h": 1174
+ },
+ "static/wp-content/uploads/2018/03/hide-imgur-homepage-1.png": {
+  "w": 2178,
+  "h": 1596
+ },
+ "static/wp-content/uploads/2018/03/hitesh-choudhary-562332-unsplash-1024x683.jpg": {
+  "w": 1024,
+  "h": 683,
+  "lqip": "data:image/webp;base64,UklGRoYAAABXRUJQVlA4IHoAAACwAwCdASoUAA0APzmGuVOvKSWisAgB4CcJbAC7ACLfkNfF0cHqcAD43R0F7uXW5wmtMdMlYgXQgrleBjuILtiqnyHnG8xPlMMx0m6J2F3KrMh3JIfxBNLh22Rr+zvyOnORxI74PfYDg5EMp1bFmV4xIKnL3aqYD3mAAA=="
+ },
+ "static/wp-content/uploads/2018/03/hover-effect.gif": {
+  "w": 458,
+  "h": 421
+ },
+ "static/wp-content/uploads/2018/03/imgur_home_page-3.png": {
+  "w": 3360,
+  "h": 1908
+ },
+ "static/wp-content/uploads/2018/03/lch-vs-rgb.png": {
+  "w": 360,
+  "h": 262
+ },
+ "static/wp-content/uploads/2018/03/naive-transition-d3-pie.gif": {
+  "w": 1024,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/03/permissions-screenshot-3.png": {
+  "w": 964,
+  "h": 348
+ },
+ "static/wp-content/uploads/2018/03/piechart-colored-with-chromajs.png": {
+  "w": 948,
+  "h": 760
+ },
+ "static/wp-content/uploads/2018/03/react-d3-love.png": {
+  "w": 800,
+  "h": 465
+ },
+ "static/wp-content/uploads/2018/03/rock-on.gif": {
+  "w": 500,
+  "h": 336
+ },
+ "static/wp-content/uploads/2018/03/Screen-Shot-2018-03-13-at-09.42.44-1-1024x126.png": {
+  "w": 1024,
+  "h": 126
+ },
+ "static/wp-content/uploads/2018/03/Screen-Shot-2018-03-13-at-09.55.39-3.png": {
+  "w": 1998,
+  "h": 1376
+ },
+ "static/wp-content/uploads/2018/03/svgblackbox-example.gif": {
+  "w": 1280,
+  "h": 720
+ },
+ "static/wp-content/uploads/2018/03/tim-gouw-68319-unsplash-1024x685.jpg": {
+  "w": 1024,
+  "h": 685,
+  "lqip": "data:image/webp;base64,UklGRmIAAABXRUJQVlA4IFYAAADwAwCdASoUAA0APzmGulQvKSWjMAgB4CcJZgC06Bh1ceXM1HgBfeZAAP5nNnl7aJO5l067NHxA684L9uMWBM38d7RSq601Za8KICHsjEhg1omXx46AAA=="
+ },
+ "static/wp-content/uploads/2018/03/transition-pie-1.gif": {
+  "w": 1024,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/03/transition-pie.gif": {
+  "w": 1024,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/03/transition-sketch.png": {
+  "w": 800,
+  "h": 568
+ },
+ "static/wp-content/uploads/2018/04/2017-book-sales.png": {
+  "w": 2094,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/04/2018-book-sales.png": {
+  "w": 2102,
+  "h": 1008
+ },
+ "static/wp-content/uploads/2018/04/3-year-screenshot.png": {
+  "w": 2206,
+  "h": 428
+ },
+ "static/wp-content/uploads/2018/04/blogs-per-week-2017.png": {
+  "w": 1194,
+  "h": 736
+ },
+ "static/wp-content/uploads/2018/04/blogs-per-week-2018.png": {
+  "w": 1192,
+  "h": 734
+ },
+ "static/wp-content/uploads/2018/04/carbon-945x1024.png": {
+  "w": 945,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/04/chart-screenshot.png": {
+  "w": 857,
+  "h": 720
+ },
+ "static/wp-content/uploads/2018/04/d3react16.3-699x1024.png": {
+  "w": 699,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/04/firebase-blockchain-init.png": {
+  "w": 1564,
+  "h": 1102
+ },
+ "static/wp-content/uploads/2018/04/gumroad-3-year-sales.png": {
+  "w": 2130,
+  "h": 992
+ },
+ "static/wp-content/uploads/2018/04/landing-page-traffic.png": {
+  "w": 2224,
+  "h": 652
+ },
+ "static/wp-content/uploads/2018/04/Screen-Shot-on-2018-04-03-at-124014.png": {
+  "w": 3360,
+  "h": 1950
+ },
+ "static/wp-content/uploads/2018/04/screenshot-gif.gif": {
+  "w": 1280,
+  "h": 720
+ },
+ "static/wp-content/uploads/2018/04/strategic-plan.jpg": {
+  "w": 500,
+  "h": 500,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAACwBACdASoUABQAPzV+t1OvJ6Uit/VYAeAmiWIAzjgQ7/6yI+WiF2b2PBu4SixAAP7qaF+R7a3GCUOdkoTwaHif1GKgr3mbfH09WHDY8cUX7XbqmSatmLb4gSc452G237cVAa1SQAA="
+ },
+ "static/wp-content/uploads/2018/04/traffic-screenshot.png": {
+  "w": 2214,
+  "h": 652
+ },
+ "static/wp-content/uploads/2018/04/wait-for-next-block.png": {
+  "w": 1498,
+  "h": 1066
+ },
+ "static/wp-content/uploads/2018/05/datachannelopen.gif": {
+  "w": 1280,
+  "h": 720
+ },
+ "static/wp-content/uploads/2018/05/F5F63D9C-009C-4F68-A4F5-EFF20A28E0E9.png": {
+  "w": 1280,
+  "h": 720
+ },
+ "static/wp-content/uploads/2018/05/gif-of-VR-on-a-plane.gif": {
+  "w": 720,
+  "h": 405
+ },
+ "static/wp-content/uploads/2018/05/peerconnection.png": {
+  "w": 1768,
+  "h": 2542
+ },
+ "static/wp-content/uploads/2018/05/photo_may_16_1_09_35_pm.jpg": {
+  "w": 1551,
+  "h": 1405,
+  "lqip": "data:image/webp;base64,UklGRjwAAABXRUJQVlA4IDAAAADwAgCdASoUABIAPzmUwVmvKicjqAgB4CcJaQAAPaXUAAD+7l64Mt2SPzQPNiAAAAA="
+ },
+ "static/wp-content/uploads/2018/05/rtcdatachannel.png": {
+  "w": 1364,
+  "h": 1138
+ },
+ "static/wp-content/uploads/2018/05/RTCPeerConnection-process-sketch.png": {
+  "w": 1629,
+  "h": 1989
+ },
+ "static/wp-content/uploads/2018/05/Screen_Shot_2018-05-21_at_02.50.00.png": {
+  "w": 896,
+  "h": 308
+ },
+ "static/wp-content/uploads/2018/05/signalconnection.png": {
+  "w": 1582,
+  "h": 1966
+ },
+ "static/wp-content/uploads/2018/06/2560px-1925_Ford_Model_T_touring-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJQAAMNIRvkTpfEy5f9k7foAD+dNKQj1hgwr3usxPz5tsgARYRg/ArshspfvXWnQnrhftH2hEI3fJEX9d5JKtPylaaUuNuDMtELVQw2QAAAA=="
+ },
+ "static/wp-content/uploads/2018/06/accordionflow-sketch.jpg": {
+  "w": 1471,
+  "h": 1979
+ },
+ "static/wp-content/uploads/2018/06/Benz-1.jpg": {
+  "w": 800,
+  "h": 708,
+  "lqip": "data:image/webp;base64,UklGRpAAAABXRUJQVlA4IIQAAACwBACdASoUABIAPzmOuVavKaUjqA1R4CcJYwC7AA9J9bqbb5thGW3XoJZi8eoAAPKlLNxviLP351MfdpRWnpocZ8ivwF70zFv3sCc5mbqxOi54hM27QhnSUw/d+5an2y0BWb1btuTYERLMJmyf0jVRAZdOaeeGwfy5eCQfELTr7i6AAAA="
+ },
+ "static/wp-content/uploads/2018/06/component-structure1.jpg": {
+  "w": 1078,
+  "h": 1029
+ },
+ "static/wp-content/uploads/2018/06/context-app.gif": {
+  "w": 720,
+  "h": 405
+ },
+ "static/wp-content/uploads/2018/06/flamegraph-screenshot.png": {
+  "w": 2584,
+  "h": 836
+ },
+ "static/wp-content/uploads/2018/06/githubscreenshot.jpg": {
+  "w": 896,
+  "h": 580
+ },
+ "static/wp-content/uploads/2018/06/Image-from-iOS-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRoQAAABXRUJQVlA4IHgAAADwAwCdASoUAA8APzmEuVOvKKWisAgB4CcJZwAARoaQ+Ow2oI3ppcIAAP7F7JXfOfhMVBDwiJpAI0Fmn5+Gtg+ktq4LK2v+aQNTKz7gQ2jiDWgNk9YonGrLrldDiCAeXS/+Nc9/I3SyXx4frZYRlWY7MHfbUgPAAAA="
+ },
+ "static/wp-content/uploads/2018/06/realworldengineering.jpg": {
+  "w": 1536,
+  "h": 2048,
+  "lqip": "data:image/webp;base64,UklGRpIAAABXRUJQVlA4IIYAAADQBACdASoUABsAPzmIuVOvKSWisAgB4CcJQBhQBHquqPiTrXZbdXsY35iHiAZXgAD8y8ARK2XStwhPe0HvtNps9OfcajoPNXVecKZinEpTFdX7ebQ1rwjDRFTnddO2CIX/oFxH5ZPz24N1D7POmQIrNCMFKW0J+Vboj5GVkd3++XEaNWyAAA=="
+ },
+ "static/wp-content/uploads/2018/07/0_gDit71HzP-KJ9JJT-1024x1022.png": {
+  "w": 1024,
+  "h": 1022
+ },
+ "static/wp-content/uploads/2018/07/biofreeze-san-francisco-marathon-r6fbytm4.png": {
+  "w": 1220,
+  "h": 1580
+ },
+ "static/wp-content/uploads/2018/07/DiraLuPWAAERMng-768x1024.jpg": {
+  "w": 768,
+  "h": 1024,
+  "lqip": "data:image/webp;base64,UklGRnYAAABXRUJQVlA4IGoAAAAwBACdASoUABsAPzmKulYvKSWjsBgIAeAnCWUAxnwQcwB74iM1hCP7YAAA/s1WgiaZmoPsxNcrMw9/5d70Tlpjdg/zRJeJx1vn5zluzT1u/zO8crEMhNNgXXSUI4UnCIFtZ8P0nGnAAAAA"
+ },
+ "static/wp-content/uploads/2018/07/DjSeSqcVsAEUnSt.jpg": {
+  "w": 1125,
+  "h": 1205,
+  "lqip": "data:image/webp;base64,UklGRpoAAABXRUJQVlA4II4AAABQBACdASoUABUAPzmOvlevKaYjqAqp4CcJbADE6f/gHodT9gOmX7YcqK2QAP7qiW3tsKjZhhh2EHyWs/vVy1XitxO+l09aXkTKQap5AvtPptP82cdvLJnu8qEBwHlLC6M0x4VWQNx462OjRQYdh94bDwxCaizj703I/ZPxxnXdWvsg4/wugd87lvSugGAA"
+ },
+ "static/wp-content/uploads/2018/07/Feynmann_Diagram_Gluon_Radiation.svg_-1024x654.png": {
+  "w": 1024,
+  "h": 654
+ },
+ "static/wp-content/uploads/2018/07/FullSizeRender-1.jpg": {
+  "w": 1125,
+  "h": 363,
+  "lqip": "data:image/webp;base64,UklGRj4AAABXRUJQVlA4IDIAAAAwAwCdASoUAAYAPzmGulQvKSWjMAgB4CcJaQAAeu2mmnAAAP7uKK5ns16tyQwMoQAAAA=="
+ },
+ "static/wp-content/uploads/2018/07/screenshot.png": {
+  "w": 2128,
+  "h": 262
+ },
+ "static/wp-content/uploads/2018/07/sketch.jpg": {
+  "w": 1325,
+  "h": 1056,
+  "lqip": "data:image/webp;base64,UklGRjIAAABXRUJQVlA4ICYAAACwAgCdASoUABAAPzmGuVOvKSWisAgB4CcJaQAAeyAA/u7AD6QAAA=="
+ },
+ "static/wp-content/uploads/2018/07/tree-with-rounded-edges.jpg": {
+  "w": 1426,
+  "h": 850
+ },
+ "static/wp-content/uploads/2018/07/vintage.jpg": {
+  "w": 1080,
+  "h": 810,
+  "lqip": "data:image/webp;base64,UklGRnQAAABXRUJQVlA4IGgAAAAQBACdASoUAA8APzmEuVOvKKWisAgB4CcJZACdL1G4ACTLoyStFn5e8AD3jBfTosu3eNe6UIO6GgGPpb01+fjryYBIcnOBBYWVjPdfKJctIqJQd+m1eG+/9JS/HdzVjqQDm4BJTa/AAA=="
+ },
+ "static/wp-content/uploads/2018/08/CleanShot_2018-08-03_at_09.01.09-1.png": {
+  "w": 1922,
+  "h": 1146
+ },
+ "static/wp-content/uploads/2018/08/CleanShot_2018-08-03_at_09.23.27-1.png": {
+  "w": 2020,
+  "h": 1262
+ },
+ "static/wp-content/uploads/2018/08/CleanShot_2018-08-13_at_23.56.24.png": {
+  "w": 1336,
+  "h": 1014
+ },
+ "static/wp-content/uploads/2018/08/CleanShot_2018-08-14_at_00.21.14.png": {
+  "w": 1424,
+  "h": 1332
+ },
+ "static/wp-content/uploads/2018/08/CleanShot_2018-08-21_at_00.44.28@2x-1-1024x623.png": {
+  "w": 1024,
+  "h": 623
+ },
+ "static/wp-content/uploads/2018/08/CleanShot-2018-08-28-at-09.27.06@2x-772x1024.png": {
+  "w": 772,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/08/CleanShot-2018-08-28-at-09.33.17@2x-994x1024.png": {
+  "w": 994,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/08/email-debugging.gif": {
+  "w": 355,
+  "h": 770
+ },
+ "static/wp-content/uploads/2018/08/image_from_ios-576x1024.png": {
+  "w": 576,
+  "h": 1024
+ },
+ "static/wp-content/uploads/2018/08/kapture_2018-08-24_at_14.34.37.gif": {
+  "w": 1920,
+  "h": 1080
+ },
+ "static/wp-content/uploads/2018/08/kapture_2018-08-24_at_14.37.34.gif": {
+  "w": 1920,
+  "h": 1080
+ },
+ "static/wp-content/uploads/2018/08/nonsquished.png": {
+  "w": 2176,
+  "h": 1452
+ },
+ "static/wp-content/uploads/2018/08/not-responsive-at-all.png": {
+  "w": 1396,
+  "h": 1354
+ },
+ "static/wp-content/uploads/2018/08/one-big-scatterplot.png": {
+  "w": 2588,
+  "h": 1092
+ },
+ "static/wp-content/uploads/2018/08/react-d3-scatterplot-dashboard.png": {
+  "w": 2792,
+  "h": 1590
+ },
+ "static/wp-content/uploads/2018/08/scatterplots-in-a-row.png": {
+  "w": 2612,
+  "h": 576
+ },
+ "static/wp-content/uploads/2018/08/scatterplots-spaced-out.png": {
+  "w": 2660,
+  "h": 1410
+ },
+ "static/wp-content/uploads/2018/08/scatterplots-vertical-offset.png": {
+  "w": 2774,
+  "h": 690
+ },
+ "static/wp-content/uploads/2018/09/andy-macmillan-775812-unsplash-1024x680.jpg": {
+  "w": 1024,
+  "h": 680,
+  "lqip": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4IEYAAABQAwCdASoUAA0APzmIulQvKSWjMAgB4CcJaACdMoR3AARxAAD518P+2o/k7qA+3bRAJAZPROyXOyxKfa59BGO4aPKInmAA"
+ },
+ "static/wp-content/uploads/2018/09/CleanShot_2018-08-26-1024x576.png": {
+  "w": 1024,
+  "h": 576
+ },
+ "static/wp-content/uploads/2018/09/IMG_1573.jpg": {
+  "w": 600,
+  "h": 800,
+  "lqip": "data:image/webp;base64,UklGRtQAAABXRUJQVlA4IMgAAABQBQCdASoUABsAPzmOvlevKaYjqAqp4CcJQBbZAXLqaDpfFkSSCB7RapcYWQKPRcumCAAA+pkVr+pkuLIBfVIhjsHbQYWSSGlv8S0PhxRUUKM8Yl9/CrD5BkwYsT0UOhTvsPfbr3Slj3AW/XCmy8uXiJgBUmvQMJICowttcMrsmp3pZ2PDdQuaOW8yFeN4oGgMtWxSHaYPzwI5Kh0+Z+DzvFIkNLASNBe4e8fZcfsEO85ICYC0AAkJE3NrWMveOdnEFy9GFmgAAA=="
+ },
+ "static/wp-content/uploads/2018/09/success-kid.jpg": {
+  "w": 256,
+  "h": 256,
+  "lqip": "data:image/webp;base64,UklGRmQAAABXRUJQVlA4IFgAAABQBACdASoUABQAPzmIvFUvKKYjKA1R4CcJQBWAAhoTL1cndxeFOvoy7eoAAP5SNNPman7cs8cZIz1bojxdH2ygTn54kAJJqYfzoHhF3JuWcEiReBX8gAAA"
+ },
+ "static/wp-content/uploads/2018/10/81nvF-p7odL.jpg": {
+  "w": 1600,
+  "h": 2416,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAABwBACdASoUAB4APzmGt1OvKSUisAgB4CcJQBlWhDFt9gaOdoI8FAv6FVlGQAD+0M25NXnvb1aiT1kRb25oCtMbTijtaoStF2fggWqpKINxXEcBbnTyP42NMz0C++RK+od4PYoVdaL5jAE9wAA="
+ },
+ "static/wp-content/uploads/2018/10/global-execution.png": {
+  "w": 1362,
+  "h": 1095
+ },
+ "static/wp-content/uploads/2018/10/local-execution.png": {
+  "w": 1292,
+  "h": 1082
+ },
+ "static/wp-content/uploads/2018/10/Photo-Oct-05-3-21-57-PM.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRkAAAABXRUJQVlA4IDQAAADwAgCdASoUAA8APzmGuVO+qSWisAgD0CcJZQC06C0kAAD+5rHcNgEA5stwRemPIPQSlgAA"
+ },
+ "static/wp-content/uploads/2018/10/Photo-Oct-05-3-22-10-PM.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4IDgAAAAQAwCdASoUAA8APzmGuVOvKSWisAgB4CcJZQCsACzbUgQA/udz5tmade7GiibuJu9P2JJRkAAAAA=="
+ },
+ "static/wp-content/uploads/2018/10/Photo-Oct-05-3-22-29-PM.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRkoAAABXRUJQVlA4ID4AAABQAwCdASoUAA8APzmEuVOvKKWisAgB4CcJYwCw7CzbMRBEAAD+4rgdIjT/GK4zWdeKsTzwC2SgusOHNCrAAA=="
+ },
+ "static/wp-content/uploads/2018/10/stephen-king.jpg": {
+  "w": 1244,
+  "h": 454,
+  "lqip": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4IDwAAABQAwCdASoUAAcAPzmGuVOvKSWisAgB4CcJaQAAUo9edejgAAD83XbxLd4O8RemUlT8RqXbL80JlVgAAAA="
+ },
+ "static/wp-content/uploads/2018/11/animated-line.gif": {
+  "w": 1280,
+  "h": 720
+ },
+ "static/wp-content/uploads/2018/11/await1.png": {
+  "w": 892,
+  "h": 918
+ },
+ "static/wp-content/uploads/2018/11/await2-1024x392.png": {
+  "w": 1024,
+  "h": 392
+ },
+ "static/wp-content/uploads/2018/11/await3.png": {
+  "w": 958,
+  "h": 630
+ },
+ "static/wp-content/uploads/2018/11/await4-1024x421.png": {
+  "w": 1024,
+  "h": 421
+ },
+ "static/wp-content/uploads/2018/11/callbackhell.png": {
+  "w": 992,
+  "h": 850
+ },
+ "static/wp-content/uploads/2018/11/doesitprint-1024x562.png": {
+  "w": 1024,
+  "h": 562
+ },
+ "static/wp-content/uploads/2018/11/errorhandlig.png": {
+  "w": 636,
+  "h": 526
+ },
+ "static/wp-content/uploads/2018/11/gracehopper.jpg": {
+  "w": 618,
+  "h": 362,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAADwAwCdASoUAAwAPzmGuVOvKSWisAgB4CcJbAC7L1yBTu99aCONvJdAAP6BHmkjFHcT0L/NYhSInaRhA8RBSRU1LpZfZX/xs9m3+InstxeIglImvneXc8iK/kWi/2bVLR1eAFy1tQ2oOFT8BVPBAAAA"
+ },
+ "static/wp-content/uploads/2018/11/gumroad-screen-1-1024x505.png": {
+  "w": 1024,
+  "h": 505
+ },
+ "static/wp-content/uploads/2018/11/gumroad-screen-2-1024x487.png": {
+  "w": 1024,
+  "h": 487
+ },
+ "static/wp-content/uploads/2018/11/pic1.jpg": {
+  "w": 2160,
+  "h": 3840,
+  "lqip": "data:image/webp;base64,UklGRroAAABXRUJQVlA4IK4AAACwBQCdASoUACQAPzmOtlcvKaSjqqoB4CcJZADJDUAAmXo9svAkjpw3Pl8cTgorrKVnoHVnTKwA/Su11LPRCJ9lCYOc8qMgXCgrggsVwMwjGJn5Nu8vNEc6X4A47FJcOKVorIoA6NDzD/CNomBehLrSSb+4YSBZBhf/Zao1kIIGAMStzWWcl3ZnF0s39qul9aYUk1nt7CuM/eefYDtVr/oXPs+yjJFNx/nFdNW8AAA="
+ },
+ "static/wp-content/uploads/2018/11/pic2.jpg": {
+  "w": 2160,
+  "h": 3840,
+  "lqip": "data:image/webp;base64,UklGRtgAAABXRUJQVlA4IMwAAADQBQCdASoUACQAPzmIulSvKSWjKqwB4CcJaAC06BbklOGZh0Mfjzg58S8VuXvYoTFlaJc4emQAAP7Y84WDqsk/O47mFkbX+KlxiIjxK5oJ4L3PcZranuBPv/YTWb2s+DWOiSqlvx4O92DtgFtyhRDdgAh5s7SkPKM9NQVxZVRMDs4rxgLF1jh4ZZGweK6d4Tua80mhTrQhDRPwyrUi69QhTh9glQfn6px+sZ4blTMsQdCBXNW4AP1zt5OHmsChxHAlOR6aEnjLdDK5QAA="
+ },
+ "static/wp-content/uploads/2018/11/pic3.jpg": {
+  "w": 2160,
+  "h": 3840,
+  "lqip": "data:image/webp;base64,UklGRv4AAABXRUJQVlA4IPIAAAAQBgCdASoUACQAPzmQwFmvKSajqrgIAeAnCWQAnTNBPTARrBWR8en/Atc5OZXtCMDe//WPhzK4pwAA+WkztJyIh8RI4A5kj+pIMRQUQW9obEvzxbZLZVfus6TCzws4953QOlldlYJjCurYydcXwIug0ZMIPLz9Gg0Kx0DTAZNVSHzu+RQu6Qu6rxeuygQL/IJpW1qOPS37BIKoUfjzIskdd/Fsv2SaHP4DFUdLo/7aHSyPRDl2jV3jgoUa+JtICXnUF0wdJfEfwdBjSYNMFDyfcSPwH0g8qvzPPIu8GVrFi4SFuzADQxl0W545PA7x0jEAAA=="
+ },
+ "static/wp-content/uploads/2018/11/pic4.jpg": {
+  "w": 2160,
+  "h": 3840,
+  "lqip": "data:image/webp;base64,UklGRtYAAABXRUJQVlA4IMoAAADQBgCdASoUACQAPzmQuFUvKqUjKrgN+eAnCWQAqSfaw2gbv5v78pWqFi3qEdoVwkeVXjGfeIelFEuynPKoIYAA/lL8Fdj25Cfw1jC2sJ/0INsRbzj4OKow8ZXdDE8Y1Ek6KGpYsxOd8EQd4nZvJq018aiCATKyU2yOUdi4AMwHQGE1+75q9fCg1USsjQoU77cBnAsqXkdzwBwGrQBN4GCaAiGNVSUfpuA0f4LYfcksqukEAbPXNtDjwjb3W/ReimLU7waYnEgABQAA"
+ },
+ "static/wp-content/uploads/2018/11/pic5.jpg": {
+  "w": 2160,
+  "h": 3840,
+  "lqip": "data:image/webp;base64,UklGRs4AAABXRUJQVlA4IMIAAAAQBgCdASoUACQAPzmUwlovKackJWmZ4CcJagC1G4CDP5NdRQYNhsRN/fci2LW7sAU0Ct99mB8u9AAA/t2NUNyn72EPeG8iujrjbBfDMJqCYBbOTIAE/nkrt6uc33b8So2/Tgv158d9WwvdBqw1zvU0qtpC8DnAvMZBNlyhFJR7gs6PP94Ekj+8nKVaQPYeEMAEHXZ54l07OxziUUlRwLtbZVlpeM0KuA0CXVNlb+t2tLHi07Ar6jmw3WkdcwAmzgAAAA=="
+ },
+ "static/wp-content/uploads/2018/11/pic6.jpg": {
+  "w": 2160,
+  "h": 3840,
+  "lqip": "data:image/webp;base64,UklGRhABAABXRUJQVlA4IAQBAAAQBgCdASoUACQAPzmKt1WvKSUjKqwB4CcJZAC4ySGJ/gJINFvtMIurrWWz9k7cIhpmqSb2X6hCiQAA/tSxARqCBFHPsSRiqS/b9O26cdm7EjaF/DJtelcV9x8Ii/PqOF4jEfjqlS5NIAUKLYS5/p0ILcAbaYt7KxX2JptKHeG+R1JCIS0RGgCkYouSv0YnZF7wV6NS/yc/kPnNOk/Xw3vI5qS4G8IMTzUoAGiN2mrr+DdPtbhbjt4I4oz8PTuQAendpl0M8JHHb+UAji4oJGpuF6OG9X9tJxRgGG5uySurMhM/JIbnw2Ttbyk/fLXxYYtHnO/72/APohnhrBltpB/wyAAAAA=="
+ },
+ "static/wp-content/uploads/2018/11/teachable-screen-1024x940.png": {
+  "w": 1024,
+  "h": 940
+ },
+ "static/wp-content/uploads/2018/11/waitforgodot-1024x605.png": {
+  "w": 1024,
+  "h": 605
+ },
+ "static/wp-content/uploads/2018/11/waitforgodot2-1024x791.png": {
+  "w": 1024,
+  "h": 791
+ },
+ "static/wp-content/uploads/2018/11/waitforgodot3-1024x871.png": {
+  "w": 1024,
+  "h": 871
+ },
+ "static/wp-content/uploads/2018/11/waitforgodot4.png": {
+  "w": 992,
+  "h": 774
+ },
+ "static/wp-content/uploads/2018/11/whatprint2-2.png": {
+  "w": 722,
+  "h": 850
+ },
+ "static/wp-content/uploads/2018/12/christmas-stockings-1-1024x750.png": {
+  "w": 1024,
+  "h": 750
+ },
+ "static/wp-content/uploads/2018/12/monthly-revenue.png": {
+  "w": 1112,
+  "h": 804
+ },
+ "static/wp-content/uploads/2018/12/stock-market.png": {
+  "w": 736,
+  "h": 756
+ },
+ "static/wp-content/uploads/2018/12/tooltip-closeup-1.png": {
+  "w": 752,
+  "h": 558
+ },
+ "static/wp-content/uploads/2018/12/trajectory.png": {
+  "w": 898,
+  "h": 640
+ },
+ "static/wp-content/uploads/2018/12/year-in-postits.jpg": {
+  "w": 1280,
+  "h": 719,
+  "lqip": "data:image/webp;base64,UklGRnwAAABXRUJQVlA4IHAAAAAQBACdASoUAAsAPzmGuVOvKSWisAgB4CcJYwC/OCP6puph1WtNA37poAD+eTj0CU7X43ZYy1xerSx6iOtELEwzcnu62uu5b/q/mHTZooy/X9OVawxO57/xd+kS/6x5BCJyyWX/nnsG0ledM1gaAAAA"
+ },
+ "static/wp-content/uploads/2019/01/callback-screenshot-1.png": {
+  "w": 1222,
+  "h": 526
+ },
+ "static/wp-content/uploads/2019/01/CleanShot_2019-01-11_at_08.41.36@2x.png": {
+  "w": 1396,
+  "h": 748
+ },
+ "static/wp-content/uploads/2019/01/dashboard-screenshot.png": {
+  "w": 1882,
+  "h": 1198
+ },
+ "static/wp-content/uploads/2019/01/Photo_Jan_04_7_51_16_AM-e1546621167625-1024x768.jpg": {
+  "w": 1024,
+  "h": 768,
+  "lqip": "data:image/webp;base64,UklGRlYAAABXRUJQVlA4IEoAAACwAwCdASoUAA8APzmEulOvKKWisAgB4CcJZQAASpZL07+4q2rurAD+yAQKuWHRiRVJnvesG0ewxd2JTN3p2c2jB9SOjp4+RfmAAA=="
+ },
+ "static/wp-content/uploads/2019/02/IMG_0201-1024x575.jpg": {
+  "w": 1024,
+  "h": 575,
+  "lqip": "data:image/webp;base64,UklGRoAAAABXRUJQVlA4IHQAAADwAwCdASoUAAsAPzmGuVOvKSWisAgB4CcJZgCw7Bbv6d/yhwgrALOAAO+79a7zrylC/774Kmlbe2POE9GmImY9lduXO9c12R/+xEEw02Y6oYmPsSkqhfk2C7jt2DMkOpbhg09rPdMDLW0NMITmMrMUcAAAAA=="
+ },
+ "static/wp-content/uploads/2019/02/IMG_0218-1024x575.jpg": {
+  "w": 1024,
+  "h": 575,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAADwAwCdASoUAAsAPzmEuVOvKKWisAgB4CcJQBhmg/A3XWKAWRt79/AAANtWqHNyqnrrGlkw0OJHJch1R99MFDp7ZJLV0Qz8iptS6Rtn/zhA98h1agro3ZDFw/cWU0kvnMXGgEZUAAA="
+ },
+ "static/wp-content/uploads/2019/02/IMG_0234-1024x575.jpg": {
+  "w": 1024,
+  "h": 575,
+  "lqip": "data:image/webp;base64,UklGRnAAAABXRUJQVlA4IGQAAADQAwCdASoUAAsAPzmGulOvKKWisAgB4CcJaACsAAqbrYmkTAqwyQAA/rnmHTyf1ST/TlHGqPOqXzOdqzXbhJ/w6FqXHFVIrGHja9gs+CNf1uBDg8Wt2TQ2gn0ueLvW9Ky2u3oA"
+ },
+ "static/wp-content/uploads/2019/02/IMG_0266-1024x575.jpg": {
+  "w": 1024,
+  "h": 575,
+  "lqip": "data:image/webp;base64,UklGRngAAABXRUJQVlA4IGwAAADQAwCdASoUAAsAPzmGuVOvKKWisAgB4CcJQAAI1GBeBFcXja8EwAAAzKEn5FjWSr2i1SWi3W3dfdEzKb2pHUp2HD7vhlhwbioud46jqdufSurp7h/eaKVQjd0N50dDC1bSiXfOzpr/bAXWiAA="
+ },
+ "static/wp-content/uploads/2019/04/11084974_642240412543178_1151569054_n.jpg": {
+  "w": 640,
+  "h": 640,
+  "lqip": "data:image/webp;base64,UklGRnIAAABXRUJQVlA4IGYAAABQBACdASoUABQAPzmGuFOvKSUisAgB4CcJYgCdMtpCOUfeSEIkH3jJLxXAAMpyaVi3kdQjxEnJLaWqm/dFzEhbeyLEHOU+c1rYJtgGicdJsQd3p0ac3c+8OwJUb8kB1v2N7A6AAAA="
+ },
+ "static/wp-content/uploads/2019/04/CleanShot-2019-04-04-at-09.10.27@2x-1024x497.png": {
+  "w": 1024,
+  "h": 497
  }
 }

--- a/lib/wp-content.mjs
+++ b/lib/wp-content.mjs
@@ -1,0 +1,60 @@
+// Legacy WordPress-era images: articles reference them at
+// https://swizec.com/wp-content/... and the files live in static/wp-content
+// (tracked, 1.3GB — mostly unreferenced). The MDX pipeline rewrites those
+// references to root-relative /wp-content/... (same public path, so old
+// inbound links keep working), and only the ~1.1k referenced files get
+// deployed (scripts/copy-wp-content.mjs) and indexed (image manifest).
+//
+// Plain ESM shared by the remark plugin, the manifest script, the copy
+// script, and the vite dev middleware.
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const WP_URL = /^https?:\/\/(?:www\.)?swizec\.com(\/wp-content\/[^\s"'<>]+)$/i;
+
+// /wp-content/... path for a swizec.com wp-content URL (query/fragment
+// stripped — files don't have them), or null for anything else.
+export function wpContentUrlPath(url) {
+  if (!url) return null;
+  if (url.startsWith('/wp-content/')) return url.split(/[?#]/)[0];
+  const match = url.match(WP_URL);
+  return match ? match[1].split(/[?#]/)[0] : null;
+}
+
+// Absolute disk path under static/ for a /wp-content/ url path, or null when
+// the file doesn't exist. Tries the path as written first — some legacy
+// filenames literally contain percent-escapes — then decoded.
+export function wpContentDiskPath(urlPath, repoRoot = process.cwd()) {
+  const raw = path.join(repoRoot, 'static', urlPath);
+  if (existsSync(raw)) return raw;
+  try {
+    const decoded = path.join(repoRoot, 'static', decodeURIComponent(urlPath));
+    if (existsSync(decoded)) return decoded;
+  } catch {
+    /* malformed escapes */
+  }
+  return null;
+}
+
+// Every /wp-content/ url path referenced by any article, deduped.
+export function listReferencedWpContent(pagesDir = 'pages') {
+  const found = new Set();
+
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.mdx?$/.test(entry.name)) {
+        const content = readFileSync(full, 'utf8');
+        for (const m of content.matchAll(
+          /https?:\/\/(?:www\.)?swizec\.com(\/wp-content\/[^\s"'<>)]+)/gi,
+        )) {
+          found.add(m[1].split(/[?#]/)[0]);
+        }
+      }
+    }
+  };
+  walk(pagesDir);
+
+  return [...found];
+}

--- a/mdx-plugins/remark-mdx-static-files.mjs
+++ b/mdx-plugins/remark-mdx-static-files.mjs
@@ -18,6 +18,7 @@ import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { injectComponentImports } from './helpers.mjs';
+import { wpContentUrlPath, wpContentDiskPath } from '../lib/wp-content.mjs';
 
 const manifest = createRequire(import.meta.url)('../lib/image-manifest.json');
 const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
@@ -173,6 +174,49 @@ export function remarkMdxStaticFiles(options) {
     // it's not inside one.
     function walk(node, insideLink) {
       if (!node || typeof node !== 'object') return node;
+
+      // Legacy https://swizec.com/wp-content/ images whose file exists in
+      // static/wp-content: rewrite to the root-relative path (same public
+      // URL, served from this deployment) and give them the full ContentImage
+      // treatment. Refs whose files are gone stay external, as today.
+      if (node.type === 'image') {
+        const wpPath = wpContentUrlPath(node.url);
+        const diskPath = wpPath && wpContentDiskPath(wpPath, repoRoot);
+        if (diskPath) {
+          usesContentImage = true;
+          const element = {
+            type: 'mdxJsxTextElement',
+            name: 'ContentImage',
+            attributes: [
+              attr('src', wpPath),
+              attr('alt', node.alt ?? ''),
+              ...(node.title ? [attr('title', node.title)] : []),
+              ...(insideLink ? [attr('linked', jsxFalse())] : []),
+            ],
+            children: [],
+          };
+          metaJobs.push(
+            Promise.resolve(imageMeta(diskPath, getExt(wpPath))).then((meta) => {
+              if (!meta) return;
+              element.attributes.push(
+                attr('width', String(meta.width)),
+                attr('height', String(meta.height)),
+              );
+              if (meta.placeholder) element.attributes.push(attr('placeholder', meta.placeholder));
+            }),
+          );
+          return element;
+        }
+      }
+
+      // Links to wp-content files (e.g. a linked full-size image) become
+      // root-relative too, so they resolve on this deployment.
+      if (node.type === 'link') {
+        const wpPath = wpContentUrlPath(node.url);
+        if (wpPath && wpContentDiskPath(wpPath, repoRoot)) {
+          node.url = wpPath;
+        }
+      }
 
       if (node.type === 'image' && isRelative(node.url) && IMAGE_EXTS.has(getExt(node.url))) {
         const name = ensureImport(node.url);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.24.0",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build && node scripts/copy-hero-images.mjs && node scripts/patch-vercel-images.mjs",
+    "build": "vite build && node scripts/copy-hero-images.mjs && node scripts/copy-wp-content.mjs && node scripts/patch-vercel-images.mjs",
     "preview": "vite preview",
     "images": "node scripts/build-image-manifest.mjs",
     "article": "node scripts/new-article.mjs"

--- a/scripts/build-image-manifest.mjs
+++ b/scripts/build-image-manifest.mjs
@@ -10,6 +10,7 @@
 import { readdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import sharp from 'sharp';
+import { listReferencedWpContent, wpContentDiskPath } from '../lib/wp-content.mjs';
 
 const RASTER_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif', '.gif']);
 const LQIP_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif']);
@@ -27,7 +28,15 @@ const t0 = performance.now();
 const manifest = {};
 let failed = 0;
 
+// pages/ rasters + the legacy wp-content images articles actually reference
+// (static/wp-content holds 1.3GB, mostly unreferenced — only referenced files
+// are indexed, deployed, and rendered through ContentImage)
 const files = [...rasters('pages')];
+for (const urlPath of listReferencedWpContent('pages')) {
+  if (!RASTER_EXTS.has(path.extname(urlPath).toLowerCase())) continue;
+  const disk = wpContentDiskPath(urlPath);
+  if (disk) files.push(path.relative(process.cwd(), disk));
+}
 await Promise.all(
   files.map(async (file) => {
     const ext = path.extname(file).toLowerCase();

--- a/scripts/copy-wp-content.mjs
+++ b/scripts/copy-wp-content.mjs
@@ -1,0 +1,34 @@
+// Deploys the legacy wp-content images that articles actually reference.
+// static/wp-content holds 1.3GB of WordPress-era uploads, mostly unreferenced
+// — copying it wholesale would bloat every deploy. Referenced files (~1.1k,
+// ~390MB) are copied as-is to their original /wp-content/... public paths, so
+// old inbound links keep resolving; display sizes come from the image
+// optimizer like every other content image.
+import { copyFileSync, mkdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { listReferencedWpContent, wpContentDiskPath } from '../lib/wp-content.mjs';
+
+const OUT = '.vercel/output/static';
+let copied = 0;
+let missing = 0;
+let bytes = 0;
+
+for (const urlPath of listReferencedWpContent('pages')) {
+  const disk = wpContentDiskPath(urlPath);
+  if (!disk) {
+    missing++;
+    continue;
+  }
+  // Preserve the on-disk name; the static server percent-decodes request
+  // paths, so encoded references still resolve.
+  const dest = path.join(OUT, path.relative(path.join(process.cwd(), 'static'), disk));
+  mkdirSync(path.dirname(dest), { recursive: true });
+  copyFileSync(disk, dest);
+  copied++;
+  bytes += statSync(disk).size;
+}
+
+console.log(
+  `  wp-content → ${OUT}/wp-content : ${copied} copied (${(bytes / 1e6).toFixed(0)} MB)` +
+    (missing ? `, ${missing} referenced files missing from static/` : ''),
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,22 +34,30 @@ const MIME: Record<string, string> = {
 //   /page-assets/<path>  — hero images (frontmatter strings, resolved relative
 //                          to the MDX file). In prod these are copied to the
 //                          static output by scripts/copy-hero-images.mjs.
+//   /wp-content/<path>   — legacy WordPress uploads from static/wp-content;
+//                          referenced ones are copied to the static output by
+//                          scripts/copy-wp-content.mjs.
 const pagesColocatedAssets = {
   name: 'pages-colocated-assets',
   configureServer(server: { middlewares: { use: Function } }) {
     const pagesDir = path.join(process.cwd(), 'pages');
+    const staticDir = path.join(process.cwd(), 'static');
     server.middlewares.use((req: { url?: string }, res: { writeHead: Function; end: Function }, next: Function) => {
-      const url = req.url?.split('?')[0] ?? '';
+      const url = decodeURIComponent(req.url?.split('?')[0] ?? '');
+      let baseDir = pagesDir;
       let rel: string;
       if (url.startsWith('/page-assets/')) {
         rel = url.slice('/page-assets/'.length);
+      } else if (url.startsWith('/wp-content/')) {
+        baseDir = staticDir;
+        rel = url; // static/wp-content mirrors the public path
       } else if (/^\/pages\/.+\.[^./]+$/.test(url) && !/\.mdx?$/.test(url)) {
         rel = url.slice('/pages/'.length);
       } else {
         return next();
       }
-      const filePath = path.join(pagesDir, rel);
-      if (filePath !== pagesDir && !filePath.startsWith(pagesDir + path.sep)) return next(); // traversal guard
+      const filePath = path.join(baseDir, rel);
+      if (filePath !== baseDir && !filePath.startsWith(baseDir + path.sep)) return next(); // traversal guard
       let stat: fs.Stats;
       try { stat = fs.statSync(filePath); } catch { return next(); }
       if (!stat.isFile()) return next();
@@ -84,7 +92,11 @@ const vercelImageDev = {
       const width = Number(params.get('w'));
       if (!src.startsWith('/') || !IMAGE_WIDTHS.includes(width)) return next();
 
-      const filePath = path.join(process.cwd(), src);
+      // /wp-content/ lives under static/; everything else resolves from the
+      // repo root (pages/, app/assets, …)
+      const filePath = src.startsWith('/wp-content/')
+        ? path.join(process.cwd(), 'static', src)
+        : path.join(process.cwd(), src);
       if (!filePath.startsWith(process.cwd() + path.sep)) return next(); // traversal guard
       const ext = path.extname(filePath).toLowerCase();
       if (!IMAGE_MIME[ext]) return next();


### PR DESCRIPTION
Fixes the wp-content gap: ~1,100 old articles embed images at `https://swizec.com/wp-content/...`, whose files are tracked in `static/wp-content` but never reach deploys (Vite's publicDir is the gitignored `public/`) — they'd all 404 at launch.

## Same paths, full treatment

When the referenced file exists on disk, the MDX pipeline rewrites the embed to root-relative `/wp-content/...` and renders it through `ContentImage` — identical behavior to every other content image:

- **srcset** via `/_vercel/image` (optimizer fetches the deployed original)
- **intrinsic dimensions + LQIP** from the committed manifest (now 4,268 entries)
- **full-size self-link to the same `/wp-content/...` path** — old inbound links and Google Image results keep resolving
- link-wins preserved: `[![](wp-image)](elsewhere)` keeps the outer link (verified)
- refs whose files are genuinely gone (6 of 1,098) stay external, exactly as today (verified)

## Deploying 390MB, not 1.3GB

`static/wp-content` is 1.3GB / 7,978 files, mostly unreferenced — so no publicDir wholesale copy. `scripts/copy-wp-content.mjs` ships only the 1,092 referenced originals (390MB) to their original public paths. Vercel content-addresses uploads, so unchanged files cost nothing on subsequent deploys. Full-size originals (not downscaled) for parity with colocated content images — display sizes always come from the optimizer.

## Wiring

- `lib/wp-content.mjs` — shared URL↔disk resolution (query-strip + raw-then-decoded lookup, same lessons as the manifest work) used by the plugin, manifest script, copy script
- dev middleware serves `/wp-content/` from `static/` and the dev optimizer resolves wp sources there too — dev behaves exactly like prod

## Verified

Dev: the `steve-jobs` article renders `<a href="/wp-content/...">` + srcset + dims + LQIP; direct fetch 200; optimizer resize 200 (11KB from a full-size source); linked-image and missing-file edge cases correct. Build exits 0 in 2:46 with the copy step reporting 1,092/390MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)