### PR TITLE
Fix: tweet links with custom text no longer render as embeds

### DIFF
--- a/mdx-plugins/remark-swizec-embeds.mjs
+++ b/mdx-plugins/remark-swizec-embeds.mjs
@@ -17,13 +17,25 @@ function embedForUrl(url, context) {
   );
 }
 
+// Only bare autolinks embed — a link whose visible text is the URL itself.
+// [some words](https://x.com/...) stays a regular link.
+function getAutolinkUrl(link) {
+  if (!Array.isArray(link.children) || link.children.length !== 1) return null;
+
+  const [child] = link.children;
+  if (child.type !== 'text') return null;
+
+  const url = link.url.trim();
+  return child.value.trim() === url ? url : null;
+}
+
 function getStandaloneUrl(node) {
   if (!node || node.type !== 'paragraph' || !Array.isArray(node.children)) return null;
   if (node.children.length !== 1) return null;
 
   const [child] = node.children;
   if (child.type === 'text') return child.value.trim();
-  if (child.type === 'link') return child.url.trim();
+  if (child.type === 'link') return getAutolinkUrl(child);
   if (child.type === 'image') return child.url.trim();
 
   return null;


### PR DESCRIPTION
## Problem

In MDX posts, a tweet URL wrapped in a markdown link with custom text — e.g. `[pirates and architects](https://x.com/danshipper/status/...)` — still rendered as a full tweet embed instead of a plain link. Visible in [how-to-be-useful-as-a-software-architect](https://swizec.com/blog/how-to-be-useful-as-a-software-architect/), where the first bullet of the analogy list renders as an embedded tweet.

## Cause

`getStandaloneUrl` in `mdx-plugins/remark-swizec-embeds.mjs` treated any paragraph whose only child is a link as an embeddable URL, ignoring the link text entirely.

## Fix

Only treat a lone link as embeddable when it's a bare autolink — the visible link text is the URL itself. Links with human-written text always stay links.

## Verified

Ran the remark plugin over four cases:
- `- [pirates and architects](https://x.com/...)` in a list → stays a link (the bug)
- `[titled link](https://twitter.com/...)` in a paragraph → stays a link
- `[https://twitter.com/...](https://twitter.com/...)` → TweetEmbed
- bare `https://twitter.com/...` → TweetEmbed (intentional embeds unaffected)

To verify in the preview deploy: check the bullet list in the middle of the [software architect post](https://swizec.com/blog/how-to-be-useful-as-a-software-architect/) — 'pirates and architects' should be a link, and the tweet embed further down (bare URL) should still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)