### PR TITLE
Show a stale-content note on posts older than 10 years

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -21,6 +21,7 @@ import { ArticleArchive } from "../../components/article-archive"
 import { ArchiveSidebar } from "../../components/archive-sidebar"
 import { SmartLink } from "../../components/link"
 import { SparkJoy } from "../../components/sparkjoy"
+import { OldPostNote } from "../../components/old-post-note"
 import { parseArchiveFrontmatter } from "../../lib/article-archive"
 
 // Vite glob: all MDX in pages/, compiled as ES modules via @mdx-js/rollup (RSC-compatible)
@@ -130,6 +131,7 @@ export default async function Page() {
         <h1>{page.title}</h1>
         {page.subtitle && <p className="article-subtitle">{page.subtitle}</p>}
         <Byline published={page.published} />
+        {isBlogPost && <OldPostNote published={page.published} />}
         <MDXContent />
         {archiveQuery && (
           <ArticleArchive query={archiveQuery} basePath={basePath} />

--- a/app/styles.css
+++ b/app/styles.css
@@ -1029,6 +1029,16 @@ a.button:hover {
   }
 }
 
+/* ---------- Old post note: stale-content heads-up on 10+ year old posts ---------- */
+
+.old-post-note {
+  background: var(--color-background-yellow);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-hard-sm);
+  margin: 1.5rem 0;
+  padding: 0.8rem 1rem;
+}
+
 /* ---------- Archive: listing, filter note, pagination ---------- */
 
 .archive-filter-note {
@@ -1330,6 +1340,7 @@ a.button,
 .testimonial-grid blockquote :is(p, cite, strong, em, a),
 .archive-filter-note,
 .archive-filter-note :is(strong, a),
+.old-post-note,
 .sparkjoy,
 .sparkjoy :is(p, label, legend):not(.sparkjoy-error) {
   color: var(--color-on-light);

--- a/components/old-post-note.tsx
+++ b/components/old-post-note.tsx
@@ -1,12 +1,12 @@
+import { isValid, parseISO, subYears } from 'date-fns';
+
 // Posts older than 10 years get a heads-up that the content may be stale.
 // Age is computed at render (build) time from the publish date.
 export function OldPostNote({ published }: { published?: string }) {
     if (!published) return null;
 
-    const cutoff = new Date();
-    cutoff.setFullYear(cutoff.getFullYear() - 10);
-    const publishedDate = new Date(published);
-    if (Number.isNaN(publishedDate.valueOf()) || publishedDate > cutoff) {
+    const publishedDate = parseISO(published);
+    if (!isValid(publishedDate) || publishedDate > subYears(new Date(), 10)) {
         return null;
     }
 

--- a/components/old-post-note.tsx
+++ b/components/old-post-note.tsx
@@ -1,0 +1,22 @@
+// Posts older than 10 years get a heads-up that the content may be stale.
+// Age is computed at render (build) time from the publish date.
+export function OldPostNote({ published }: { published?: string }) {
+    if (!published) return null;
+
+    const cutoff = new Date();
+    cutoff.setFullYear(cutoff.getFullYear() - 10);
+    const publishedDate = new Date(published);
+    if (Number.isNaN(publishedDate.valueOf()) || publishedDate > cutoff) {
+        return null;
+    }
+
+    return (
+        <p className="old-post-note">
+            Hi 👋 you&apos;re reading a pretty old post! I started writing on
+            here back in high school and this page may not reflect my current
+            views. Recommend checking out related articles and categories down
+            below, I&apos;ve likely published more recent thoughts on this
+            topic.
+        </p>
+    );
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@vercel/postgres": "^0.10.0",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitejs/plugin-rsc": "^0.5.27",
+    "date-fns": "^4.4.0",
     "feed": "^6.0.0",
     "highlight.js": "^11.11.1",
     "lite-youtube-embed": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@vitejs/plugin-rsc':
         specifier: ^0.5.27
         version: 0.5.27(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.25.12)(yaml@2.9.0))
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       feed:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1092,6 +1095,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==, tarball: https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz}
 
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==, tarball: https://registry.npmjs.org/db0/-/db0-0.3.4.tgz}
@@ -2942,6 +2948,8 @@ snapshots:
   css-mediaquery@0.1.2: {}
 
   csstype@3.2.3: {}
+
+  date-fns@4.4.0: {}
 
   db0@0.3.4: {}
 


### PR DESCRIPTION
Blog posts published 10 or more years ago now show a note right after the byline:

> Hi 👋 you're reading a pretty old post! I started writing on here back in high school and this page may not reflect my current views. Recommend checking out related articles and categories down below, I've likely published more recent thoughts on this topic.

## Implementation

- New `components/old-post-note.tsx` — renders nothing unless the post's `published` date is over 10 years old (computed at build/render time, so posts age into the note naturally on rebuilds)
- Wired into the blog-post branch of `app/[...slug]/page.tsx`, between the byline and the MDX content
- Styled as a pastel-yellow Y2K callout (`--color-background-yellow`, hard shadow) and added to the dark-mode `--color-on-light` override list so text stays readable on the light background in both themes

## Verification

Checked in the dev server preview:
- 2008 post shows the note in light and dark mode
- July 2026 post shows no note

🤖 Generated with [Claude Code](https://claude.com/claude-code)