### PR TITLE
Add Backend and Travel + Events as parent categories

### DIFF
--- a/pages/blog/5-soloists-in-a-trench-coat/index.mdx
+++ b/pages/blog/5-soloists-in-a-trench-coat/index.mdx
@@ -3,7 +3,7 @@ title: "5 soloists in a trench coat"
 description: "Ever felt like your software team is just soloists in a trench coat? You may be right!"
 published: 2024-03-05
 content_upgrade: SeniorMindset
-categories: "Mindset, Teamwork, Scaling Fast Book, Leadership"
+categories: "Senior Mindset, Teamwork, Scaling Fast Book, Leadership"
 ---
 
 Many teams start as a group of individuals.

--- a/pages/blog/5-tips-for-effective-standups/index.mdx
+++ b/pages/blog/5-tips-for-effective-standups/index.mdx
@@ -2,7 +2,7 @@
 title: "5 tips for effective standups"
 description: "Talk about today, not yesterday"
 published: 2024-02-13
-categories: "Leadership, Teamwork, Mindset, Scaling Fast Book"
+categories: "Leadership, Teamwork, Senior Mindset, Scaling Fast Book"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/6-books-engineers-should-read/index.mdx
+++ b/pages/blog/6-books-engineers-should-read/index.mdx
@@ -3,7 +3,7 @@ title: "6 books engineers should read"
 description: "Here are 6 books I'd buy every engineer who joins my team, if I ran a team. You might like 'em too."
 published: 2024-06-29
 content_upgrade: SeniorMindset
-categories: "Books, Software Engineering, Career, Mindset"
+categories: "Books, Software Engineering, Career, Senior Mindset"
 ---
 
 Here are 6 books I'd buy every engineer who joins my team, if I ran a team. You might like 'em too.

--- a/pages/blog/90p-of-performance-is-data-access-patterns/index.mdx
+++ b/pages/blog/90p-of-performance-is-data-access-patterns/index.mdx
@@ -2,7 +2,7 @@
 title: "90% of performance is data access patterns"
 description: "Removing a single line of code slashed database CPU usage by 66% 🤘"
 published: 2024-07-26
-categories: "Software Engineering, Observability, Scaling Fast Book"
+categories: "Software Engineering, Observability, Scaling Fast Book, Backend"
 ---
 
 If you want a fast app focus on your data patterns. Here's a war story from production.

--- a/pages/blog/a-backend-service-nobody-can-grok/index.mdx
+++ b/pages/blog/a-backend-service-nobody-can-grok/index.mdx
@@ -2,7 +2,7 @@
 title: "A backend service nobody can grok"
 description: "a little case study from an upcoming book I'm writing with Manning about software rewrites"
 published: 2023-04-28
-categories: "Software Architecture, Lesson"
+categories: "Software Architecture, Lesson, Software Engineering"
 ---
 
 This is a little case study from an upcoming book I'm writing with Manning about software rewrites. I think it stands on its own and figured you'd appreciate the lessons learned. Maybe share a _"oof been there"_ laugh.

--- a/pages/blog/a-better-way-to-end-to-end-test-your-webapp/index.mdx
+++ b/pages/blog/a-better-way-to-end-to-end-test-your-webapp/index.mdx
@@ -2,7 +2,7 @@
 title: "A better way to end-to-end test your webapp"
 description: "End-to-end tests are the best way to test your webapp, but they're flaky and annoying to write. I'm trying a new agentic approach that fixes the issue."
 published: 2026-01-06
-categories: "Testing, TypeScript, AI, Frontend"
+categories: "Testing, TypeScript, AI, Frontend, Software Engineering"
 hero: ./img/e2e-testing-agent-thumbnail.png
 ---
 

--- a/pages/blog/a-few-more-thoughts-on-mentoring/index.mdx
+++ b/pages/blog/a-few-more-thoughts-on-mentoring/index.mdx
@@ -2,7 +2,7 @@
 title: "A few more thoughts on mentoring"
 description: "Wanted to share a few more thoughts on my mentoring philosophy and answer questions that readers asked"
 published: 2025-07-09
-categories: "Mindset, Reader Question, Teamwork, Leadership"
+categories: "Senior Mindset, Reader Question, Teamwork, Leadership"
 ---
 
 Wanted to share a few more thoughts on [my mentoring philosophy](https://swizec.com/blog/my-mentoring-philosophy/) and answer questions that readers asked.

--- a/pages/blog/a-flight/index.mdx
+++ b/pages/blog/a-flight/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-10-14
 redirect_from:
   - /blog/a-flight/swizec/1468
-categories: "San Francisco, Tea"
+categories: "San Francisco, Tea, Travel + Events"
 ---
 
 It is 8 o'clock airplane time and I just got caught red handed making some unauthorized tea.

--- a/pages/blog/a-great-engineer-knows-their-tools/index.mdx
+++ b/pages/blog/a-great-engineer-knows-their-tools/index.mdx
@@ -2,7 +2,7 @@
 title: "A great engineer knows their tools"
 description: 'Earlier in my career when I thought I was god''s gift to engineering but wasn''t, I failed one of those stupid interview questions that "have nothing to do with the work". It was a great question.'
 published: 2021-09-09
-categories: "Mindset, Learning, Senior Mindset"
+categories: "Senior Mindset, Learning"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/a-lesson-about-clientside-templating/index.mdx
+++ b/pages/blog/a-lesson-about-clientside-templating/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-12-19
 redirect_from:
   - /blog/a-lesson-about-client-side-templating/swizec/3208
-categories: "Client, JavaScript, jQuery, Server, Fullstack"
+categories: "Client, JavaScript, jQuery, Server, Fullstack, Backend"
 ---
 
 ![Preona Muffin Making](https://swizec.com/wp-content/uploads/2011/12/4371042134_c7431995c4_m6.jpg)

--- a/pages/blog/a-mental-framework-that-helps-you-code-faster/index.mdx
+++ b/pages/blog/a-mental-framework-that-helps-you-code-faster/index.mdx
@@ -2,7 +2,7 @@
 title: "A mental framework that helps you code faster"
 description: "What slows you down the most when you're coding or doing software engineering? I think it's how fast you make decisions"
 published: 2021-12-16
-categories: "Mindset"
+categories: "Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/a-pattern-for-composable-ui-in-flask/index.mdx
+++ b/pages/blog/a-pattern-for-composable-ui-in-flask/index.mdx
@@ -2,7 +2,7 @@
 title: "A pattern for composable UI in Flask"
 description: "Turn your unwieldy Flask codebase into manageable, composable fragments with this UI pattern. Very close to HTMX."
 published: 2025-02-08
-categories: "Technical, Fullstack, Architectural Complexity"
+categories: "Technical, Fullstack, Architectural Complexity, Software Engineering"
 ---
 
 The component model of web development has won. But how do you bring that innovation back to traditional frameworks? I've been trying to figure that out.

--- a/pages/blog/about-achieving-polymorphism-in-javascript/index.mdx
+++ b/pages/blog/about-achieving-polymorphism-in-javascript/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-10-15
 redirect_from:
   - /blog/about-achieving-polymorphism-in-javascript/swizec/6370
-categories: "API, Haskell, JavaScript, Language, Programming, Toshl"
+categories: "API, Haskell, JavaScript, Language, Programming, Toshl, Backend"
 ---
 
 Over the weekend I started working on a [node.js client library for Toshl's new API](https://github.com/Swizec/toshl.js). An old side project stopped working recently and I need to fix it because life without [frequent emails about my money](https://swizec.com/blog/a-message-from-your-future-self-2/) is disorienting as hell.

--- a/pages/blog/age/index.mdx
+++ b/pages/blog/age/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-07-02
 redirect_from:
   - /blog/age/swizec/6263
-categories: "Business, California, Silicon Valley, Slovenia, Stanford University, Startup"
+categories: "Business, California, Silicon Valley, Slovenia, Stanford University, Startup, Travel + Events"
 hero: ./img/71864a192249030907e2103ea6e70a05-tumblr_mp64iuwMuL1qekjngo1_500.jpg
 ---
 

--- a/pages/blog/ai-writes-good-tests-actually/index.mdx
+++ b/pages/blog/ai-writes-good-tests-actually/index.mdx
@@ -2,7 +2,7 @@
 title: "AI writes good tests, actually"
 description: "I've been using AI to write tests and it works surprisingly well! Here's how."
 published: 2025-03-18
-categories: "AI, Programming, Testing"
+categories: "AI, Programming, Testing, Software Engineering"
 ---
 
 You may be way ahead of me – AI writes good tests actually. It's super handy for this use-case.

--- a/pages/blog/always-have-3-answers/index.mdx
+++ b/pages/blog/always-have-3-answers/index.mdx
@@ -2,7 +2,7 @@
 title: "Always have 3 answers"
 description: "How do you stand out as an expert amid tech layoffs?"
 published: 2022-07-01
-categories: "Mindset, Interviewing, Career"
+categories: "Senior Mindset, Interviewing, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/amdahls-law-in-action-27s-to-003s-by-changing-a-function/index.mdx
+++ b/pages/blog/amdahls-law-in-action-27s-to-003s-by-changing-a-function/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-08-17
 redirect_from:
   - /blog/amdahls-law-in-action-27s-to-0-03s-by-changing-a-function/swizec/5106
-categories: "Haskell, PHP, Reddit, Database"
+categories: "Haskell, PHP, Reddit, Database, Backend"
 ---
 
 Perhaps the most important lesson I've learned while studying computer science is that of [Amdahl's law](http://en.wikipedia.org/wiki/Amdahl%27s_law "Amdahl's law").

--- a/pages/blog/are-you-annoyed-by-the-extra-space-after-your-name-name/index.mdx
+++ b/pages/blog/are-you-annoyed-by-the-extra-space-after-your-name-name/index.mdx
@@ -2,7 +2,7 @@
 title: "Are you annoyed by the extra space after your name [name|]?"
 description: "Behind the scenes of a tiny bug that survive 919 days"
 published: 2023-03-21
-categories: "TechLetterApp, Serverless, Side Project"
+categories: "TechLetterApp, Serverless, Side Project, Backend"
 ---
 
 The extra space is no more! All fixed. Here's a little backstory that I hope inspires you to build more tools for yourself.

--- a/pages/blog/are-you-playing-games-you-want-to-win/index.mdx
+++ b/pages/blog/are-you-playing-games-you-want-to-win/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Are you playing games you want to win?"
 description: "As we enter the funny week-without-time between Christmas and New Year, it's a great time to reflect. Here's a framework I like to use."
-categories: "Personal, Mindset, Thoughts, Year in Review"
+categories: "Personal, Senior Mindset, Thoughts, Year in Review"
 published: 2025-12-25
 ---
 

--- a/pages/blog/are-you-the-engineer-who-scoffs-at-high-salary-numbers/index.mdx
+++ b/pages/blog/are-you-the-engineer-who-scoffs-at-high-salary-numbers/index.mdx
@@ -2,7 +2,7 @@
 title: "Are you the engineer who scoffs at high salary numbers?"
 description: "Engineering compensation falls into groups so different that neither group even realizes the others exist. And they fight about it."
 published: 2022-03-07
-categories: "Mindset, Compensation, Salary"
+categories: "Senior Mindset, Compensation, Salary"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/askers-vs-guessers/index.mdx
+++ b/pages/blog/askers-vs-guessers/index.mdx
@@ -3,7 +3,7 @@ title: "Askers vs. Guessers"
 description: "Askers vs Guessers: the culture clash that explains half the conflicts you've ever had"
 published: 2023-11-29
 content_upgrade: SeniorMindset
-categories: "Psychology, Mindset"
+categories: "Psychology, Senior Mindset"
 ---
 
 Here's a culture clash that comes up every few weeks in various contexts: People who Just Ask and people who Guess Before Asking.

--- a/pages/blog/async-react-with-nextjs-13/index.mdx
+++ b/pages/blog/async-react-with-nextjs-13/index.mdx
@@ -2,7 +2,7 @@
 title: "Async React with NextJS 13"
 description: "We look at React's native async support and how to use it in a NextJS 13 app. Learn how to use async components, parallel loading states, and caching with React.js and NextJS 13."
 published: 2023-01-14
-categories: "ScholarStream, React, NextJS, Frontend, Technical, Serverless"
+categories: "ScholarStream, React, NextJS, Frontend, Technical, Serverless, Backend"
 ---
 
 Wanna see something cool? React is getting native async support _and you can already try it out_ 😍

--- a/pages/blog/be-action-oriented/index.mdx
+++ b/pages/blog/be-action-oriented/index.mdx
@@ -3,7 +3,7 @@ title: "Be action oriented"
 description: "Unearth the surprising connection between the CIA's Simple Sabotage Manual and your productivity, and learn how to transform tiny actions into big wins. Dive into Swizec's engaging exploration of how small actions can make a huge impact on your progress."
 published: 2024-01-16
 content_upgrade: SeniorMindset
-categories: "Mindset, Management, Productivity, Teamwork, Leadership"
+categories: "Senior Mindset, Management, Productivity, Teamwork, Leadership"
 ---
 
 The [CIA Simple Sabotage Manual](https://swizec.com/pdfs/SimpleSabotageFieldManualStrategicServicesProvisional.pdf) talks about little things you can do day-to-day to sabotage an effort. Each on its own looks silly and pointless, but over weeks and months they add up to war-winning delays.

--- a/pages/blog/be-their-shit-umbrella/index.mdx
+++ b/pages/blog/be-their-shit-umbrella/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Be their shit umbrella"
 description: "because if you go to bat for the team, the team goes to bat for you"
-categories: "Mindset, Ownership, Senior Mindset, Leadership"
+categories: "Senior Mindset, Ownership, Leadership"
 content_upgrade: SeniorMindset
 published: 2022-02-16
 ---

--- a/pages/blog/being-young-and-naive/index.mdx
+++ b/pages/blog/being-young-and-naive/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-12-04
 redirect_from:
   - /blog/being-young-and-naive/swizec/5636
-categories: "Philosophy, Slovenia"
+categories: "Philosophy, Slovenia, Travel + Events"
 ---
 
 ![InstaGotof](https://swizec.com/wp-content/uploads/2012/12/Screen-Shot-2012-12-04-at-12.47.42-PM.png "InstaGotof")

--- a/pages/blog/benchmarking-node-tornado-and-django-for-concurrency/index.mdx
+++ b/pages/blog/benchmarking-node-tornado-and-django-for-concurrency/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-04-15
 redirect_from:
   - /blog/benchmarking-node-tornado-and-django-for-concurrency/swizec/1616
-categories: "JSON, Language, PHP, Programming, Database, Ruby"
+categories: "JSON, Language, PHP, Programming, Database, Ruby, Backend"
 hero: ./img/6sGx6.png
 ---
 

--- a/pages/blog/better-is-good/index.mdx
+++ b/pages/blog/better-is-good/index.mdx
@@ -2,7 +2,7 @@
 title: "Better is good"
 description: "A small improvement that lands is better than a large improvement stuck in review"
 published: 2024-09-14
-categories: "Scaling Fast Book, Mindset, Software Engineering, Productivity"
+categories: "Scaling Fast Book, Senior Mindset, Software Engineering, Productivity"
 ---
 
 You'll never get a 6 month respite to fix the code.

--- a/pages/blog/blackbox-testing-nodejs-apps/index.mdx
+++ b/pages/blog/blackbox-testing-nodejs-apps/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-07-23
 redirect_from:
   - /blog/blackbox-testing-node-js-apps/swizec/4884
-categories: "API, JavaScript, NodeJS, Server, Testing, Fullstack, Backend"
+categories: "API, JavaScript, NodeJS, Server, Testing, Fullstack, Backend, Software Engineering"
 ---
 
 One of the best features in [Django](http://www.djangoproject.com "Django (Web framework)")is the test client that comes with the test framework -> blackbox testing baby, yeah!

--- a/pages/blog/blackbox-testing-nodejs-apps/index.mdx
+++ b/pages/blog/blackbox-testing-nodejs-apps/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-07-23
 redirect_from:
   - /blog/blackbox-testing-node-js-apps/swizec/4884
-categories: "API, JavaScript, NodeJS, Server, Testing, Fullstack"
+categories: "API, JavaScript, NodeJS, Server, Testing, Fullstack, Backend"
 ---
 
 One of the best features in [Django](http://www.djangoproject.com "Django (Web framework)")is the test client that comes with the test framework -> blackbox testing baby, yeah!

--- a/pages/blog/breaking-bounds-with-boundbreaker/index.mdx
+++ b/pages/blog/breaking-bounds-with-boundbreaker/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-02-19
 redirect_from:
   - /blog/breaking-bounds-with-boundbreaker/swizec/6003
-categories: "Silicon Valley, Slovenia"
+categories: "Silicon Valley, Slovenia, Travel + Events"
 ---
 
 > Remember to clench your butt.

--- a/pages/blog/bring-ruby-vcr-to-javascript-testing-with-capybara-and-puffingbilly/index.mdx
+++ b/pages/blog/bring-ruby-vcr-to-javascript-testing-with-capybara-and-puffingbilly/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-03-14
 redirect_from:
   - /blog/bring-ruby-vcr-to-javascript-testing-with-capybara-and-puffing-billy/swizec/6067
-categories: "JavaScript, Ruby, Testing"
+categories: "JavaScript, Ruby, Testing, Software Engineering"
 ---
 
 Let's say you are writing an application in [Ruby](http://www.ruby-lang.org/ "Ruby (programming language)"). You are probably talking to every API under the sun and are happily writing tests to make sure your code isn't failing.

--- a/pages/blog/build-simple-backends-with-gatsby-serverless-functions/index.mdx
+++ b/pages/blog/build-simple-backends-with-gatsby-serverless-functions/index.mdx
@@ -3,7 +3,7 @@ title: "Build simple backends with Gatsby Serverless Functions"
 description: "Until recently adding a little backend to your Gatsby site meant 2 options:\n1. Climbing the AWS learning curve\n2. Rewrite with NextJS\nNow there's an /api directory 😱"
 published: 2021-08-24
 content_upgrade: ServerlessHandbook
-categories: "Serverless, Podcast, Gatsby"
+categories: "Serverless, Podcast, Gatsby, Backend"
 hero: ./img/build-simple-backends-with-gatsby-serverless-functions.png
 ---
 

--- a/pages/blog/bun-first-impressions/index.mdx
+++ b/pages/blog/bun-first-impressions/index.mdx
@@ -2,7 +2,7 @@
 title: "Bun – first impressions"
 description: "I've been using Bun in a few side-projects and I like it a lot"
 published: 2023-10-20
-categories: "JavaScript, TypeScript, NodeJS, Bun"
+categories: "JavaScript, TypeScript, NodeJS, Bun, Backend"
 ---
 
 Heard of Bun? It's a new JavaScript runtime that recently reached 1.0.0. I've been using it on a few side-projects. Even at work!

--- a/pages/blog/but-if-ai-does-it-all-whats-my-job/index.mdx
+++ b/pages/blog/but-if-ai-does-it-all-whats-my-job/index.mdx
@@ -2,7 +2,7 @@
 title: '"But if AI does it all, what''s *my* job?"'
 description: "On AI, mental load, and delegation"
 published: 2026-05-09
-categories: "Mindset, Productivity, Reader Question"
+categories: "Senior Mindset, Productivity, Reader Question"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/can-you-automate-love/index.mdx
+++ b/pages/blog/can-you-automate-love/index.mdx
@@ -2,7 +2,7 @@
 title: "Can you automate love?"
 description: "What's the laziest thing you've ever built? For me it's a bot that sends cute pictures every day"
 published: 2021-03-17
-categories: "Serverless, Technical"
+categories: "Serverless, Technical, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/can-you-code-faster/index.mdx
+++ b/pages/blog/can-you-code-faster/index.mdx
@@ -2,7 +2,7 @@
 title: "Can you code faster?"
 description: "What slows you down most while coding? It's not lack of skill. It's not lack of ideas. It's uncertainty. Fear."
 published: 2021-02-26
-categories: "Opinion, Learning, Mindset"
+categories: "Opinion, Learning, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/can-you-pay-one-compliment-to-one-stranger-every-day/index.mdx
+++ b/pages/blog/can-you-pay-one-compliment-to-one-stranger-every-day/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-05-22
 redirect_from:
   - /blog/can-you-pay-one-compliment-to-one-stranger-every-day/swizec/4449
-categories: "Ljubljana, London"
+categories: "Ljubljana, London, Travel + Events"
 hero: ./img/large-2105-21057650.jpg
 ---
 

--- a/pages/blog/can-you-stay-a-senior-engineer-forever/index.mdx
+++ b/pages/blog/can-you-stay-a-senior-engineer-forever/index.mdx
@@ -3,7 +3,7 @@ title: "Can you stay a senior engineer forever?"
 description: "Here's an idea that can take the pressure off your career: Yes, you can stay a senior software engineer forever. But how?"
 published: 2022-11-24
 content_upgrade: SeniorMindset
-categories: "Reader Question, mindset, career"
+categories: "Reader Question, Senior Mindset, career"
 hero: ./img/35F4B8BB-5DC1-4246-86A4-D90E4CBFA548.png
 ---
 

--- a/pages/blog/chestertons-true-lesson/index.mdx
+++ b/pages/blog/chestertons-true-lesson/index.mdx
@@ -2,7 +2,7 @@
 title: "Chesterton's true lesson"
 description: "Too many engineers cry chestertons fence and never check why the code exists"
 published: 2025-10-29
-categories: "Mindset"
+categories: "Senior Mindset"
 ---
 
 You've heard of Chesterton's fence yes? When you see bad code DONT DELETE! It might serve a purpose you don't realize.

--- a/pages/blog/circleci-sexy-continuous-integration-for-private-repos/index.mdx
+++ b/pages/blog/circleci-sexy-continuous-integration-for-private-repos/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-07-05
 redirect_from:
   - /blog/circleci-sexy-continuous-integration-for-private-repos/swizec/6267
-categories: "Github, Heroku, Programming"
+categories: "Github, Heroku, Programming, Backend"
 ---
 
 One of the best parts of spinning up a new programming team is setting the processes up from scratch. That means fixing your past failures and, more importantly, playing with the shiny new toys.

--- a/pages/blog/clarification-on-how-ownership-makes-careers/index.mdx
+++ b/pages/blog/clarification-on-how-ownership-makes-careers/index.mdx
@@ -2,7 +2,7 @@
 title: "Clarification on how ownership makes careers"
 description: "Aa few readers wrote in with questions and objections to last week's Ownership makes careers email. Here's a few clarifications."
 published: 2023-06-26
-categories: "Mindset, Career"
+categories: "Senior Mindset, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/clever-technical-hackery-can-t-solve-the-wrong-design/index.mdx
+++ b/pages/blog/clever-technical-hackery-can-t-solve-the-wrong-design/index.mdx
@@ -2,7 +2,7 @@
 title: "Clever technical hackery can't solve the wrong design"
 description: "A simple change in perspective can help you overcome complex technical challenges and save time on future projects."
 published: 2023-03-07
-categories: "Lesson, API, Software Architecture, data modeling, UX"
+categories: "Lesson, API, Software Architecture, data modeling, UX, Backend"
 ---
 
 Do you ever get stuck on a project that the more you look at it, the harder it gets? We faced that the other week and with 1 tweak to requirements it became easy, almost trivial. Here's the story.

--- a/pages/blog/clever-technical-hackery-can-t-solve-the-wrong-design/index.mdx
+++ b/pages/blog/clever-technical-hackery-can-t-solve-the-wrong-design/index.mdx
@@ -2,7 +2,7 @@
 title: "Clever technical hackery can't solve the wrong design"
 description: "A simple change in perspective can help you overcome complex technical challenges and save time on future projects."
 published: 2023-03-07
-categories: "Lesson, API, Software Architecture, data modeling, UX, Backend"
+categories: "Lesson, API, Software Architecture, data modeling, UX, Backend, Software Engineering"
 ---
 
 Do you ever get stuck on a project that the more you look at it, the harder it gets? We faced that the other week and with 1 tweak to requirements it became easy, almost trivial. Here's the story.

--- a/pages/blog/code-yourself-out-of-the-job-2/index.mdx
+++ b/pages/blog/code-yourself-out-of-the-job-2/index.mdx
@@ -2,7 +2,7 @@
 title: "Code yourself out of the job"
 description: "Let go of your legos and let others do the work."
 published: 2025-02-19
-categories: "Teamwork, Growth, Career, Mindset, Scaling Fast Book, Leadership"
+categories: "Teamwork, Growth, Career, Senior Mindset, Scaling Fast Book, Leadership"
 ---
 
 The solution to burnout is to aggressively let others do the work. You _have to_ let others play with your legos.

--- a/pages/blog/code-yourself-out-of-the-job/index.mdx
+++ b/pages/blog/code-yourself-out-of-the-job/index.mdx
@@ -2,7 +2,7 @@
 title: "Code yourself out of the job"
 description: "Don't get stuck being a critical member of the team."
 published: 2024-03-19
-categories: "Teamwork, Growth, Career, Mindset, Scaling Fast Book, Leadership"
+categories: "Teamwork, Growth, Career, Senior Mindset, Scaling Fast Book, Leadership"
 ---
 
 Your ego loves being the critical member of a team.

--- a/pages/blog/codewithswiz-19-firebase-auth-support-in-useauth-pt1/index.mdx
+++ b/pages/blog/codewithswiz-19-firebase-auth-support-in-useauth-pt1/index.mdx
@@ -2,7 +2,7 @@
 title: "[CodeWithSwiz 19] Firebase Auth support in useAuth, pt1"
 description: "Support for Firebase Auth is one of the most requested features for useAuth and I figured what the heck, how hard can it be?"
 published: 2021-01-12
-categories: "CodeWithSwiz, Technical, Firebase, useAuth, Livecoding, State machines"
+categories: "CodeWithSwiz, Technical, Firebase, useAuth, Livecoding, State machines, Backend"
 ---
 
 Support for Firebase Auth is one of the most requested features for [useAuth](https://useauth.dev) and I figured what the heck, how hard can it be?

--- a/pages/blog/codewithswiz-20-adding-firebase-support-to-useauth-pt2/index.mdx
+++ b/pages/blog/codewithswiz-20-adding-firebase-support-to-useauth-pt2/index.mdx
@@ -2,7 +2,7 @@
 title: "[CodeWithSwiz 20] Adding Firebase support to useAuth, pt2"
 description: "Firebase continues to be 💩. No wonder people keep asking for support in useAuth. Almost there ✌️"
 published: 2021-01-19
-categories: "CodeWithSwiz, Technical, Firebase, useAuth, Livecoding"
+categories: "CodeWithSwiz, Technical, Firebase, useAuth, Livecoding, Backend"
 ---
 
 Firebase continues to be 💩. No wonder people keep asking for support in [useAuth](https://useauth.dev).

--- a/pages/blog/codewithswiz-21-useauth-beta-support-for-firebase/index.mdx
+++ b/pages/blog/codewithswiz-21-useauth-beta-support-for-firebase/index.mdx
@@ -2,7 +2,7 @@
 title: "[CodeWithSwiz 21] useAuth beta support for Firebase 🎉"
 description: "It works! useAuth has beta-level support for Firebase Auth 🥳 I did not expect that to take 3 sessions."
 published: 2021-01-26
-categories: "CodeWithSwiz, Technical, Firebase, useAuth, Livecoding"
+categories: "CodeWithSwiz, Technical, Firebase, useAuth, Livecoding, Backend"
 ---
 
 It works! [useAuth](https://useAuth.dev) has beta-level support for Firebase Auth 🥳 I did not expect that to take 3 sessions.

--- a/pages/blog/coding-forces-you-to-understand-the-problem/index.mdx
+++ b/pages/blog/coding-forces-you-to-understand-the-problem/index.mdx
@@ -2,7 +2,7 @@
 title: "Coding forces you to understand the problem"
 description: "Programming translates fuzzy understanding into exacting specifications. That’s why it’s hard. The Illusion of Explanatory Depth reigns supreme"
 published: 2022-06-22
-categories: "Mindset, Lesson, Refactoring, Scaling Fast Book, Software Engineering"
+categories: "Senior Mindset, Lesson, Refactoring, Scaling Fast Book, Software Engineering"
 content_upgrade: ScalingFast
 hero: ./img/E6C0823C-DBD7-4392-A0A0-A2D7BD1C00B4.png
 ---

--- a/pages/blog/coding-forces-you-to-understand-the-problem/index.mdx
+++ b/pages/blog/coding-forces-you-to-understand-the-problem/index.mdx
@@ -2,7 +2,7 @@
 title: "Coding forces you to understand the problem"
 description: "Programming translates fuzzy understanding into exacting specifications. That’s why it’s hard. The Illusion of Explanatory Depth reigns supreme"
 published: 2022-06-22
-categories: "Mindset, Lesson, Refactoring, Scaling Fast Book"
+categories: "Mindset, Lesson, Refactoring, Scaling Fast Book, Software Engineering"
 content_upgrade: ScalingFast
 hero: ./img/E6C0823C-DBD7-4392-A0A0-A2D7BD1C00B4.png
 ---

--- a/pages/blog/coding-is-a-brawl-not-a-battle-of-wits/index.mdx
+++ b/pages/blog/coding-is-a-brawl-not-a-battle-of-wits/index.mdx
@@ -2,7 +2,7 @@
 title: "Coding is a brawl, not a battle of wits"
 description: "Discover why coding is more like a boxing match, focused on delivering results rather than perfect technique. Learn how to navigate economic upheaval and prioritize business needs in this unexpected comparison."
 published: 2024-04-12
-categories: "Mindset, Business"
+categories: "Senior Mindset, Business"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/coding-is-the-easy-part/index.mdx
+++ b/pages/blog/coding-is-the-easy-part/index.mdx
@@ -3,7 +3,7 @@ title: "Coding is the easy part"
 description: "Behind the scenes of a vendor migration project. What senior+ engineers do so you can focus on the code."
 published: 2023-03-24
 content_upgrade: SeniorMindset
-categories: "Lesson, Mindset, Leadership"
+categories: "Lesson, Senior Mindset, Leadership"
 ---
 
 Tutorials make every project look easy. You start at the beginning and code your way to the end. Wonderful.

--- a/pages/blog/computer-science-is-not-software-engineering/index.mdx
+++ b/pages/blog/computer-science-is-not-software-engineering/index.mdx
@@ -3,7 +3,7 @@ title: "Computer science is not software engineering"
 description: "Wow, college was such a waste of time ... when did you ever invert a binary tree outside of an interview? Honestly I never inverted a binary tree in college either ☹️"
 published: 2020-10-02
 content_upgrade: SeniorMindset
-categories: "Opinion, Learning, Mindset"
+categories: "Opinion, Learning, Senior Mindset"
 ---
 
 

--- a/pages/blog/cool-thing-thursday-fog-of-world/index.mdx
+++ b/pages/blog/cool-thing-thursday-fog-of-world/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-10-04
 redirect_from:
   - /blog/cool-thing-thursday-fog-of-world/swizec/5363
-categories: "Dubrovnik, IPhone, London"
+categories: "Dubrovnik, IPhone, London, Travel + Events"
 ---
 
 [![Area of world explored](https://swizec.com/wp-content/uploads/2012/10/area-explored.png "Area of world explored")](https://swizec.com/wp-content/uploads/2012/10/area-explored.png)

--- a/pages/blog/cursor-background-agents-in-slack-changed-my-workflow/index.mdx
+++ b/pages/blog/cursor-background-agents-in-slack-changed-my-workflow/index.mdx
@@ -2,7 +2,7 @@
 title: "Cursor background agents in Slack changed my workflow"
 description: "a couple weeks ago Cursor launched a Slack integration and ... wow. First time I can say AI *changed* my workflow"
 published: 2025-07-02
-categories: "AI, Software Engineering, Mindset"
+categories: "AI, Software Engineering, Senior Mindset"
 ---
 
 A couple weeks ago Cursor launched a Slack integration and ... wow. First time I can say AI _changed_ my workflow.

--- a/pages/blog/depth-takes-time/index.mdx
+++ b/pages/blog/depth-takes-time/index.mdx
@@ -2,7 +2,7 @@
 title: "Depth takes time"
 description: "It takes about 3 years to experience the consequences of your own decisions."
 published: 2025-02-25
-categories: "Mindset, Software Engineering, Career"
+categories: "Senior Mindset, Software Engineering, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/different-medium-different-mindset/index.mdx
+++ b/pages/blog/different-medium-different-mindset/index.mdx
@@ -2,7 +2,7 @@
 title: "Different medium, different mindset"
 description: "Ever wondered what it's like to make a physical book? It ain't as easy as shipping code lemme tell ya 😅"
 published: 2021-03-19
-categories: "Books, Lesson, Serverless, Indie Hacking"
+categories: "Books, Lesson, Serverless, Indie Hacking, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/different-worlds/index.mdx
+++ b/pages/blog/different-worlds/index.mdx
@@ -2,7 +2,7 @@
 title: "Different worlds"
 description: "Different lenses, different worlds. Your perspective is shaped by your experiences. Even in debates, all sides can be right in their own context."
 published: 2023-07-14
-categories: "Mindset, Software Engineering"
+categories: "Senior Mindset, Software Engineering"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/django-protip-1-a-better-app-structure/index.mdx
+++ b/pages/blog/django-protip-1-a-better-app-structure/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-07-21
 redirect_from:
   - /blog/django-protip-1-a-better-app-structure/swizec/1386
-categories: "API, django, Language, Programming, python"
+categories: "API, django, Language, Programming, python, Backend"
 ---
 
 - [![Crow's nest of SMS Derfflinger](https://swizec.com/wp-content/uploads/2010/07/300px-Derfflinger%27s_crow%27s_nest.jpg "Crow's nest of SMS Derfflinger")](http://en.wikipedia.org/wiki/File:Derfflinger%27s_crow%27s_nest.JPG)

--- a/pages/blog/django-protip-2-forms-are-awesome/index.mdx
+++ b/pages/blog/django-protip-2-forms-are-awesome/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-08-03
 redirect_from:
   - /blog/django-protip-2-forms-are-awesome/swizec/1410
-categories: "API, django, RSS, Database, Fullstack"
+categories: "API, django, RSS, Database, Fullstack, Backend"
 ---
 
 - [![Moss](https://swizec.com/wp-content/uploads/2010/08/2686845422_d924cc453e_m.jpg "Moss")](http://www.flickr.com/photos/50811886@N00/2686845422)

--- a/pages/blog/do-important-work/index.mdx
+++ b/pages/blog/do-important-work/index.mdx
@@ -2,7 +2,7 @@
 title: "Do important work"
 description: 'Next time you finish a project, ask yourself: *"Might this work be important?"*. Add the polish.'
 published: 2021-06-19
-categories: "Opinion, Learning, Mindset"
+categories: "Opinion, Learning, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/does-it-even-make-sense-to-move-to-san-francisco/index.mdx
+++ b/pages/blog/does-it-even-make-sense-to-move-to-san-francisco/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2016-05-13
 redirect_from:
   - /blog/does-it-make-sense-move-san-francisco/swizec/6805
-categories: "Business, Programming, Freelancing, Learning, Personal, San Francisco, Side Project, Startup"
+categories: "Business, Programming, Freelancing, Learning, Personal, San Francisco, Side Project, Startup, Travel + Events"
 ---
 
 No.

--- a/pages/blog/doing-a-startup-taught-me-the-value-of-staying-in-school/index.mdx
+++ b/pages/blog/doing-a-startup-taught-me-the-value-of-staying-in-school/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-06-02
 redirect_from:
   - /blog/doing-a-startup-taught-me-the-value-of-staying-in-school/swizec/1819
-categories: "London, Seedcamp, Twitulater, Y Combinator"
+categories: "London, Seedcamp, Twitulater, Y Combinator, Travel + Events"
 ---
 
 ![Frankfurt: Reflection of giants](https://swizec.com/wp-content/uploads/2011/06/5785335346_32457a62b2_m47.jpg "Frankfurt: Reflection of giants")

--- a/pages/blog/doing-nothing-is-the-hardest-thing-ever/index.mdx
+++ b/pages/blog/doing-nothing-is-the-hardest-thing-ever/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-10-04
 redirect_from:
   - /blog/doing-nothing-is-the-hardest-thing-ever/swizec/1464
-categories: "App Store, API, IPad, Programming"
+categories: "App Store, API, IPad, Programming, Backend"
 ---
 
 - [![Behold the iPad in All Its Glory](https://swizec.com/wp-content/uploads/2010/10/300px-IPad-02.jpg "Behold the iPad in All Its Glory")](http://commons.wikipedia.org/wiki/File:IPad-02.jpg)

--- a/pages/blog/dont-be-a-quiet-professional/index.mdx
+++ b/pages/blog/dont-be-a-quiet-professional/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-05-04
 redirect_from:
   - /blog/dont-be-a-quiet-professional/swizec/1707
-categories: "United States"
+categories: "United States, Travel + Events"
 ---
 
 ![SEAL jumps over the side from boat.](./img/SEAL-jumps-over-the-side-from-boatigjcjg.jpeg "SEAL jumps over the side from boat.")

--- a/pages/blog/dont-judge-tech-just-because-you-re-old/index.mdx
+++ b/pages/blog/dont-judge-tech-just-because-you-re-old/index.mdx
@@ -2,7 +2,7 @@
 title: "Don't judge tech just because you're old"
 description: "Your favorite way of doing things may just be an expression of tech limitations at the time"
 published: 2024-10-29
-categories: "Mindset, Personal"
+categories: "Senior Mindset, Personal"
 ---
 
 Here's a quote to keep in mind every time a new tech makes you go _"No that's dumb and wrong"_

--- a/pages/blog/elementary/index.mdx
+++ b/pages/blog/elementary/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-10-02
 redirect_from:
   - /blog/elementary/swizec/5354
-categories: "London, New York City"
+categories: "London, New York City, Travel + Events"
 ---
 
 [![Elementary title scene](https://swizec.com/wp-content/uploads/2012/10/elementary-title-scene-1024x576.png "Elementary title scene")](https://swizec.com/wp-content/uploads/2012/10/elementary-title-scene.png)

--- a/pages/blog/even-small-things-can-make-your-code-gnarly/index.mdx
+++ b/pages/blog/even-small-things-can-make-your-code-gnarly/index.mdx
@@ -2,7 +2,7 @@
 title: "Small choices can wreck your codebase"
 description: "wanna see the strangest looping construct I've found in production code?"
 published: 2021-12-03
-categories: "JavaScript, Mindset, Technical, Programming Lessons, Software Engineering"
+categories: "JavaScript, Senior Mindset, Technical, Programming Lessons, Software Engineering"
 content_upgrade: JavaScript
 hero: ./img/carbon__3_.png
 ---

--- a/pages/blog/even-small-things-can-make-your-code-gnarly/index.mdx
+++ b/pages/blog/even-small-things-can-make-your-code-gnarly/index.mdx
@@ -2,7 +2,7 @@
 title: "Small choices can wreck your codebase"
 description: "wanna see the strangest looping construct I've found in production code?"
 published: 2021-12-03
-categories: "JavaScript, Mindset, Technical, Programming Lessons"
+categories: "JavaScript, Mindset, Technical, Programming Lessons, Software Engineering"
 content_upgrade: JavaScript
 hero: ./img/carbon__3_.png
 ---

--- a/pages/blog/feedback-is-a-strange-thing/index.mdx
+++ b/pages/blog/feedback-is-a-strange-thing/index.mdx
@@ -3,7 +3,7 @@ title: "Feedback is a strange thing"
 description: "Performance oscillates around your mean. Your average is what matters."
 published: 2025-10-16
 content_upgrade: SeniorMindset
-categories: "Career, Learning, Mindset"
+categories: "Career, Learning, Senior Mindset"
 ---
 
 Does it ever feel like you get random feedback? Positive one week, negative the next, but you're always doing the same things the same way? Regression to the mean, baby!

--- a/pages/blog/finding-unresolved-promises-in-javascript/index.mdx
+++ b/pages/blog/finding-unresolved-promises-in-javascript/index.mdx
@@ -3,7 +3,7 @@ title: "Finding unresolved promises in JavaScript"
 description: "JavaScript is a fantastic server-side language because it's async. That also makes it tricky. 💩 What happens when you swallow errors? Forget to resolve promises? Or run into a number of other anti-patterns"
 published: 2021-11-03
 content_upgrade: Javascript
-categories: "JavaScript, NodeJS, Papers"
+categories: "JavaScript, NodeJS, Papers, Backend"
 hero: ./img/Annotated-promise-graphgi88c2.jpeg
 ---
 

--- a/pages/blog/first-impressions-of-rails-as-a-javascripter/index.mdx
+++ b/pages/blog/first-impressions-of-rails-as-a-javascripter/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-02-07
 redirect_from:
   - /blog/first-impressions-of-rails-as-a-javascripter/swizec/5948
-categories: "django, NodeJS, python, Rails, Ruby"
+categories: "django, NodeJS, python, Rails, Ruby, Backend"
 hero: ./img/1307-5184860600_62f1e5dacb_m.jpg
 ---
 

--- a/pages/blog/flow-good-for-programming-not-engineering/index.mdx
+++ b/pages/blog/flow-good-for-programming-not-engineering/index.mdx
@@ -2,7 +2,7 @@
 title: "Flow good for programming, not engineering"
 description: "Friend, how good are you at your best? ... Nobody cares. How good are you at your average? What about your worst?"
 published: 2021-04-24
-categories: "Opinion, Mindset"
+categories: "Opinion, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/follow-up-to-the-most-pleasant-job-interview-i-have-ever-had/index.mdx
+++ b/pages/blog/follow-up-to-the-most-pleasant-job-interview-i-have-ever-had/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-05-23
 redirect_from:
   - /blog/follow-up-to-the-most-pleasant-job-interview-i-have-ever-had/swizec/6190
-categories: "Canada, Employment, Interviewing"
+categories: "Canada, Employment, Interviewing, Travel + Events"
 ---
 
 ![](https://www.filepicker.io/api/file/9HlBZ5SbQGeZE0urzi2s)

--- a/pages/blog/frustration-driven-development/index.mdx
+++ b/pages/blog/frustration-driven-development/index.mdx
@@ -3,7 +3,7 @@ title: "Frustration Driven Development"
 description: "Frustration is your greatest engineering asset. What do you do the 5th time someone asks for the same damn thing yet again?"
 published: 2026-04-02
 content_upgrade: ScalingFast
-categories: "Mindset, Software Engineering, Productivity"
+categories: "Senior Mindset, Software Engineering, Productivity"
 ---
 
 Frustration is your greatest engineering asset. What do you do the 5th time someone asks for the same damn thing yet again?

--- a/pages/blog/ge-ll-man-amnesia/index.mdx
+++ b/pages/blog/ge-ll-man-amnesia/index.mdx
@@ -2,7 +2,7 @@
 title: "GeLLMan amnesia"
 description: "AI will automate every job except the ones I'm deeply familiar with"
 published: 2026-02-16
-categories: "AI, Career, Mindset"
+categories: "AI, Career, Senior Mindset"
 ---
 
 When people talk about all the jobs AI will soon automate away pay close attention. It's always somebody else's job.

--- a/pages/blog/geeks-of-america-please-start-fighting-sopa/index.mdx
+++ b/pages/blog/geeks-of-america-please-start-fighting-sopa/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-01-12
 redirect_from:
   - /blog/geeks-of-america-please-start-fighting-sopa/swizec/3426
-categories: "PayPal, United States, Wikipedia, YouTube"
+categories: "PayPal, United States, Wikipedia, YouTube, Travel + Events"
 ---
 
 The [Stop Online Piracy Act](http://en.wikipedia.org/wiki/SOPA) is a bill in the US aimed at protecting intellectual property online. As originally proposed the bill would _(skip to [Something Useful](#something_useful) if you know this stuff)_

--- a/pages/blog/get-us-over-the-water-not-build-us-a-bridge/index.mdx
+++ b/pages/blog/get-us-over-the-water-not-build-us-a-bridge/index.mdx
@@ -2,7 +2,7 @@
 title: "Get us over the water, not build us a bridge"
 description: "effective engineering teams should work *with* their product owner/manager, not *for* them"
 published: 2024-05-14
-categories: "Mindset, Teamwork, Product development, Scaling Fast Book, Leadership"
+categories: "Senior Mindset, Teamwork, Product development, Scaling Fast Book, Leadership"
 content_upgrade: ScalingFast
 ---
 

--- a/pages/blog/getting-from-junior-to-senior/index.mdx
+++ b/pages/blog/getting-from-junior-to-senior/index.mdx
@@ -2,7 +2,7 @@
 title: "Getting from junior to senior"
 description: "The difference in salary between a junior and senior engineer can be orders of magnitude. Many multiples at least. But what's the difference in mindset that gets you there?"
 published: 2021-11-19
-categories: "Mindset, Podcast, Career"
+categories: "Senior Mindset, Podcast, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/go-full-stack-in-5min-with-your-first-cloud-function/index.mdx
+++ b/pages/blog/go-full-stack-in-5min-with-your-first-cloud-function/index.mdx
@@ -2,7 +2,7 @@
 title: "Go full-stack in 5min with your first cloud function"
 description: "How *do* you build a JavaScript function that runs in the cloud serverlessly? Here's how to get started with Vercel, Netlify, or AWS Lambda"
 published: 2021-03-18
-categories: "Serverless, Technical"
+categories: "Serverless, Technical, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/going-from-slovenia-to-palo-alto-what-culture-shock/index.mdx
+++ b/pages/blog/going-from-slovenia-to-palo-alto-what-culture-shock/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-07-14
 redirect_from:
   - /blog/going-from-slovenia-to-palo-alto-what-culture-shock/swizec/1947
-categories: "Entrepreneur, Ljubljana, London, Palo Alto, Slovenia, United States"
+categories: "Entrepreneur, Ljubljana, London, Palo Alto, Slovenia, United States, Travel + Events"
 ---
 
 The drink/coffee meetings resulting from my post about coming to [Palo Alto](<http://maps.google.com/maps?ll=37.4291666667,-122.138055556&spn=0.1,0.1&q=37.4291666667,-122.138055556 (Palo%20Alto%2C%20California)&t=h> "Palo Alto, California") have started happening. It's great fun meeting new people and getting a feel for the local community and entrepreneurial scene. Certainly a great place to be for meeting cool people and hackers.

--- a/pages/blog/grow-your-career-in-this-economy/index.mdx
+++ b/pages/blog/grow-your-career-in-this-economy/index.mdx
@@ -3,7 +3,7 @@ title: "Grow your career ... in this economy??"
 description: "if you've been following tech news lately, things feel ... 😖 Between the layoffs, hiring freezes, investors suddenly caring about revenue, and whatever the heck stock markets are doing, we're in for a rough time. BUT!"
 published: 2022-10-12
 content_upgrade: SeniorMindset
-categories: "Career, Mindset"
+categories: "Career, Senior Mindset"
 ---
 
 If you've been following tech news lately, things feel ... 😖 Between the layoffs, hiring freezes, investors suddenly caring about revenue, and whatever the heck stock markets are doing, we're in for a rough time.

--- a/pages/blog/hard-work-is-a-total-waste-of-time/index.mdx
+++ b/pages/blog/hard-work-is-a-total-waste-of-time/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-09-22
 redirect_from:
   - /blog/hard-work-is-a-total-waste-of-time/swizec/1458
-categories: "Java, JavaScript, NodeJS, Programming"
+categories: "Java, JavaScript, NodeJS, Programming, Backend"
 ---
 
 - [![Steacie Science and Engineering Library at Yor...](https://swizec.com/wp-content/uploads/2010/09/300px-SteacieLibrary.jpg "Steacie Science and Engineering Library at Yor...")](http://commons.wikipedia.org/wiki/File:SteacieLibrary.jpg)

--- a/pages/blog/heroku-mongo-nodejs-a-problem/index.mdx
+++ b/pages/blog/heroku-mongo-nodejs-a-problem/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-01-30
 redirect_from:
   - /blog/heroku-mongo-node-js-a-problem/swizec/3565
-categories: "Heroku, JavaScript, JSON, Database, NodeJS, Programming, Ruby"
+categories: "Heroku, JavaScript, JSON, Database, NodeJS, Programming, Ruby, Backend"
 ---
 
 A couple facts about three cool technologies

--- a/pages/blog/how-a-dollar12-aws-bill-powers-a-dollar50k-business/index.mdx
+++ b/pages/blog/how-a-dollar12-aws-bill-powers-a-dollar50k-business/index.mdx
@@ -2,7 +2,7 @@
 title: "How a $12 AWS bill powers a $50k business"
 description: "my point is that running server code on the web has become ridiculously cheap *and* easy"
 published: 2021-03-09
-categories: "Serverless, Indie Hacking, Technical"
+categories: "Serverless, Indie Hacking, Technical, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/how-better-data-modeling-fixes-your-code/index.mdx
+++ b/pages/blog/how-better-data-modeling-fixes-your-code/index.mdx
@@ -3,7 +3,7 @@ title: "How better data modeling fixes your code"
 description: "When your code feels hard, 9 times out of 10, the problem is with your data model. The signs are subtle."
 published: 2022-09-27
 content_upgrade: FullstackWeb
-categories: "Data Modeling, Database, Lesson"
+categories: "Data Modeling, Database, Lesson, Backend"
 ---
 
 When your code feels hard, 9 times out of 10, the problem is with your data model.

--- a/pages/blog/how-defensive-coding-leads-to-bloat/index.mdx
+++ b/pages/blog/how-defensive-coding-leads-to-bloat/index.mdx
@@ -2,7 +2,7 @@
 title: "How defensive coding leads to bloat"
 description: "Defensive coding is an important lesson and over time and engineers it leads to massive bloat, if you're not careful."
 published: 2021-11-15
-categories: "Technical, Opinion, Mindset, Lesson"
+categories: "Technical, Opinion, Senior Mindset, Lesson"
 ---
 
 Defensive coding is an important [lesson from Pragmatic Programmer](https://swizec.com/blog/my-favorite-lessons-from-pragmatic-programmer/), although not my favorite. It says that you should validate your inputs. Don't trust anyone!

--- a/pages/blog/how-do-you-break-down-a-large-project/index.mdx
+++ b/pages/blog/how-do-you-break-down-a-large-project/index.mdx
@@ -3,7 +3,7 @@ title: "How *do* you break down a large project? INVEST"
 description: "Going from Big Vision to Series of Executable Steps is a key skill for senior+ engineers. PMs can help but they don't know everything."
 published: 2025-02-04
 content_upgrade: SeniorMindset
-categories: "Project Management, Mindset, Teamwork, Software Engineering, Reader Question, Leadership"
+categories: "Project Management, Senior Mindset, Teamwork, Software Engineering, Reader Question, Leadership"
 ---
 
 Going from Big Vision to Series of Executable Steps is a key skill for senior+ engineers. PMs can help but they don't know everything.

--- a/pages/blog/how-do-you-find-time-for-cleanup-work/index.mdx
+++ b/pages/blog/how-do-you-find-time-for-cleanup-work/index.mdx
@@ -2,7 +2,7 @@
 title: "How do you find time for cleanup work"
 description: "A reader asks how do you find time for technical cleanup work. If OKRs and bugs take priority, when will you make improvements?"
 published: 2025-05-01
-categories: "Reader Question, Software Engineering, Teamwork, Mindset, Leadership"
+categories: "Reader Question, Software Engineering, Teamwork, Senior Mindset, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/how-do-you-know-if-serverless-fits-your-project/index.mdx
+++ b/pages/blog/how-do-you-know-if-serverless-fits-your-project/index.mdx
@@ -2,7 +2,7 @@
 title: "How do you know if serverless fits your project?"
 description: "The hallmark of a true expert is understanding about the pros and cons of your technical decisions."
 published: 2021-03-25
-categories: "Mindset, Serverless"
+categories: "Mindset, Serverless, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/how-do-you-know-if-serverless-fits-your-project/index.mdx
+++ b/pages/blog/how-do-you-know-if-serverless-fits-your-project/index.mdx
@@ -2,7 +2,7 @@
 title: "How do you know if serverless fits your project?"
 description: "The hallmark of a true expert is understanding about the pros and cons of your technical decisions."
 published: 2021-03-25
-categories: "Mindset, Serverless, Backend"
+categories: "Senior Mindset, Serverless, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/how-i-added-a-related-articles-feature-on-swizec-com-using-gpt-4-embeddings/index.mdx
+++ b/pages/blog/how-i-added-a-related-articles-feature-on-swizec-com-using-gpt-4-embeddings/index.mdx
@@ -2,7 +2,7 @@
 title: "How I Added a Related Articles Feature on Swizec.com Using GPT-4 Embeddings"
 description: "Making 15 years of blog archives easier to navigate with AI and cosine similarity to build a related articles featur"
 published: 2024-01-04
-categories: "AI, DevOps, Database"
+categories: "AI, DevOps, Database, Backend"
 ---
 
 A feature I've been wanting for months finally shipped on swizec.com. Related articles! 🥳 Here's how it works.

--- a/pages/blog/how-i-use-delegation-to-get-more-done/index.mdx
+++ b/pages/blog/how-i-use-delegation-to-get-more-done/index.mdx
@@ -2,7 +2,7 @@
 title: "How I use delegation to get more done"
 description: "Productivity porn shows you how to pack more into your day. Productivity porn is wrong my friend. You need to remove things to grow."
 published: 2020-10-23
-categories: "Opinion, Learning, Mindset"
+categories: "Opinion, Learning, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/how-one-sentence-guides-your-career/index.mdx
+++ b/pages/blog/how-one-sentence-guides-your-career/index.mdx
@@ -3,7 +3,7 @@ title: "How one sentence guides your career"
 description: "Unlock the secret to guiding your career with a powerful positioning statement. Learn to stand out in the job market and attract opportunities that align with your expertise and values."
 published: 2023-05-31
 content_upgrade: SeniorMindset
-categories: "Reader Question, Career, Mindset"
+categories: "Reader Question, Career, Senior Mindset"
 ---
 
 Do you know what fires you up in the morning?

--- a/pages/blog/how-to-add-typeform-as-a-gatsby-source/index.mdx
+++ b/pages/blog/how-to-add-typeform-as-a-gatsby-source/index.mdx
@@ -2,7 +2,7 @@
 title: "How to add Typeform as a Gatsby source"
 description: "Every year I ask readers if they're enjoying my newsletter. Then fail to use those responses 😅 This year I said heck it and built a /testimonials page that shows everyone's feedback raw from Typeform. Here's how."
 published: 2022-01-25
-categories: "Gatsby, API, React, Indie Hacking"
+categories: "Gatsby, API, React, Indie Hacking, Backend"
 content_upgrade: ReactCU
 hero: ./img/A-testimonialeei0d4.png
 ---

--- a/pages/blog/how-to-ask-for-help/index.mdx
+++ b/pages/blog/how-to-ask-for-help/index.mdx
@@ -2,7 +2,7 @@
 title: "How to ask for help"
 description: "what makes a senior engineer stand out in an interview? No it's not the amount of side projects or their leetcoding speed. It's knowing how and when to ask for help."
 published: 2021-08-27
-categories: "Mindset, Opinion, Senior Mindset"
+categories: "Senior Mindset, Opinion"
 content_upgrade: SeniorMindset
 hero: ./img/Asking-for-help-diagramg96ahi.png
 ---

--- a/pages/blog/how-to-be-useful-as-a-software-architect/index.mdx
+++ b/pages/blog/how-to-be-useful-as-a-software-architect/index.mdx
@@ -3,7 +3,7 @@ title: "How to be useful as a software architect"
 description: "Software architects have a weird role: Think about the code _tomorrow_. Today's code is what it is, how do we make it good tomorrow? Without slowing down, losing business, or falling off a cliff."
 published: 2026-07-25
 content_upgrade: ScalingFast
-categories: "Career, Teamwork, Engineering Management, Software Architecture, Leadership"
+categories: "Career, Teamwork, Engineering Management, Software Architecture, Leadership, Software Engineering"
 ---
 
 Ever worked with a useful software architect? Yeah me neither. But I sure have tried to be one.

--- a/pages/blog/how-to-be-witty-and-off-the-cuff-as-a-slow-deep-thinker/index.mdx
+++ b/pages/blog/how-to-be-witty-and-off-the-cuff-as-a-slow-deep-thinker/index.mdx
@@ -2,7 +2,7 @@
 title: "How to be witty and off-the-cuff as a slow deep thinker"
 description: "Deep thinking is the super power of wit"
 published: 2025-09-16
-categories: "Mindset, Learning, Writing"
+categories: "Senior Mindset, Learning, Writing"
 ---
 
 How can you be witty and off-the-cuff, if you like to think deeply? As Winston Churchill once said to an aide – *"Oh just preparing my off-the-cuff remarks for tomorrow"*.

--- a/pages/blog/how-to-configure-jest-with-typescript/index.mdx
+++ b/pages/blog/how-to-configure-jest-with-typescript/index.mdx
@@ -2,7 +2,7 @@
 title: "How to configure Jest with TypeScript"
 description: "Using plain Jest on a TypeScript codebase is kinda rough. No types in tests no thanks.  Making Jest and TypeScript work together smoothly is something you do just rarely enough to forget the details. Hope this helps you and future me too ✌️"
 published: 2021-10-19
-categories: "Technical, Tutorial, TypeScript, Testing, Backend, Frontend"
+categories: "Technical, Tutorial, TypeScript, Testing, Backend, Frontend, Software Engineering"
 ---
 
 this is something I do just rarely enough that it's a pain in the butt. Next time Google is going to find this article and we'll know what to do 🤞

--- a/pages/blog/how-to-give-and-receive-feedback/index.mdx
+++ b/pages/blog/how-to-give-and-receive-feedback/index.mdx
@@ -2,7 +2,7 @@
 title: "How to give and receive feedback"
 description: "Feedback can save an airplane from crashing, or upset everyone around you. But for you personally, honest feedback is the fastest way to become a better engineer. Fixing what you're bad at is where the gains hide."
 published: 2022-03-04
-categories: "Mindset, Feedback, Culture, Leadership"
+categories: "Senior Mindset, Feedback, Culture, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/how-to-go-from-senior-to-lead/index.mdx
+++ b/pages/blog/how-to-go-from-senior-to-lead/index.mdx
@@ -2,7 +2,7 @@
 title: "How to go from Senior to Lead"
 description: "Transitioning from Senior to Lead Engineer isn't just about technical prowess, but strategic thinking, soft skills, and going beyond your role. And remember, strong individual contributions matter!"
 published: 2023-11-03
-categories: "Mindset, Leadership, Career, Reader Question"
+categories: "Senior Mindset, Leadership, Career, Reader Question"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/how-to-lead-a-project/index.mdx
+++ b/pages/blog/how-to-lead-a-project/index.mdx
@@ -2,7 +2,7 @@
 title: "How to lead a project"
 description: "you were asked to lead or own a project. Now what? Here are a few practical steps to help you succeed."
 published: 2025-11-19
-categories: "Mindset, Leadership, Teamwork"
+categories: "Senior Mindset, Leadership, Teamwork"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/how-to-make-your-django-app-slow/index.mdx
+++ b/pages/blog/how-to-make-your-django-app-slow/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-03-05
 redirect_from:
   - /blog/how-to-make-your-django-app-slow/swizec/3825
-categories: "django, Testing, Language, Programming, python, Backend"
+categories: "django, Testing, Language, Programming, python, Backend, Software Engineering"
 ---
 
 The task every developer fears _"Hey, I sometimes get a timeout when I want to see the last gazillion days of activity in the [dashboard](http://en.wikipedia.org/wiki/Dashboard "Dashboard"). What gives?"_

--- a/pages/blog/how-to-make-your-django-app-slow/index.mdx
+++ b/pages/blog/how-to-make-your-django-app-slow/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-03-05
 redirect_from:
   - /blog/how-to-make-your-django-app-slow/swizec/3825
-categories: "django, Testing, Language, Programming, python"
+categories: "django, Testing, Language, Programming, python, Backend"
 ---
 
 The task every developer fears _"Hey, I sometimes get a timeout when I want to see the last gazillion days of activity in the [dashboard](http://en.wikipedia.org/wiki/Dashboard "Dashboard"). What gives?"_

--- a/pages/blog/how-to-own-projects-like-a-senior-engineer/index.mdx
+++ b/pages/blog/how-to-own-projects-like-a-senior-engineer/index.mdx
@@ -2,7 +2,7 @@
 title: "How to own projects like a senior engineer"
 description: "The best skill you can learn is ownership. The second best is to let go."
 published: 2021-07-02
-categories: "Opinion, Leadership, Mindset, Senior Mindset"
+categories: "Opinion, Leadership, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/how-to-rewrite-your-app-while-growing-to-a-dollar100000000-series-b/index.mdx
+++ b/pages/blog/how-to-rewrite-your-app-while-growing-to-a-dollar100000000-series-b/index.mdx
@@ -2,7 +2,7 @@
 title: "How to rewrite your app while growing to a $100,000,000 series B"
 description: "When you're in a company desperately trying to meet demand, *ship*. You'll have money, time, and professionals to fix code later. Even if you start with jQuery."
 published: 2021-09-18
-categories: "Software Engineering, Mindset, Personal"
+categories: "Software Engineering, Senior Mindset, Personal"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/how-to-royally-cock-up-as-a-freelancer/index.mdx
+++ b/pages/blog/how-to-royally-cock-up-as-a-freelancer/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2014-05-06
 redirect_from:
   - /blog/how-to-royally-cock-up-as-a-freelancer/swizec/6570
-categories: "Bank account, Business, Client, Freelancing, Silicon Valley, Slovenia, United States"
+categories: "Bank account, Business, Client, Freelancing, Silicon Valley, Slovenia, United States, Travel + Events"
 ---
 
 ![Photo borrowed without permission from Marc Kodis because I can't find contact info](./img/Photo-borrowed-without-permission-from-Marc-Kodis-because-I-cant-find-contact-infog069ej.jpeg "Photo borrowed without permission from Marc Kodis because I can't find contact info")

--- a/pages/blog/how-to-run-javascript-tests-in-chrome-on-travis/index.mdx
+++ b/pages/blog/how-to-run-javascript-tests-in-chrome-on-travis/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2015-01-27
 redirect_from:
   - /blog/how-to-run-javascript-tests-in-chrome-on-travis/swizec/6647
-categories: "Github, JavaScript, Technical, Testing"
+categories: "Github, JavaScript, Technical, Testing, Software Engineering"
 hero: ./img/images-26240.png
 ---
 

--- a/pages/blog/how-we-made-the-best-burndown-chart-youve-ever-seen/index.mdx
+++ b/pages/blog/how-we-made-the-best-burndown-chart-youve-ever-seen/index.mdx
@@ -2,7 +2,7 @@
 title: "How we made the best burndown chart you've ever seen"
 description: 'My entire career I''ve never seen a sprint finished on time. The new manager said "Oh I think we can fix that" ... 18 months later he proved me wrong'
 published: 2022-04-12
-categories: "Productivity, Velocity, Mindset, Management, Teamwork, Leadership"
+categories: "Productivity, Velocity, Mindset, Management, Teamwork, Leadership, Software Engineering"
 content_upgrade: SeniorMindset
 hero: ./img/how-we-made-the-best-burndown-youve-ever-seen.png
 ---

--- a/pages/blog/how-we-made-the-best-burndown-chart-youve-ever-seen/index.mdx
+++ b/pages/blog/how-we-made-the-best-burndown-chart-youve-ever-seen/index.mdx
@@ -2,7 +2,7 @@
 title: "How we made the best burndown chart you've ever seen"
 description: 'My entire career I''ve never seen a sprint finished on time. The new manager said "Oh I think we can fix that" ... 18 months later he proved me wrong'
 published: 2022-04-12
-categories: "Productivity, Velocity, Mindset, Management, Teamwork, Leadership, Software Engineering"
+categories: "Productivity, Velocity, Senior Mindset, Management, Teamwork, Leadership, Software Engineering"
 content_upgrade: SeniorMindset
 hero: ./img/how-we-made-the-best-burndown-youve-ever-seen.png
 ---

--- a/pages/blog/howto-convince-the-istore-youre-from-the-us-and-circumvent-regional-copyright-restrictions/index.mdx
+++ b/pages/blog/howto-convince-the-istore-youre-from-the-us-and-circumvent-regional-copyright-restrictions/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2009-11-12
 redirect_from:
   - /blog/howto-convince-the-istore-youre-from-the-us/swizec/824
-categories: "Apple, Business, Personal, United States"
+categories: "Apple, Business, Personal, United States, Travel + Events"
 ---
 
 - [![Copyrighted](./img/Copyrightedh1cc38.png "Copyrighted")](http://commons.wikipedia.org/wiki/Image:Green_copyright.svg)

--- a/pages/blog/i-infiltrated-another-rails-girls-event-railsgirlsmb/index.mdx
+++ b/pages/blog/i-infiltrated-another-rails-girls-event-railsgirlsmb/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-06-04
 redirect_from:
   - /blog/i-infiltrated-another-rails-girls-event-railsgirlsmb/swizec/6222
-categories: "Heroku, HTML, Learning, Programming, Rails, Travel + Events"
+categories: "Heroku, HTML, Learning, Programming, Rails, Travel + Events, Backend"
 ---
 
 ![Rails Girls Maribor heart](https://www.filepicker.io/api/file/LLvKgLJ7Tf6Qyxcmcloy "Rails Girls Maribor heart")![]()

--- a/pages/blog/i-infiltrated-railsgirlslj-heres-what-it-was-like/index.mdx
+++ b/pages/blog/i-infiltrated-railsgirlslj-heres-what-it-was-like/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-12-17
 redirect_from:
   - /blog/i-infiltrated-railsgirlsj-heres-what-it-was-like/swizec/5717
-categories: "Language, Ljubljana, Programming, Rails, Ruby, Travel + Events, Fullstack"
+categories: "Language, Ljubljana, Programming, Rails, Ruby, Travel + Events, Fullstack, Backend"
 hero: ./img/5c2acea173c932d419bf93c9fd9b254e-tumblr_mf2fcpFlrG1qekjngo1_500.jpg
 ---
 

--- a/pages/blog/i-kicked-myself-in-the-balls/index.mdx
+++ b/pages/blog/i-kicked-myself-in-the-balls/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-12-05
 redirect_from:
   - /blog/i-kicked-myself-in-the-balls/swizec/3115
-categories: "Programming, Ljubljana"
+categories: "Programming, Ljubljana, Travel + Events"
 ---
 
 Nice sunny Sunday here in [Ljubljana](<http://maps.google.com/maps?ll=46.0555555556,14.5083333333&spn=0.1,0.1&q=46.0555555556,14.5083333333 (Ljubljana)&t=h> "Ljubljana") yesterday. Around noon something particularly odd happened though. The week was over. I had finished everything I absolutely had to do, there was no more coursework, no more tasks for this week in pivotaltracker ... nothing.

--- a/pages/blog/i-learned-two-things-today-168-2/index.mdx
+++ b/pages/blog/i-learned-two-things-today-168-2/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-08-17
 redirect_from:
   - /blog/i-learned-two-things-today-16-8-2/swizec/2219
-categories: "Airbnb, Learning, Personal, San Francisco, Y Combinator"
+categories: "Airbnb, Learning, Personal, San Francisco, Y Combinator, Travel + Events"
 ---
 
 ![Brian Chesky, CEO of Airbnb, speaks to Startup...](https://swizec.com/wp-content/uploads/2011/08/5089475323_3dd9dbf197_m1.jpg "Brian Chesky, CEO of Airbnb, speaks to Startup...")

--- a/pages/blog/i-learned-two-things-today-278/index.mdx
+++ b/pages/blog/i-learned-two-things-today-278/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-08-27
 redirect_from:
   - /blog/i-learned-two-things-today-27-8/swizec/2294
-categories: "API, Foursquare, Health, Learning, Personal, Recreation, Travel + Events"
+categories: "API, Foursquare, Health, Learning, Personal, Recreation, Travel + Events, Backend"
 ---
 
 ![Sleep-cycle](https://swizec.com/wp-content/uploads/2011/08/Sleep-cycle1.gif "Sleep-cycle")

--- a/pages/blog/i-learned-two-things-today-58/index.mdx
+++ b/pages/blog/i-learned-two-things-today-58/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-08-06
 redirect_from:
   - /blog/i-learned-two-things-today-5/swizec/2087
-categories: "Learning, Palo Alto, Personal"
+categories: "Learning, Palo Alto, Personal, Travel + Events"
 ---
 
 ![Photograph of Palo Alto City Hall.]\( "Photograph of Palo Alto City Hall.")

--- a/pages/blog/i-learned-two-things-today-68/index.mdx
+++ b/pages/blog/i-learned-two-things-today-68/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-08-07
 redirect_from:
   - /blog/i-learned-two-things-today-6-8/swizec/2094
-categories: "Airbnb, Learning, Personal, San Francisco"
+categories: "Airbnb, Learning, Personal, San Francisco, Travel + Events"
 ---
 
 ![San Francisco by Night: Mission Street](https://swizec.com/wp-content/uploads/2011/08/4101129542_d3e9ae80f4_m2.jpg "San Francisco by Night: Mission Street")

--- a/pages/blog/i-learned-two-things-today-78/index.mdx
+++ b/pages/blog/i-learned-two-things-today-78/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-08-07
 redirect_from:
   - /blog/i-learned-two-things-today-7-8/swizec/2100
-categories: "California, Learning, Palo Alto, Personal, San Francisco"
+categories: "California, Learning, Palo Alto, Personal, San Francisco, Travel + Events"
 ---
 
 ![Grant Ave. in Chinatown, San Francisco.](https://swizec.com/wp-content/uploads/2011/08/300px-SF_Chinatown_CA6.jpg "Grant Ave. in Chinatown, San Francisco.")

--- a/pages/blog/i-m-a-different-engineer-than-i-was-3-years-ago/index.mdx
+++ b/pages/blog/i-m-a-different-engineer-than-i-was-3-years-ago/index.mdx
@@ -2,7 +2,7 @@
 title: "I'm a different engineer than I was 3 years ago"
 description: "A reflection on engineering through The Hockeystick"
 published: 2024-01-02
-categories: "Personal, Mindset, Career"
+categories: "Personal, Senior Mindset, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/i-published-a-book-with-a-publisher-heres-what-the-journey-was-like/index.mdx
+++ b/pages/blog/i-published-a-book-with-a-publisher-heres-what-the-journey-was-like/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-10-29
 redirect_from:
   - /blog/i-published-a-book-with-a-publisher-heres-what-the-journey-was-like/swizec/6398
-categories: "Business, Data Visualization, Ljubljana, Packt, Side Project, Skype, Writing"
+categories: "Business, Data Visualization, Ljubljana, Packt, Side Project, Skype, Writing, Travel + Events"
 ---
 
 ![Data Visualization with d3.js cover](https://www.filepicker.io/api/file/4lQnyBJ3SmbpxTTkl5lO?policy=eyJoYW5kbGUiOiI0bFFueUJKM1NtYnB4VFRrbDVsTyIsImV4cGlyeSI6MTM4MzA1ODA5OSwiY2FsbCI6WyJyZWFkIl19&signature=973d407bbf3113c8d1a6336e07d57ec8729918d0caa81bebef4783d108329ca7)

--- a/pages/blog/i-walked-all-over-a-lake/index.mdx
+++ b/pages/blog/i-walked-all-over-a-lake/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-02-18
 redirect_from:
   - /blog/i-walked-all-over-a-lake/swizec/3686
-categories: "Recreation, Slovenia"
+categories: "Recreation, Slovenia, Travel + Events"
 ---
 
 You've heard of [Lake Bled](<http://maps.google.com/maps?ll=46.3644444444,14.0947222222&spn=0.1,0.1&q=46.3644444444,14.0947222222 (Lake%20Bled)&t=h> "Lake Bled") right? The only lake in [Slovenia](<http://maps.google.com/maps?ll=46.05,14.5&spn=10.0,10.0&q=46.05,14.5 (Slovenia)&t=h> "Slovenia") containing the only island in Slovenia? Right!? Oh it's just one of the most beautifulest places in Slovenia.

--- a/pages/blog/i-went-through-yc-as-an-intern-heres-what-i-learned/index.mdx
+++ b/pages/blog/i-went-through-yc-as-an-intern-heres-what-i-learned/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-08-31
 redirect_from:
   - /blog/i-went-through-yc-as-an-intern-heres-what-i-learned/swizec/2345
-categories: "Airbnb, California, Silicon Valley, Startup, Y Combinator"
+categories: "Airbnb, California, Silicon Valley, Startup, Y Combinator, Travel + Events"
 ---
 
 _Second time I'm writing this post after the official [Moleskine](http://www.moleskine.com/ "Moleskine") app for [the iPad](http://www.apple.com/ipad/ "iPad") ate the first version some 80% through. Don't use it. It doesn't behave as a notebook should ..._

--- a/pages/blog/i-went-to-ai-woodstock-and-wow/index.mdx
+++ b/pages/blog/i-went-to-ai-woodstock-and-wow/index.mdx
@@ -2,7 +2,7 @@
 title: 'I went to "AI Woodstock" and wow'
 description: '"AI Woodstock" was a HuggingFace meetup showcasing groundbreaking AI projects and innovations. Here are some of my favs.'
 published: 2023-04-04
-categories: "Events, AI, Personal"
+categories: "Events, AI, Personal, Travel + Events"
 hero: ./img/swizec-at-hugginface.jpg
 ---
 

--- a/pages/blog/i-wish-this-existed/index.mdx
+++ b/pages/blog/i-wish-this-existed/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-03-23
 redirect_from:
   - /blog/i-wish-this-existed/swizec/4045
-categories: "Code, Editor, HTML, Programming"
+categories: "Code, Editor, HTML, Programming, Software Engineering"
 ---
 
 https://twitter.com/Swizec/status/181674782339772416

--- a/pages/blog/if-you-re-so-good-why-aren-t-you-making-600k-at-bigtech/index.mdx
+++ b/pages/blog/if-you-re-so-good-why-aren-t-you-making-600k-at-bigtech/index.mdx
@@ -3,7 +3,7 @@ title: '"If you''re so good, why aren''t you making 600k at BigTech?"'
 description: "Swiz shares why he's not making the big bucks at a tech giant, from the soul-crushing grind of corporate to the funny money of tech compensation."
 published: 2023-03-10
 content_upgrade: SeniorMindset
-categories: "Reader Question, career, salary, mindset"
+categories: "Reader Question, career, salary, Senior Mindset"
 ---
 
 Your fellow reader Samuel asked a pointed question and I thought my answer could help you too.

--- a/pages/blog/insights-for-interviews-from-kahneman-s-noise/index.mdx
+++ b/pages/blog/insights-for-interviews-from-kahneman-s-noise/index.mdx
@@ -2,7 +2,7 @@
 title: "Insights for interviews from Kahneman's Noise"
 description: "everything people say is bad about modern tech interviews is actually good 🤯"
 published: 2023-04-14
-categories: "Interviewing, Mindset, Books"
+categories: "Interviewing, Senior Mindset, Books"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/interviewing-tips-for-experienced-engineers/index.mdx
+++ b/pages/blog/interviewing-tips-for-experienced-engineers/index.mdx
@@ -3,7 +3,7 @@ title: "Interviewing tips for experienced engineers"
 description: "The way you interview changes as you go through your career. If you're grinding leetcode 10 years in, something's wrong."
 published: 2024-08-24
 content_upgrade: SeniorMindset
-categories: "Career, Mindset, Interviewing"
+categories: "Career, Senior Mindset, Interviewing"
 ---
 
 The way you interview changes as you go through your career. If you're grinding leetcode 10 years in, something's wrong.

--- a/pages/blog/just-fix-their-pr/index.mdx
+++ b/pages/blog/just-fix-their-pr/index.mdx
@@ -3,7 +3,7 @@ title: "Just fix their PR"
 description: "You know what's better than a code review comment? A fix."
 published: 2026-05-13
 content_upgrade: ScalingFast
-categories: "Teamwork, Software Engineering, Mindset, Leadership"
+categories: "Teamwork, Software Engineering, Senior Mindset, Leadership"
 ---
 
 You know what's better than a code review comment? A fix.

--- a/pages/blog/just-read-the-paper/index.mdx
+++ b/pages/blog/just-read-the-paper/index.mdx
@@ -2,7 +2,7 @@
 title: "Just Read the Paper"
 description: "Read more papers. You can learn the latest and greatest in your field in one chill afternoon."
 published: 2026-04-20
-categories: "Mindset, Learning, Papers"
+categories: "Senior Mindset, Learning, Papers"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/keeping-a-high-engineering-culture-tips-from-the-field/index.mdx
+++ b/pages/blog/keeping-a-high-engineering-culture-tips-from-the-field/index.mdx
@@ -3,7 +3,7 @@ title: "Keeping a high engineering culture, tips from the field"
 description: "I asked engineers how they keep a high quality culture. These are the takeaways"
 published: 2023-12-08
 content_upgrade: SeniorMindset
-categories: "Leadership, Mindset, Software Engineering"
+categories: "Leadership, Senior Mindset, Software Engineering"
 ---
 
 You are what you do. Culture beats everything.

--- a/pages/blog/kids-always-remember-to-clear-your-intervals/index.mdx
+++ b/pages/blog/kids-always-remember-to-clear-your-intervals/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2014-11-05
 redirect_from:
   - /blog/kids-always-remember-to-clear-your-intervals/swizec/6614
-categories: "JavaScript, NodeJS"
+categories: "JavaScript, NodeJS, Backend"
 hero: ./img/images-23704.png
 ---
 

--- a/pages/blog/learnings-about-the-future-of-the-web-from-reactathon/index.mdx
+++ b/pages/blog/learnings-about-the-future-of-the-web-from-reactathon/index.mdx
@@ -2,7 +2,7 @@
 title: "Learnings about the future of the web from Reactathon"
 description: "The first in-person conference in years! It was wonderful 🤩\n- Remix is great\n- Serverless at edge is the future\n- GDPR does not play with 👆"
 published: 2022-05-07
-categories: "Events, React, Lesson"
+categories: "Events, React, Lesson, Travel + Events"
 ---
 
 The first in-person conference in years! It was wonderful 🤩

--- a/pages/blog/lesson-learned-test-your-migrations-on-the-big-dataset/index.mdx
+++ b/pages/blog/lesson-learned-test-your-migrations-on-the-big-dataset/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2015-09-02
 redirect_from:
   - /blog/lesson-learned-test-your-migrations-on-the-big-dataset/swizec/6729
-categories: "Database, Heroku, Rails, Technical"
+categories: "Database, Heroku, Rails, Technical, Backend"
 ---
 
 https://twitter.com/Swizec/status/634452345007550464

--- a/pages/blog/lessons-learned-in-a-year-of-freelancing/index.mdx
+++ b/pages/blog/lessons-learned-in-a-year-of-freelancing/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-09-26
 redirect_from:
   - /blog/lessons-learned-in-a-year-of-freelancing/swizec/6348
-categories: "Business, Freelancing, HackerNews, Ljubljana, work"
+categories: "Business, Freelancing, HackerNews, Ljubljana, work, Travel + Events"
 hero: ./img/images-1597.jpg
 ---
 

--- a/pages/blog/let-small-fires-burn/index.mdx
+++ b/pages/blog/let-small-fires-burn/index.mdx
@@ -2,7 +2,7 @@
 title: "Let small fires burn"
 description: "You can't fix everything. Focus on the next big thing and let the small fires burn."
 published: 2024-08-21
-categories: "Scaling Fast Book, Mindset, Software Engineering, Management, Leadership"
+categories: "Scaling Fast Book, Senior Mindset, Software Engineering, Management, Leadership"
 ---
 
 _Something_ is always on fire when you're growing. You can't fix everything.

--- a/pages/blog/make-mistakes-easy-to-fix/index.mdx
+++ b/pages/blog/make-mistakes-easy-to-fix/index.mdx
@@ -2,7 +2,7 @@
 title: "Make mistakes easy to fix"
 description: "You can't prevent bugs. You'll burn out. Instead focus on making them quick to fix."
 published: 2024-10-08
-categories: "Software Engineering, Scaling Fast Book, Mindset, Teamwork, Observability, Leadership"
+categories: "Software Engineering, Scaling Fast Book, Mindset, Teamwork, Observability, Leadership, Backend"
 ---
 
 You can't prevent bugs. You'll burn out. Instead, you can focus on making them quick to fix.

--- a/pages/blog/make-mistakes-easy-to-fix/index.mdx
+++ b/pages/blog/make-mistakes-easy-to-fix/index.mdx
@@ -2,7 +2,7 @@
 title: "Make mistakes easy to fix"
 description: "You can't prevent bugs. You'll burn out. Instead focus on making them quick to fix."
 published: 2024-10-08
-categories: "Software Engineering, Scaling Fast Book, Mindset, Teamwork, Observability, Leadership, Backend"
+categories: "Software Engineering, Scaling Fast Book, Senior Mindset, Teamwork, Observability, Leadership, Backend"
 ---
 
 You can't prevent bugs. You'll burn out. Instead, you can focus on making them quick to fix.

--- a/pages/blog/make-sure-it-works-first/index.mdx
+++ b/pages/blog/make-sure-it-works-first/index.mdx
@@ -2,7 +2,7 @@
 title: "Make sure it works first"
 description: "Explore the importance of functionality over elegance in Swizec's latest piece. Learn from his experience of tripling an engineering team's size within a year."
 published: 2025-10-21
-categories: "Software Engineering, Learning, Mindset, Podcast, Talks, Scaling Fast Book"
+categories: "Software Engineering, Learning, Senior Mindset, Podcast, Talks, Scaling Fast Book"
 content_upgrade: ScalingFast
 ---
 

--- a/pages/blog/meetings-a-senior-engineers-secret-weapon/index.mdx
+++ b/pages/blog/meetings-a-senior-engineers-secret-weapon/index.mdx
@@ -3,7 +3,7 @@ title: "Meetings – a senior engineer's secret weapon"
 description: "Boo meetings, yay code, right? There comes a time in your career when coding is no longer your highest impact contribution. Might even be holding you back. 🙊"
 published: 2021-10-01
 content_upgrade: SeniorMindset
-categories: "Mindset, Learning, Senior Mindset"
+categories: "Senior Mindset, Learning"
 ---
 
 I have a confession to make ... I'm starting to enjoy meetings 🙊

--- a/pages/blog/modern-backend-is-a-javascript-function/index.mdx
+++ b/pages/blog/modern-backend-is-a-javascript-function/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Modern backend is a JavaScript function"
 description: "Many engineers think server-side code is the scary domain of True Engineers. Something newbies, juniors, and frontend engineers shouldn't touch. They're wrong. Modern backend is a joy. ❤️"
-categories: "Serverless, JavaScript, Technical"
+categories: "Serverless, JavaScript, Technical, Backend"
 content_upgrade: ServerlessHandbook
 published: 2020-09-22
 ---

--- a/pages/blog/my-biggest-react-app-performance-boost-was-a-backend-change/index.mdx
+++ b/pages/blog/my-biggest-react-app-performance-boost-was-a-backend-change/index.mdx
@@ -2,7 +2,7 @@
 title: "My biggest React App performance boost was a backend change"
 description: "Performance lives in the unlikliest of places. Follow the metrics."
 published: 2023-01-31
-categories: "JavaScript, Lesson, React, NodeJS, Performance"
+categories: "JavaScript, Lesson, React, NodeJS, Performance, Backend"
 ---
 
 Yesterday I shipped my biggest ever React App performance improvement. You'll never guess what the tiny change was 😛

--- a/pages/blog/my-language-is-better-than-yours/index.mdx
+++ b/pages/blog/my-language-is-better-than-yours/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-03-30
 redirect_from:
   - /blog/my-language-is-better-than-yours/swizec/4093
-categories: "Google, Java, JavaScript, Lisp, PHP, Programming language, Wikipedia"
+categories: "Google, Java, JavaScript, Lisp, PHP, Programming language, Wikipedia, Backend"
 ---
 
 > My language brings all the geeks to the yard, And they're like "It's better than yours" Damn right, it's better than yours, I can teach you, but I have to charge

--- a/pages/blog/my-mentoring-philosophy/index.mdx
+++ b/pages/blog/my-mentoring-philosophy/index.mdx
@@ -2,7 +2,7 @@
 title: "My mentoring philosophy"
 description: "Yesterday I had lunch with a newly promoted lead and realized I have opinions on mentoring engineers. Here they are."
 published: 2025-06-26
-categories: "Teamwork, Mindset, Leadership"
+categories: "Teamwork, Senior Mindset, Leadership"
 ---
 
 Yesterday I had lunch with a newly promoted lead and realized I have opinions on mentoring engineers. Here they are.

--- a/pages/blog/my-old-code-is-atrocious/index.mdx
+++ b/pages/blog/my-old-code-is-atrocious/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-11-12
 redirect_from:
   - /blog/my-old-code-is-atrocious/swizec/6414
-categories: "Haskell, Language, Programming, Architectural Complexity, Toshl"
+categories: "Haskell, Language, Programming, Architectural Complexity, Toshl, Software Engineering"
 hero: ./img/images-3841.png
 ---
 

--- a/pages/blog/nobody-is-coming-to-save-you/index.mdx
+++ b/pages/blog/nobody-is-coming-to-save-you/index.mdx
@@ -2,7 +2,7 @@
 title: "Nobody is coming to save you"
 description: "How do you react when you don't like The Process at work? Most programmers complain on social media, make a wry joke, and ... suffer. Not great"
 published: 2022-07-29
-categories: "Mindset, Leadership"
+categories: "Senior Mindset, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/nodeunshortener-can-unshort-any-url/index.mdx
+++ b/pages/blog/nodeunshortener-can-unshort-any-url/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-05-21
 redirect_from:
   - /blog/node-unshortener-can-unshort-any-url/swizec/1763
-categories: "API, JavaScript, Online Communities, Twitter"
+categories: "API, JavaScript, Online Communities, Twitter, Backend"
 ---
 
 ![Twitter Inc HQ](./img/Twitter-Inc-HQjgh1bc.jpeg "Twitter Inc HQ")

--- a/pages/blog/notes-on-a-relational-model-of-data-for-large-shared-data-banks/index.mdx
+++ b/pages/blog/notes-on-a-relational-model-of-data-for-large-shared-data-banks/index.mdx
@@ -2,7 +2,7 @@
 title: "Notes on A Relational Model of Data for Large Shared Data Banks"
 description: "In 1970 a paper came out that changed the world of business computing. It laid the ground work for modern databases."
 published: 2022-09-20
-categories: "Papers, Database, Computer Science, Data Modeling"
+categories: "Papers, Database, Computer Science, Data Modeling, Backend"
 ---
 
 In 1970 a paper came out that changed the world of business computing – [A Relational Model of Data for Large Shared Data Banks](https://www.seas.upenn.edu/~zives/03f/cis550/codd.pdf) by E. F. Codd. It laid the ground work for modern databases.

--- a/pages/blog/of-london-murphy-and-seedcamp/index.mdx
+++ b/pages/blog/of-london-murphy-and-seedcamp/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2009-09-14
 redirect_from:
   - /blog/of-london-murphy-and-seedcamp/swizec/718
-categories: "Business, Personal, Linear algebra, London, Seedcamp"
+categories: "Business, Personal, Linear algebra, London, Seedcamp, Travel + Events"
 ---
 
 - [![Greater London](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/442px_-_London_Lead_Image.jpg/300px-442px_-_London_Lead_Image.jpg "Greater London")](http://commons.wikipedia.org/wiki/Image:442px_-_London_Lead_Image.jpg)

--- a/pages/blog/onboarding-to-a-new-team/index.mdx
+++ b/pages/blog/onboarding-to-a-new-team/index.mdx
@@ -4,7 +4,7 @@ description: "People are starting to cheat in interviews using ChatGPT. It's obv
 published: 2024-02-06
 hero: ./img/thumbnail.png
 content_upgrade: SeniorMindset
-categories: "Mindset, Leadership, Books"
+categories: "Senior Mindset, Leadership, Books"
 ---
 
 Joining a new team wrong can set you up to fail for years to come. Here's an algorithm I learned from a book that makes the process downright enjoyable.

--- a/pages/blog/online-real-names-provide-anonymity/index.mdx
+++ b/pages/blog/online-real-names-provide-anonymity/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-04-03
 redirect_from:
   - /blog/online-real-names-provide-anonymity/swizec/4099
-categories: "Facebook, Google, Online Communities, Slovenia, Social Network, Twitter"
+categories: "Facebook, Google, Online Communities, Slovenia, Social Network, Twitter, Travel + Events"
 ---
 
 There are [845 million active users on facebook](http://newsroom.fb.com/content/default.aspx?NewsAreaId=22).

--- a/pages/blog/our-intuitive-understanding-of-distance-fails-us/index.mdx
+++ b/pages/blog/our-intuitive-understanding-of-distance-fails-us/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-09-06
 redirect_from:
   - /blog/our-intuitive-understanding-of-distance-fails-us/swizec/2368
-categories: "Math, United States"
+categories: "Math, United States, Travel + Events"
 ---
 
 ![](https://swizec.com/wp-content/uploads/2011/09/photo-150x150.jpg "Distance vs. cost")

--- a/pages/blog/outputs-are-not-outcomes/index.mdx
+++ b/pages/blog/outputs-are-not-outcomes/index.mdx
@@ -3,7 +3,7 @@ title: "Outputs are not outcomes"
 description: "Doing the work is not the same as getting things done"
 published: 2024-04-26
 content_upgrade: SeniorMindset
-categories: "Mindset, Productivity"
+categories: "Senior Mindset, Productivity"
 ---
 
 Doing the work is not the same as getting things done.

--- a/pages/blog/over-engineering-tweet-embeds-with-web-components-for-fun-and-privacy/index.mdx
+++ b/pages/blog/over-engineering-tweet-embeds-with-web-components-for-fun-and-privacy/index.mdx
@@ -2,7 +2,7 @@
 title: "Over-engineering tweet embeds with web components for fun and privacy"
 description: "A way to embed tweets in static sites with full pre-renders and live updates using just 9kB of client-side JavaScript, 2 HTTP requests, and full reader privacy ✌️"
 published: 2022-10-26
-categories: "Technical, JavaScript, Serverless, Fullstack"
+categories: "Technical, JavaScript, Serverless, Fullstack, Backend"
 ---
 
 Here's something fun I've been fiddling with for over a year – fast privacy-focused tweet embeds. Because where's the fun in using a plugin with Twitter's native embed widget like a normal person?

--- a/pages/blog/own-the-outcome-not-the-work/index.mdx
+++ b/pages/blog/own-the-outcome-not-the-work/index.mdx
@@ -3,7 +3,7 @@ title: "Own the outcome, not the work"
 description: "Efficient problem-solving in engineering with a shift in perspective – focusing on user outcomes can lead to innovative solutions and change your approach to system design."
 published: 2023-04-26
 content_upgrade: SeniorMindset
-categories: "Mindset, Lesson, Software Architecture"
+categories: "Mindset, Lesson, Software Architecture, Software Engineering"
 ---
 
 One of my favorite engineering things to do is to look at a system, squint a little, and go _"If we move this piece over there, everything becomes easier"_.

--- a/pages/blog/own-the-outcome-not-the-work/index.mdx
+++ b/pages/blog/own-the-outcome-not-the-work/index.mdx
@@ -3,7 +3,7 @@ title: "Own the outcome, not the work"
 description: "Efficient problem-solving in engineering with a shift in perspective – focusing on user outcomes can lead to innovative solutions and change your approach to system design."
 published: 2023-04-26
 content_upgrade: SeniorMindset
-categories: "Mindset, Lesson, Software Architecture, Software Engineering"
+categories: "Senior Mindset, Lesson, Software Architecture, Software Engineering"
 ---
 
 One of my favorite engineering things to do is to look at a system, squint a little, and go _"If we move this piece over there, everything becomes easier"_.

--- a/pages/blog/own-your-career-like-an-expert/index.mdx
+++ b/pages/blog/own-your-career-like-an-expert/index.mdx
@@ -3,7 +3,7 @@ title: "Own your career like an expert"
 description: 'You can achieve more with your career by leveraging your experience, advice, and ability to clear blockers, rather than just working hard. This approach of "force multiplying" your team can create more value than working alone'
 published: 2023-03-03
 content_upgrade: SeniorMindset
-categories: "Mindset, Career"
+categories: "Senior Mindset, Career"
 ---
 
 What's the difference between a career you own and a career you have?

--- a/pages/blog/ownership-makes-careers/index.mdx
+++ b/pages/blog/ownership-makes-careers/index.mdx
@@ -2,7 +2,7 @@
 title: "Ownership makes careers"
 description: "Own shit. At least put your name on things. Yes, before it's successful."
 published: 2023-06-23
-categories: "Mindset, Career"
+categories: "Senior Mindset, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/parsing-javascript-with-javascript/index.mdx
+++ b/pages/blog/parsing-javascript-with-javascript/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-11-11
 redirect_from:
   - /blog/parsing-javascript-with-javascript/swizec/2909
-categories: "API, Compiler, JavaScript, Language, Parsing, Programming"
+categories: "API, Compiler, JavaScript, Language, Parsing, Programming, Backend"
 ---
 
 Over the weekend I started working on [llamaduck](https://github.com/Swizec/llamaduck)- a simple tool that aims to figure out whether your code will run on the newly released node 0.6.0. Eventually it might be able to perform other compatibility assessment tasks as well, but I'm focusing on simple stuff first.

--- a/pages/blog/pay-yourself-first/index.mdx
+++ b/pages/blog/pay-yourself-first/index.mdx
@@ -2,7 +2,7 @@
 title: "Pay yourself first"
 description: "Profit is not what's left after expenses, expenses are what's left after profit."
 published: 2021-07-30
-categories: "Mindset, Personal, Career, Money"
+categories: "Senior Mindset, Personal, Career, Money"
 ---
 
 Friend, I like to share financials to encourage others. It benefits everyone when we [talk about these things](https://swizec.com/blog/why-you-should-talk-about-engineering-salaries/) at the small expense of bruising an ego or three. ✌️

--- a/pages/blog/peeshkot-cookie-warnings-go-away/index.mdx
+++ b/pages/blog/peeshkot-cookie-warnings-go-away/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-06-19
 redirect_from:
   - /blog/peeshkot-cookie-warnings-go-away/swizec/6242
-categories: "Google Analytics, Slovenia"
+categories: "Google Analytics, Slovenia, Travel + Events"
 ---
 
 ![](https://www.filepicker.io/api/file/nUpYuoErSieYKXEEti7b)

--- a/pages/blog/people-detangle-a-ball-of-mud/index.mdx
+++ b/pages/blog/people-detangle-a-ball-of-mud/index.mdx
@@ -2,7 +2,7 @@
 title: "*People* detangle a ball of mud"
 description: "Ball of mud is the world's most popular software architecture. The one we all use at work. But it sucks to work with. So what do you do?"
 published: 2025-11-15
-categories: "Teamwork, Software Architecture, Mindset, Scaling Fast Book, Leadership"
+categories: "Teamwork, Software Architecture, Mindset, Scaling Fast Book, Leadership, Software Engineering"
 ---
 
 Ball of mud is [the world's most popular software architecture](https://swizec.com/blog/big-ball-of-mud-the-worlds-most-popular-software-architecture/). The one we all use at work while we debate gang of four and fancy patterns on the internet.

--- a/pages/blog/people-detangle-a-ball-of-mud/index.mdx
+++ b/pages/blog/people-detangle-a-ball-of-mud/index.mdx
@@ -2,7 +2,7 @@
 title: "*People* detangle a ball of mud"
 description: "Ball of mud is the world's most popular software architecture. The one we all use at work. But it sucks to work with. So what do you do?"
 published: 2025-11-15
-categories: "Teamwork, Software Architecture, Mindset, Scaling Fast Book, Leadership, Software Engineering"
+categories: "Teamwork, Software Architecture, Senior Mindset, Scaling Fast Book, Leadership, Software Engineering"
 ---
 
 Ball of mud is [the world's most popular software architecture](https://swizec.com/blog/big-ball-of-mud-the-worlds-most-popular-software-architecture/). The one we all use at work while we debate gang of four and fancy patterns on the internet.

--- a/pages/blog/people-like-me-are-why-you-shouldnt-run-a-hosting-company/index.mdx
+++ b/pages/blog/people-like-me-are-why-you-shouldnt-run-a-hosting-company/index.mdx
@@ -2,7 +2,7 @@
 title: "People like me are why you shouldn't run a hosting company"
 description: "A daring adventure of manipulating GET parameters in a NextJS 14 project, pushing hosting limits and avoiding the need for data storage. Dive into the chaos of compressing inputs to keep the project delightfully storage-free."
 published: 2023-12-22
-categories: "NextJS, React, Serverless"
+categories: "NextJS, React, Serverless, Backend"
 ---
 
 Did you know Vercel limits URLs to 14kb? I know because I'm awful 😂

--- a/pages/blog/pg-mem-and-jest-for-smooth-integration-testing/index.mdx
+++ b/pages/blog/pg-mem-and-jest-for-smooth-integration-testing/index.mdx
@@ -2,7 +2,7 @@
 title: "pg-mem and jest for smooth integration testing"
 description: "The cult of TDD leads you down a dark and stormy path towards brittle code with a false sense of security. But there is a better way. A sweet spot between unit and heavy integration."
 published: 2021-12-21
-categories: "Backend, JavaScript, TypeScript, Testing"
+categories: "Backend, JavaScript, TypeScript, Testing, Software Engineering"
 ---
 
 It's no secret that I think [the cult of TDD](https://swizec.com/blog/25-lessons-from-25-years-of-coding/#2-tests-are-great-swbut-tdd-is-a-cult) leads you down a dark and stormy path towards brittle code with a false sense of security.

--- a/pages/blog/probably-the-realest-thing-i-ever-wrote/index.mdx
+++ b/pages/blog/probably-the-realest-thing-i-ever-wrote/index.mdx
@@ -2,7 +2,7 @@
 title: "Probably the realest thing I ever wrote"
 description: ""
 published: 2026-02-28
-categories: "Career, Mindset, Scaling Fast Book"
+categories: "Career, Senior Mindset, Scaling Fast Book"
 content_upgrade: ScalingFast
 ---
 

--- a/pages/blog/programatically-uploading-to-blobstore-in-python/index.mdx
+++ b/pages/blog/programatically-uploading-to-blobstore-in-python/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-08-10
 redirect_from:
   - /blog/programatically-uploading-to-blobstore-in-python/swizec/1423
-categories: "API, django, python"
+categories: "API, django, python, Backend"
 ---
 
 Officially this is something that cannot be done. Or rather that shouldn't be done. When you look at the [google appengine](http://code.google.com/appengine/ "Google App Engine") docs on "[uploading](http://en.wikipedia.org/wiki/Uploading_and_downloading "Uploading and downloading") to blobstore" this is what they have to say:

--- a/pages/blog/pure-pwnage-is-the-best-show-ever/index.mdx
+++ b/pages/blog/pure-pwnage-is-the-best-show-ever/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-03-22
 redirect_from:
   - /blog/pure-pwnage-is-the-best-show-ever/swizec/1258
-categories: "Canada, Games, intrigues, Personal"
+categories: "Canada, Games, intrigues, Personal, Travel + Events"
 ---
 
 - [![Pure Pwnage](https://swizec.com/wp-content/uploads/2010/03/300px-Purepwnage.jpg "Pure Pwnage")](http://en.wikipedia.org/wiki/Image:Purepwnage.jpg)

--- a/pages/blog/put-scope-on-your-resume/index.mdx
+++ b/pages/blog/put-scope-on-your-resume/index.mdx
@@ -2,7 +2,7 @@
 title: "Put scope on your resume"
 description: "Your resume titles don't matter. Just tell me what did you do."
 published: 2026-03-04
-categories: "Career, Mindset, Positioning"
+categories: "Career, Senior Mindset, Positioning"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/python-multiprocessing-is-fucking-sweet/index.mdx
+++ b/pages/blog/python-multiprocessing-is-fucking-sweet/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-01-18
 redirect_from:
   - /blog/python-multiprocessing-is-fucking-sweet/swizec/1150
-categories: "API, food for thought, Personal, Programming"
+categories: "API, food for thought, Personal, Programming, Backend"
 ---
 
 - [![CRAY-1 (no longer used, of course) displayed i...](https://swizec.com/wp-content/uploads/2010/01/300px-Cray-1-p1010221.jpg "CRAY-1 (no longer used, of course) displayed i...")](http://commons.wikipedia.org/wiki/Image:Cray-1-p1010221.jpg)

--- a/pages/blog/quick-and-easy-way-to-getting-burned-by-nginx/index.mdx
+++ b/pages/blog/quick-and-easy-way-to-getting-burned-by-nginx/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-10-05
 redirect_from:
   - /blog/quick-and-easy-way-to-getting-burned-by-nginx/swizec/2572
-categories: "Linux, Server"
+categories: "Linux, Server, Backend"
 ---
 
 ![HTTP 403: Forbidden](https://swizec.com/wp-content/uploads/2011/10/2990635787_f61ba8ce93_m1.jpg)

--- a/pages/blog/quick-tip-for-system-design-interviews/index.mdx
+++ b/pages/blog/quick-tip-for-system-design-interviews/index.mdx
@@ -2,7 +2,7 @@
 title: "Quick tip for system design interviews"
 description: "What are system design interviews for anyway?"
 published: 2022-01-28
-categories: "Interviewing, Tips, Mindset"
+categories: "Interviewing, Tips, Senior Mindset"
 hero: ./img/3217FB24-9CD2-4253-BBBC-7901DA7C904A.png
 ---
 

--- a/pages/blog/react-bricks-visual-blocks-editor-for-nextjs-codewithswiz-22/index.mdx
+++ b/pages/blog/react-bricks-visual-blocks-editor-for-nextjs-codewithswiz-22/index.mdx
@@ -3,7 +3,7 @@ title: "React Bricks - visual blocks editor for NextJS #CodeWithSwiz 22"
 description: "Tried a new visual editor for NextJS and CreateReactApp. Got a site up in 20min 🤘"
 published: 2021-02-09
 hero: ./img/hero-page.png
-categories: "CodeWithSwiz, Technical, NextJS, DevOps, Livecoding"
+categories: "CodeWithSwiz, Technical, NextJS, DevOps, Livecoding, Backend"
 ---
 
 Tried a new visual editor for NextJS and CreateReactApp. Got a site up in 20min 🤘

--- a/pages/blog/reader-question-feeling-guilt-as-a-tech-lead/index.mdx
+++ b/pages/blog/reader-question-feeling-guilt-as-a-tech-lead/index.mdx
@@ -2,7 +2,7 @@
 title: "Reader question: Feeling guilt as a tech lead"
 description: "Keep getting the guilt, that I'm not able to code, just running around for discussions and solving other issues, managing people. Any idea to manage all the fronts and get rid of this guilt?"
 published: 2022-07-23
-categories: "Productivity, Mindset, Reader Question"
+categories: "Productivity, Senior Mindset, Reader Question"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/reader-question-so-about-that-perfect-burndown-chart/index.mdx
+++ b/pages/blog/reader-question-so-about-that-perfect-burndown-chart/index.mdx
@@ -2,7 +2,7 @@
 title: "Reader question: So about that perfect burndown chart ..."
 description: "If your approach works so well, why isn't every team doing this?"
 published: 2022-08-06
-categories: "Productivity, Velocity, Mindset, Management, Teamwork, Reader Question, Leadership, Software Engineering"
+categories: "Productivity, Velocity, Senior Mindset, Management, Teamwork, Reader Question, Leadership, Software Engineering"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/reader-question-so-about-that-perfect-burndown-chart/index.mdx
+++ b/pages/blog/reader-question-so-about-that-perfect-burndown-chart/index.mdx
@@ -2,7 +2,7 @@
 title: "Reader question: So about that perfect burndown chart ..."
 description: "If your approach works so well, why isn't every team doing this?"
 published: 2022-08-06
-categories: "Productivity, Velocity, Mindset, Management, Teamwork, Reader Question, Leadership"
+categories: "Productivity, Velocity, Mindset, Management, Teamwork, Reader Question, Leadership, Software Engineering"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/reader-question-what-do-collaborative-teams-look-like/index.mdx
+++ b/pages/blog/reader-question-what-do-collaborative-teams-look-like/index.mdx
@@ -3,7 +3,7 @@ title: "Reader Question: What do collaborative teams look like?"
 description: "New members on our team invariably say 2 things:\n1. Wow I've never seen a team move this fast\n2. This approach feels weird. I'm uncomfortable\nTeams like this are not common."
 published: 2022-08-27
 content_upgrade: SeniorMindset
-categories: "Productivity, Velocity, Mindset, Management, Teamwork, Reader Question, Leadership, Software Engineering"
+categories: "Productivity, Velocity, Senior Mindset, Management, Teamwork, Reader Question, Leadership, Software Engineering"
 ---
 
 Fellow reader Jeremy wrote in with a question:

--- a/pages/blog/reader-question-what-do-collaborative-teams-look-like/index.mdx
+++ b/pages/blog/reader-question-what-do-collaborative-teams-look-like/index.mdx
@@ -3,7 +3,7 @@ title: "Reader Question: What do collaborative teams look like?"
 description: "New members on our team invariably say 2 things:\n1. Wow I've never seen a team move this fast\n2. This approach feels weird. I'm uncomfortable\nTeams like this are not common."
 published: 2022-08-27
 content_upgrade: SeniorMindset
-categories: "Productivity, Velocity, Mindset, Management, Teamwork, Reader Question, Leadership"
+categories: "Productivity, Velocity, Mindset, Management, Teamwork, Reader Question, Leadership, Software Engineering"
 ---
 
 Fellow reader Jeremy wrote in with a question:

--- a/pages/blog/reader-question:-when-do-you-fix-tech-debt/index.mdx
+++ b/pages/blog/reader-question:-when-do-you-fix-tech-debt/index.mdx
@@ -2,7 +2,7 @@
 title: 'Reader question: "When do you fix tech debt?"'
 description: 'Long time reader Phil asks when do you fix the tech debt you used to ship faster. Heroic efforts don''t work. The real answer is "always" – a mindset of gardening.'
 published: 2021-08-17
-categories: "Senior Mindset, Mindset, Opinion, Reader Question"
+categories: "Senior Mindset, Opinion, Reader Question"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/remember-to-feed-your-sysadmins/index.mdx
+++ b/pages/blog/remember-to-feed-your-sysadmins/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-05-14
 redirect_from:
   - /blog/remember-to-feed-your-sysadmins/swizec/4332
-categories: "Server, Tools, WordPress"
+categories: "Server, Tools, WordPress, Backend"
 hero: ./img/2270-1800816503_6147f638fd_m.jpg
 ---
 

--- a/pages/blog/reverse-engineer-a-graphql-api-to-automate-love-notes-codewithswiz-24/index.mdx
+++ b/pages/blog/reverse-engineer-a-graphql-api-to-automate-love-notes-codewithswiz-24/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Reverse engineer a GraphQL API to automate love notes – CodeWithSwiz 24"
 description: "We used a man-in-the-middle attack to snoop an app's API traffic, replayed it in a GraphQL client, and successfully put it inside an AWS Lambda 🤘"
-categories: "CodeWithSwiz, Technical, GraphQL, Serverless, AWS, Livecoding, DevOps"
+categories: "CodeWithSwiz, Technical, GraphQL, Serverless, AWS, Livecoding, DevOps, Backend"
 published: 2021-02-23
 ---
 

--- a/pages/blog/running-bloody-hurts/index.mdx
+++ b/pages/blog/running-bloody-hurts/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2009-07-18
 redirect_from:
   - /blog/running-bloody-hurts/swizec/626
-categories: "Personal, Ljubljana, running"
+categories: "Personal, Ljubljana, running, Travel + Events"
 ---
 
 - [](http://www.flickr.com/photos/90731709@N00/2854210384/)

--- a/pages/blog/scaling-teams-is-a-technical-challenge/index.mdx
+++ b/pages/blog/scaling-teams-is-a-technical-challenge/index.mdx
@@ -2,7 +2,7 @@
 title: "Scaling teams is a technical challenge"
 description: "A founder friend asked me about growing pains on his team. How do you avoid stepping on each other's toes? "
 published: 2022-11-29
-categories: "Leadership, Teamwork, Productivity, Velocity"
+categories: "Leadership, Teamwork, Productivity, Velocity, Software Engineering"
 ---
 
 The other day a founder friend asked me about growing pains on his team. How do you avoid stepping on each other's toes?

--- a/pages/blog/science-wednesday-selfdriving-cars/index.mdx
+++ b/pages/blog/science-wednesday-selfdriving-cars/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-12-14
 redirect_from:
   - /blog/science-wednesday-self-driving-cars/swizec/3178
-categories: "Algorithm, Google, San Francisco"
+categories: "Algorithm, Google, San Francisco, Travel + Events"
 ---
 
 ![A DARPA challenge loser](https://swizec.com/wp-content/uploads/2011/12/ai-car-lol7.jpg "A DARPA challenge loser")

--- a/pages/blog/science-wednesday-towards-a-computational-model-of-poetry-generation/index.mdx
+++ b/pages/blog/science-wednesday-towards-a-computational-model-of-poetry-generation/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-03-07
 redirect_from:
   - /blog/science-wednesday-towards-a-computational-model-of-poetry-generation/swizec/3855
-categories: "art, Ljubljana, Poetry"
+categories: "art, Ljubljana, Poetry, Travel + Events"
 ---
 
 ![English: Three quarter length portrait of Osca...](https://swizec.com/wp-content/uploads/2012/03/300px-Oscar_Wilde_portrait_by_Napoleon_Sarony_-_albumen4.jpg "English: Three quarter length portrait of Osca...")

--- a/pages/blog/selling-to-girls/index.mdx
+++ b/pages/blog/selling-to-girls/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-03-20
 redirect_from:
   - /blog/know-your-market-selling-to-girls/swizec/4031
-categories: "Business, Recreation, Slovenia"
+categories: "Business, Recreation, Slovenia, Travel + Events"
 ---
 
 This is a story of three guys writing a [business plan](http://en.wikipedia.org/wiki/Business_plan "Business plan") for a class at college. A business that rakes in 500,000 euro in sales after three years, with 30k of pure profits to boot.

--- a/pages/blog/serverless-file-upload-to-s3-with-nextjs-and-aws-lambda-codewithswiz-27/index.mdx
+++ b/pages/blog/serverless-file-upload-to-s3-with-nextjs-and-aws-lambda-codewithswiz-27/index.mdx
@@ -2,7 +2,7 @@
 title: "Serverless file upload to S3 with NextJS and AWS Lambda – CodeWithSwiz 27"
 description: "The Girl loves her daily cute photos, but she's bored of repeats. What if adding images was easier 🤔"
 published: 2021-04-20
-categories: "Livecoding, CodeWithSwiz, Serverless"
+categories: "Livecoding, CodeWithSwiz, Serverless, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/serverless-handbook-coming-mar-31st/index.mdx
+++ b/pages/blog/serverless-handbook-coming-mar-31st/index.mdx
@@ -2,7 +2,7 @@
 title: "Serverless Handbook coming Mar 31st"
 description: "Serverless is the future. New book coming out Mar 31st and it's looking bomb"
 published: 2021-03-23
-categories: "Books, Serverless"
+categories: "Books, Serverless, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/shipped-code-wins/index.mdx
+++ b/pages/blog/shipped-code-wins/index.mdx
@@ -2,7 +2,7 @@
 title: "Shipped code wins"
 description: ""
 published: 2022-11-02
-categories: "Thoughts, Mindset"
+categories: "Thoughts, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/should-you-join-an-ai-startup-right-now/index.mdx
+++ b/pages/blog/should-you-join-an-ai-startup-right-now/index.mdx
@@ -3,7 +3,7 @@ title: "Should you join an AI startup right now?"
 description: "Beyond income there's 2 reasons to take any specific job: Invest in yourself or invest in the company. Both is best."
 published: 2025-09-09
 content_upgrade: SeniorMindset
-categories: "Career, Startup, Mindset, Reader Question"
+categories: "Career, Startup, Senior Mindset, Reader Question"
 ---
 
 Beyond income there's 2 reasons to take any specific job: Invest in yourself or invest in the company. Both is best.

--- a/pages/blog/should-you-take-a-pay-cut-for-equity/index.mdx
+++ b/pages/blog/should-you-take-a-pay-cut-for-equity/index.mdx
@@ -3,7 +3,7 @@ title: "Should you take a pay cut for equity"
 description: "Would you take some % of your salary in bitcoin? The joke is that compared to pre-IPO equity, bitcoin is predictable and has a known value."
 published: 2020-10-09
 content_upgrade: SeniorMindset
-categories: "Opinion, Learning, Mindset"
+categories: "Opinion, Learning, Senior Mindset"
 ---
 
 

--- a/pages/blog/silicon-valley-is-like-hollywood/index.mdx
+++ b/pages/blog/silicon-valley-is-like-hollywood/index.mdx
@@ -3,7 +3,7 @@ title: '"silicon valley is like hollywood"'
 description: "and I don't mean Silicon Valley the place, I mean Silicon Valley the concept."
 published: 2021-01-29
 hero: ./img/swizec-teller-large.jpg
-categories: "Opinion, Podcast, Mindset"
+categories: "Opinion, Podcast, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/similarity-search-with-pgvector-and-supabase/index.mdx
+++ b/pages/blog/similarity-search-with-pgvector-and-supabase/index.mdx
@@ -2,7 +2,7 @@
 title: "Similarity search with pgvector and Supabase"
 description: "Explore the power of pgvector and Supabase for efficient similarity search in this comprehensive guide. Keep vector data next to your business data for efficient queries and less overhead."
 published: 2023-09-04
-categories: "AI, Database, AI Engineer, SwizBot, Side Project"
+categories: "AI, Database, AI Engineer, SwizBot, Side Project, Backend"
 ---
 
 A while back I shared how you can build [semantic search in an afternoon](https://swizec.com/blog/build-semantic-search-in-an-afternoon-yep/) with modern tech. Pretty sweet, right?

--- a/pages/blog/simple-trick-for-testing-forms-full-of-checkboxes-with-django/index.mdx
+++ b/pages/blog/simple-trick-for-testing-forms-full-of-checkboxes-with-django/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-12-02
 redirect_from:
   - /blog/simple-trick-for-testing-forms-full-of-checkboxes-with-django/swizec/3098
-categories: "django, Programming, python, Testing"
+categories: "django, Programming, python, Testing, Backend"
 ---
 
 In late 2011 I hope we can all agree that [unit testing](http://en.wikipedia.org/wiki/Unit_testing "Unit testing") is pretty important when creating websites or almost anything. Doesn't really matter whether you prefer a blackbox [integration testing](http://en.wikipedia.org/wiki/Integration_testing "Integration testing") approach or a strict unit testing style. What matters is that you have tests.

--- a/pages/blog/simple-trick-for-testing-forms-full-of-checkboxes-with-django/index.mdx
+++ b/pages/blog/simple-trick-for-testing-forms-full-of-checkboxes-with-django/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-12-02
 redirect_from:
   - /blog/simple-trick-for-testing-forms-full-of-checkboxes-with-django/swizec/3098
-categories: "django, Programming, python, Testing, Backend"
+categories: "django, Programming, python, Testing, Backend, Software Engineering"
 ---
 
 In late 2011 I hope we can all agree that [unit testing](http://en.wikipedia.org/wiki/Unit_testing "Unit testing") is pretty important when creating websites or almost anything. Doesn't really matter whether you prefer a blackbox [integration testing](http://en.wikipedia.org/wiki/Integration_testing "Integration testing") approach or a strict unit testing style. What matters is that you have tests.

--- a/pages/blog/simple-trick-that-lets-you-code-twice-as-fast/index.mdx
+++ b/pages/blog/simple-trick-that-lets-you-code-twice-as-fast/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-10-08
 redirect_from:
   - /blog/simple-trick-that-lets-you-code-twice-as-fast/swizec/5382
-categories: "Automation, Programming, Testing"
+categories: "Automation, Programming, Testing, Software Engineering"
 ---
 
 ![Basic idea from THE Bret Victor talk](https://icant.co.uk/talks/h5/pictures/smashingconf/shorterjourney.jpg "Basic idea from THE Bret Victor talk")

--- a/pages/blog/small-change-in-big-scary-codebase/index.mdx
+++ b/pages/blog/small-change-in-big-scary-codebase/index.mdx
@@ -2,7 +2,7 @@
 title: "Small change in big scary codebase?"
 description: "Making small changes in large unfamiliar codebases is the job. That's what engineers do all day."
 published: 2024-08-07
-categories: "Mindset, Software Engineering, Reader Question"
+categories: "Senior Mindset, Software Engineering, Reader Question"
 ---
 
 Fellow reader B writes in with a great question: How do you make a small change in a large unfamiliar codebase?

--- a/pages/blog/small-trick-for-seamless-base64-password-storage-in-django/index.mdx
+++ b/pages/blog/small-trick-for-seamless-base64-password-storage-in-django/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-07-14
 redirect_from:
   - /blog/small-trick-for-seamless-base64-password-storage-in-django/swizec/1378
-categories: "API, django, python"
+categories: "API, django, python, Backend"
 ---
 
 - [![OAuth logo](https://swizec.com/wp-content/uploads/2010/08/300px-Oauth_logo.svg_.png "OAuth logo")](http://commons.wikipedia.org/wiki/File:Oauth_logo.svg)

--- a/pages/blog/software-engineer-interviews-for-the-age-of-ai/index.mdx
+++ b/pages/blog/software-engineer-interviews-for-the-age-of-ai/index.mdx
@@ -2,7 +2,7 @@
 title: "Software engineer interviews for the age of AI"
 description: "Maybe AI will replace engineers, I don't know. Self-driving cars were just around the corner for 50 years. Until then we've got shit to do and engineers to hire."
 published: 2026-03-25
-categories: "Interviewing, Career, AI, Mindset"
+categories: "Interviewing, Career, AI, Senior Mindset"
 content_upgrade: ScalingFast
 ---
 

--- a/pages/blog/solve-the-problem-not-a-different-more-difficult-problem/index.mdx
+++ b/pages/blog/solve-the-problem-not-a-different-more-difficult-problem/index.mdx
@@ -2,7 +2,7 @@
 title: "Solve the problem, not a different more difficult problem"
 description: "Solve the problem at hand, not the one you imagine might come next. A simple fix now often beats a complex one later."
 published: 2023-10-04
-categories: "Mindset, Software Engineering, Software Architecture, Complexity"
+categories: "Senior Mindset, Software Engineering, Software Architecture, Complexity"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/some-personal-news/index.mdx
+++ b/pages/blog/some-personal-news/index.mdx
@@ -2,7 +2,7 @@
 title: "Some personal news"
 description: "When you see a unicorn, you gotta hop on"
 published: 2024-08-09
-categories: "Career, Personal, Mindset"
+categories: "Career, Personal, Senior Mindset"
 ---
 
 Almost 10 years ago I came to Silicon Valley because _"if you want to build unicorns, you have to be where the unicorns are"_. That means if you see a unicorn, you gotta jump on it.

--- a/pages/blog/splitting-and-merging-django-models-with-perfect-transparency/index.mdx
+++ b/pages/blog/splitting-and-merging-django-models-with-perfect-transparency/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-02-18
 redirect_from:
   - /blog/splitting-and-merging-django-models-with-perfect-transparency/swizec/1178
-categories: "django, food for thought, intrigues, Programming, python"
+categories: "django, food for thought, intrigues, Programming, python, Backend"
 ---
 
 This is a howto that might come in handy to some people, but mostly I just want to document how I poked around some very angry django dragons and created something marvelous. There are also people on twitter who were wondering what the fuck I was doing.

--- a/pages/blog/sprint-vs-shape-up-vs-kanban/index.mdx
+++ b/pages/blog/sprint-vs-shape-up-vs-kanban/index.mdx
@@ -2,7 +2,7 @@
 title: "Sprint vs Shape Up vs Kanban"
 description: "Whenever I talk about sprints, someone mentions Shape Up. So you have 9 week sprints – what's the difference?"
 published: 2025-03-26
-categories: "Teamwork, Mindset, Scaling Fast Book, Reader Question, Leadership"
+categories: "Teamwork, Senior Mindset, Scaling Fast Book, Reader Question, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/squash-merge-really/index.mdx
+++ b/pages/blog/squash-merge-really/index.mdx
@@ -3,7 +3,7 @@ title: "Squash merge? Really!?"
 description: "Learn why squash merging is your friend - from hating it to loving it! Squash merging helps you keep moving and focus on the work instead of recording the work."
 published: 2023-01-27
 content_upgrade: SeniorMindset
-categories: "Teamwork, Productivity, Mindset, Velocity, Reader Question, Leadership, Software Engineering"
+categories: "Teamwork, Productivity, Senior Mindset, Velocity, Reader Question, Leadership, Software Engineering"
 ---
 
 Yes, squash merge. I hated it, now I love it. Squash merge is your friend.

--- a/pages/blog/squash-merge-really/index.mdx
+++ b/pages/blog/squash-merge-really/index.mdx
@@ -3,7 +3,7 @@ title: "Squash merge? Really!?"
 description: "Learn why squash merging is your friend - from hating it to loving it! Squash merging helps you keep moving and focus on the work instead of recording the work."
 published: 2023-01-27
 content_upgrade: SeniorMindset
-categories: "Teamwork, Productivity, Mindset, Velocity, Reader Question, Leadership"
+categories: "Teamwork, Productivity, Mindset, Velocity, Reader Question, Leadership, Software Engineering"
 ---
 
 Yes, squash merge. I hated it, now I love it. Squash merge is your friend.

--- a/pages/blog/stateless-decision-making/index.mdx
+++ b/pages/blog/stateless-decision-making/index.mdx
@@ -2,7 +2,7 @@
 title: "Stateless decision making"
 description: "Do you ever feel like your brain is full and there's so much going on you can barely keep up? Me too."
 published: 2025-05-10
-categories: "Mindset, Teamwork, Leadership"
+categories: "Senior Mindset, Teamwork, Leadership"
 ---
 
 Do you ever feel like your brain is full and there's so much going on you can barely keep up? Me too.

--- a/pages/blog/steal-my-startup-idea-rentamum/index.mdx
+++ b/pages/blog/steal-my-startup-idea-rentamum/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-05-04
 redirect_from:
   - /blog/steal-my-startup-idea-rent-a-mum/swizec/4300
-categories: "Business, Entrepreneur, Silicon Valley, Startup"
+categories: "Business, Entrepreneur, Silicon Valley, Startup, Travel + Events"
 hero: ./img/1241-745454236_b09e49d2ee_m.jpg
 ---
 

--- a/pages/blog/stop-shouting-shouting/index.mdx
+++ b/pages/blog/stop-shouting-shouting/index.mdx
@@ -2,7 +2,7 @@
 title: "Stop SHOUTING = 'shouting'"
 description: "A hill I will die on 👉 global CONSTANT = 'constant' are bad"
 published: 2021-09-21
-categories: "Opinion, TypeScript, JavaScript, Programming Lessons"
+categories: "Opinion, TypeScript, JavaScript, Programming Lessons, Software Engineering"
 ---
 
 You've seen this pattern before – CONSTANT = 'constant' – common in dynamic languages.

--- a/pages/blog/switching-from-apache-to-nginx-is-a-dream/index.mdx
+++ b/pages/blog/switching-from-apache-to-nginx-is-a-dream/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2009-12-14
 redirect_from:
   - /blog/switching-from-apache-to-nginx-is-a-dream/swizec/978
-categories: "intrigues, Personal, Server"
+categories: "intrigues, Personal, Server, Backend"
 ---
 
 [![A server used for the My Home](https://swizec.com/wp-content/uploads/2009/12/300px-My_Opera_Server.jpg](http://commons.wikipedia.org/wiki/Image:My_Opera_Server.jpg)

--- a/pages/blog/symfony-and-the-scary-world-of-php/index.mdx
+++ b/pages/blog/symfony-and-the-scary-world-of-php/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-10-26
 redirect_from:
   - /blog/symfony-and-the-scary-world-of-php/swizec/5441
-categories: "API, django, OpenSource, PHP"
+categories: "API, django, OpenSource, PHP, Backend"
 hero: ./img/3157-2523296126_77affed9eb.jpg
 ---
 

--- a/pages/blog/talk-to-more-users-sooner/index.mdx
+++ b/pages/blog/talk-to-more-users-sooner/index.mdx
@@ -2,7 +2,7 @@
 title: "Talk to more users sooner"
 description: "Debate less, ship more."
 published: 2025-03-06
-categories: "Product Development, Mindset, Leadership"
+categories: "Product Development, Senior Mindset, Leadership"
 ---
 
 Here's a fun lesson. Sharing while it's fresh.

--- a/pages/blog/taming-chaos-is-a-learnable-skill/index.mdx
+++ b/pages/blog/taming-chaos-is-a-learnable-skill/index.mdx
@@ -3,7 +3,7 @@ title: "Taming chaos is a learnable skill"
 description: "How you approach software engineering makes it harder or easier to handle interruptions and other chaos. Writing a behavioral interview made me realize this is a learnable skill!"
 published: 2026-03-11
 content_upgrade: ScalingFast
-categories: "Mindset, Software Engineering, Scaling Fast Book"
+categories: "Senior Mindset, Software Engineering, Scaling Fast Book"
 ---
 
 How you approach software engineering makes it harder or easier to handle interruptions and other chaos. Writing a behavioral interview made me realize this is a learnable skill!

--- a/pages/blog/tedxyouth-ljubljana-report/index.mdx
+++ b/pages/blog/tedxyouth-ljubljana-report/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-11-22
 redirect_from:
   - /blog/tedxyouth-ljubljana-report/swizec/3039
-categories: "Ljubljana, Online Communities, Slovenia, TED, Twitter"
+categories: "Ljubljana, Online Communities, Slovenia, TED, Twitter, Travel + Events"
 ---
 
 Sunday saw the eighth [TEDx](http://www.ted.com/tedx "TEDx")event in Ljubljana and through immense luck I was able to attend despite forgetting to reserve a ticket.

--- a/pages/blog/testing-socketio-apps/index.mdx
+++ b/pages/blog/testing-socketio-apps/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-11-30
 redirect_from:
   - /blog/testing-socket-io-apps/swizec/5625
-categories: "Client, JavaScript, Programming, Server"
+categories: "Client, JavaScript, Programming, Server, Backend"
 ---
 
 [![Nyan cat testing](https://swizec.com/wp-content/uploads/2012/11/nyan-cat-testing2.png](https://swizec.com/wp-content/uploads/2012/11/nyan-cat-testing2.png)

--- a/pages/blog/that-time-serverless-melted-my-credit-card/index.mdx
+++ b/pages/blog/that-time-serverless-melted-my-credit-card/index.mdx
@@ -2,7 +2,7 @@
 title: "That time serverless melted my credit card"
 description: "Serverless is pretty cheap. But you *can* get it wrong."
 published: 2021-03-12
-categories: "Serverless, Technical, Indie Hacking"
+categories: "Serverless, Technical, Indie Hacking, Backend"
 content_upgrade: Serverless
 ---
 

--- a/pages/blog/the-3-budgets/index.mdx
+++ b/pages/blog/the-3-budgets/index.mdx
@@ -3,7 +3,7 @@ title: "The 3 budgets"
 description: "Software engineering salaries come from one of 3 budgets. Which budget pays your salary shapes your day-to-day and influences your career trajectory"
 published: 2023-12-26
 content_upgrade: SeniorMindset
-categories: "Mindset, Career"
+categories: "Senior Mindset, Career"
 ---
 
 Software engineering salaries come from one of 3 budgets. Which budget pays your salary shapes your day-to-day and influences your career trajectory.

--- a/pages/blog/the-3-curves-that-make-a-scalable-business/index.mdx
+++ b/pages/blog/the-3-curves-that-make-a-scalable-business/index.mdx
@@ -2,7 +2,7 @@
 title: "The 3 curves that make a scalable business"
 description: "You want users and revenue to grow exponentially. Bugs per day to grow linearly. Support work to grow logarithmically. Your goal is to make this happen."
 published: 2026-02-10
-categories: "Software Engineering, Scaling Fast Book, Career, Mindset"
+categories: "Software Engineering, Scaling Fast Book, Career, Senior Mindset"
 content_upgrade: ScalingFast
 hero: ./img/IMG_3369.PNG
 ---

--- a/pages/blog/the-answer-to-5-soloists-in-a-trench-coat/index.mdx
+++ b/pages/blog/the-answer-to-5-soloists-in-a-trench-coat/index.mdx
@@ -3,7 +3,7 @@ title: "The answer to 5 soloists in a trench coat"
 description: "Team dysfunction where everyone's a soloist? Try this fix: Force the team to work on ONE story at a time."
 published: 2024-03-08
 content_upgrade: SeniorMindset
-categories: "Mindset, Teamwork, Reader Question, Scaling Fast Book, Leadership"
+categories: "Senior Mindset, Teamwork, Reader Question, Scaling Fast Book, Leadership"
 ---
 
 [name|Friend], many of you wrote back this week saying that I left you hanging on a cliffhanger. _"Yes! This is my team! What do we do!?"_

--- a/pages/blog/the-art-of-the-cowboy-merge/index.mdx
+++ b/pages/blog/the-art-of-the-cowboy-merge/index.mdx
@@ -3,7 +3,7 @@ title: "The art of the cowboy merge 🤠"
 description: "how do you catch a critical deadline that cannot be missed? We're talking external stakeholders, millions on the line, and it all hinges on *your* team getting it done on time. No overtime"
 published: 2022-09-08
 content_upgrade: SeniorMindset
-categories: "Productivity, Velocity, Mindset, Management, Teamwork, Leadership, Software Engineering"
+categories: "Productivity, Velocity, Senior Mindset, Management, Teamwork, Leadership, Software Engineering"
 ---
 
 How do you catch a critical deadline that cannot be missed? We're talking external stakeholders, millions on the line, and it all hinges on _your_ team getting it done on time.

--- a/pages/blog/the-art-of-the-cowboy-merge/index.mdx
+++ b/pages/blog/the-art-of-the-cowboy-merge/index.mdx
@@ -3,7 +3,7 @@ title: "The art of the cowboy merge 🤠"
 description: "how do you catch a critical deadline that cannot be missed? We're talking external stakeholders, millions on the line, and it all hinges on *your* team getting it done on time. No overtime"
 published: 2022-09-08
 content_upgrade: SeniorMindset
-categories: "Productivity, Velocity, Mindset, Management, Teamwork, Leadership"
+categories: "Productivity, Velocity, Mindset, Management, Teamwork, Leadership, Software Engineering"
 ---
 
 How do you catch a critical deadline that cannot be missed? We're talking external stakeholders, millions on the line, and it all hinges on _your_ team getting it done on time.

--- a/pages/blog/the-audience-loved-my-talk-but-i-didnt/index.mdx
+++ b/pages/blog/the-audience-loved-my-talk-but-i-didnt/index.mdx
@@ -2,7 +2,7 @@
 title: "The audience loved my talk but I didn't"
 description: "A critical look at a conference talk that went great but felt a little off."
 published: 2022-06-24
-categories: "Learning, Personal, Events, Talks"
+categories: "Learning, Personal, Events, Talks, Travel + Events"
 hero: ./img/FVb3vC0XoAE1-v0.jpeg
 ---
 

--- a/pages/blog/the-best-engineering-books-get-good-5-years-into-your-career/index.mdx
+++ b/pages/blog/the-best-engineering-books-get-good-5-years-into-your-career/index.mdx
@@ -3,7 +3,7 @@ title: "The best engineering books get good 5  years into your career "
 description: "The best engineering books aren't those you read at the start of your career. It's the ones you appreciate 5 years in."
 published: 2024-04-05
 content_upgrade: SeniorMindset
-categories: "Learning, Mindset, Books"
+categories: "Learning, Senior Mindset, Books"
 ---
 
 The best engineering books aren't those you read at the start of your career. It's the ones you appreciate 5 years in.

--- a/pages/blog/the-best-engineers-just-get-shit-done-sometimes-with-ai/index.mdx
+++ b/pages/blog/the-best-engineers-just-get-shit-done-sometimes-with-ai/index.mdx
@@ -3,7 +3,7 @@ title: "The best engineers just get shit done, sometimes with AI"
 description: "The best engineers I know never talk about their AI setup. The worst engineers I know only talk about their AI setup."
 published: 2026-03-19
 content_upgrade: ScalingFast
-categories: "Mindset, Career, Teamwork, Leadership"
+categories: "Senior Mindset, Career, Teamwork, Leadership"
 ---
 
 The best engineers I know never talk about their AI setup. The worst engineers I know only talk about their AI setup.

--- a/pages/blog/the-buxton-index-why-some-are-hard-to-work-with/index.mdx
+++ b/pages/blog/the-buxton-index-why-some-are-hard-to-work-with/index.mdx
@@ -2,7 +2,7 @@
 title: "The Buxton Index – why some are hard to work with"
 description: "The Buxton Index measures an entity's planning period and explains many of your work dynamics."
 published: 2024-01-12
-categories: "Mindset, Management, Learning, Leadership"
+categories: "Senior Mindset, Management, Learning, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/the-difference-between-a-product-and-a-project/index.mdx
+++ b/pages/blog/the-difference-between-a-product-and-a-project/index.mdx
@@ -2,7 +2,7 @@
 title: "The difference between a product and a project"
 description: "A project is something you do, a product is something you own."
 published: 2025-04-03
-categories: "Mindset, Teamwork, Product development, Scaling Fast Book, Leadership"
+categories: "Senior Mindset, Teamwork, Product development, Scaling Fast Book, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/the-future-of-software-engineering-is-sre/index.mdx
+++ b/pages/blog/the-future-of-software-engineering-is-sre/index.mdx
@@ -2,7 +2,7 @@
 title: "The future of software engineering is SRE"
 description: "When code gets cheap operational excellence wins. Anyone can build a greenfield demo, but it takes engineering to run a service."
 published: 2026-01-24
-categories: "Software Engineering, DevOps, Scaling Fast Book"
+categories: "Software Engineering, DevOps, Scaling Fast Book, Backend"
 content_upgrade: ScalingFast
 ---
 

--- a/pages/blog/the-greatest-story-i-have-to-tell/index.mdx
+++ b/pages/blog/the-greatest-story-i-have-to-tell/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-02-07
 redirect_from:
   - /blog/the-greatest-story-i-have-to-tell/swizec/3631
-categories: "California, Palo Alto, San Francisco, Silicon Valley"
+categories: "California, Palo Alto, San Francisco, Silicon Valley, Travel + Events"
 ---
 
 War veterans tell the best stories - testosterone-filled men crammed in compact spaces doing something dangerous/awesome produce the best stories.

--- a/pages/blog/the-grind-wont-get-you-there/index.mdx
+++ b/pages/blog/the-grind-wont-get-you-there/index.mdx
@@ -2,7 +2,7 @@
 title: "The grind won't get you there"
 description: "Don't grind on something the company doesn't value. Hard work is not rewarded. **_Outcomes_** are rewarded."
 published: 2025-10-04
-categories: "Mindset, Career"
+categories: "Senior Mindset, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/the-job-behind-the-job-of-a-high-level-ic/index.mdx
+++ b/pages/blog/the-job-behind-the-job-of-a-high-level-ic/index.mdx
@@ -2,7 +2,7 @@
 title: "The job behind the job [of a high level IC]"
 description: "Advancing big goals while you stay on top of operational day-to-day fires _is the job_. This is hard. Here are a few tips I've found helpful."
 published: 2025-10-25
-categories: "Mindset, Teamwork, Career, Leadership"
+categories: "Senior Mindset, Teamwork, Career, Leadership"
 ---
 
 Advancing big goals while you stay on top of operational day-to-day fires _is the job_. This is hard. Here are a few tips I've found helpful.

--- a/pages/blog/the-magic-function-principle/index.mdx
+++ b/pages/blog/the-magic-function-principle/index.mdx
@@ -2,7 +2,7 @@
 title: "The Magic Function principle"
 description: "Write functions, mostly magic."
 published: 2021-02-05
-categories: "Technical, Software Architecture, Mindset, Software Engineering"
+categories: "Technical, Software Architecture, Senior Mindset, Software Engineering"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/the-magic-function-principle/index.mdx
+++ b/pages/blog/the-magic-function-principle/index.mdx
@@ -2,7 +2,7 @@
 title: "The Magic Function principle"
 description: "Write functions, mostly magic."
 published: 2021-02-05
-categories: "Technical, Software Architecture, Mindset"
+categories: "Technical, Software Architecture, Mindset, Software Engineering"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/the-man-you-want-to-be-does-not-matter/index.mdx
+++ b/pages/blog/the-man-you-want-to-be-does-not-matter/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-08-03
 redirect_from:
   - /blog/the-man-you-want-to-be-does-not-matter/swizec/2071
-categories: "Oscar Wilde, Silicon Valley"
+categories: "Oscar Wilde, Silicon Valley, Travel + Events"
 ---
 
 ![Trade card of a cigar dealer after a photograp...](https://swizec.com/wp-content/uploads/2011/08/300px-Oscar_Wilde_Aesthetic_Cigars.jpg "Trade card of a cigar dealer after a photograp...")

--- a/pages/blog/the-one-thing-every-experienced-engineer-gets-wrong/index.mdx
+++ b/pages/blog/the-one-thing-every-experienced-engineer-gets-wrong/index.mdx
@@ -3,7 +3,7 @@ title: "The one thing every experienced engineer gets wrong"
 description: "In the last few months every engineer I hired stumbled in exactly the same way: Project management. They learned quickly, but that first big project has become a rite of passage."
 published: 2026-07-11
 content_upgrade: ScalingFast
-categories: "Project management, Teamwork, Engineering management, Mindset, Leadership"
+categories: "Project management, Teamwork, Engineering management, Senior Mindset, Leadership"
 ---
 
 In the last few months every engineer I hired stumbled in exactly the same way: Project management. They learned quickly, but that first big project has become a rite of passage.

--- a/pages/blog/the-programming-tutorial-seo-industry-is-dead/index.mdx
+++ b/pages/blog/the-programming-tutorial-seo-industry-is-dead/index.mdx
@@ -2,7 +2,7 @@
 title: "The programming tutorial SEO industry is dead"
 description: "20 years ago greybeards laughed at us for Googling. Now they laugh when we ask ChatGPT. But the leverage is 🚀"
 published: 2023-03-28
-categories: "AI, Opinion, Mindset"
+categories: "AI, Opinion, Senior Mindset"
 ---
 
 You may have noticed it's getting hard to find good programming help online. I've had several engineers say _"After 2 hours of Googling I finally looked at the docs and solved my problem in 5 minutes"_

--- a/pages/blog/the-quickest-way-to-fail-a-tech-interview/index.mdx
+++ b/pages/blog/the-quickest-way-to-fail-a-tech-interview/index.mdx
@@ -2,7 +2,7 @@
 title: "The quickest way to fail a tech interview"
 description: "No it's not a wrong answer or floundering with algorithms. Not even being nervous or shy or having a language barrier. Culture fit is the least of your worries if you make this mistake."
 published: 2022-01-11
-categories: "Mindset, Lesson, Interviewing"
+categories: "Senior Mindset, Lesson, Interviewing"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/the-quickest-way-to-kill-a-team/index.mdx
+++ b/pages/blog/the-quickest-way-to-kill-a-team/index.mdx
@@ -3,7 +3,7 @@ title: "The quickest way to kill a team"
 description: ""
 published: 2024-03-15
 content_upgrade: SeniorMindset
-categories: "Mindset, Teamwork, Scaling Fast Book, Leadership"
+categories: "Senior Mindset, Teamwork, Scaling Fast Book, Leadership"
 ---
 
 The quickest way to kill a team is by setting a bar where ideas are "good enough" to share.

--- a/pages/blog/the-realtime-webcamp-bash/index.mdx
+++ b/pages/blog/the-realtime-webcamp-bash/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-02-21
 redirect_from:
   - /blog/the-real-time-webcamp-bash/swizec/1184
-categories: "Personal, Ljubljana, Monty Python, review, YouTube"
+categories: "Personal, Ljubljana, Monty Python, review, YouTube, Travel + Events"
 ---
 
 - [![Carol Cleveland as the stereotypical "blo...](https://swizec.com/wp-content/uploads/2010/02/300px-CarolCleveland.jpg 'Carol Cleveland as the stereotypical "blo...')](http://en.wikipedia.org/wiki/Image:CarolCleveland.jpg)

--- a/pages/blog/the-role-of-a-senior-engineer/index.mdx
+++ b/pages/blog/the-role-of-a-senior-engineer/index.mdx
@@ -2,7 +2,7 @@
 title: "The role of a senior+ engineer"
 description: '"Every product org should have a senior+ engineer whose job it is to run around and make everyone else more productive" 🤔 That IS the role of a senior+ engineer'
 published: 2022-04-26
-categories: "Mindset, Ownership, Lesson, Leadership"
+categories: "Senior Mindset, Ownership, Lesson, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/the-score-takes-care-of-itself/index.mdx
+++ b/pages/blog/the-score-takes-care-of-itself/index.mdx
@@ -2,7 +2,7 @@
 title: "The score takes care of itself"
 description: "Less talking more doing"
 published: 2025-01-03
-categories: "Mindset, Books, Career"
+categories: "Senior Mindset, Books, Career"
 hero: ./img/IMG_2511.png
 ---
 

--- a/pages/blog/the-ten-pros-and-cons-of-unit-testing/index.mdx
+++ b/pages/blog/the-ten-pros-and-cons-of-unit-testing/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2009-08-04
 redirect_from:
   - /blog/the-ten-pros-and-cons-of-unit-testing/swizec/679
-categories: "Programming, Testing, Twitulater"
+categories: "Programming, Testing, Twitulater, Software Engineering"
 hero: ./img/2593-3788230354_c9ec0f8daa_m.jpg
 ---
 

--- a/pages/blog/the-tour-of-duty-approach-to-career/index.mdx
+++ b/pages/blog/the-tour-of-duty-approach-to-career/index.mdx
@@ -2,7 +2,7 @@
 title: "The Tour of Duty approach to career"
 description: "Quick note today to plant the seed of an idea I've always loved: The Tour of Duty."
 published: 2024-09-07
-categories: "Mindset, Career, Senior Mindset"
+categories: "Senior Mindset, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/the-trials-and-tribulations-of-a-largeish-dataset/index.mdx
+++ b/pages/blog/the-trials-and-tribulations-of-a-largeish-dataset/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2013-01-15
 redirect_from:
   - /blog/the-trials-and-tribulations-of-a-large-ish-dataset/swizec/5852
-categories: "Database, Github, Programming"
+categories: "Database, Github, Programming, Backend"
 ---
 
 Last week I wrote a little script in node.js.

--- a/pages/blog/the-unreasonable-effectiveness-of-stack-ranking/index.mdx
+++ b/pages/blog/the-unreasonable-effectiveness-of-stack-ranking/index.mdx
@@ -2,7 +2,7 @@
 title: "The unreasonable effectiveness of stack ranking"
 description: "Stakeholders are silly people. Everything feels important and urgent. Stack ranking helps"
 published: 2025-11-04
-categories: "Scaling Fast Book, Mindset, Teamwork, Leadership"
+categories: "Scaling Fast Book, Senior Mindset, Teamwork, Leadership"
 ---
 
 Stakeholders are silly people. TRAGEDY OF TRAGEDIES THE BUTTON IS 3px WRONG! Huh it kinda sucks that people get stuck in this checkout flow sometimes OMG I CLICKED A BUTTON AND THE PAGE DID SOMETHING FUNNY btw sometimes I can't do my work for like 2 hours but then it's fine.

--- a/pages/blog/there-are-no-bad-teams/index.mdx
+++ b/pages/blog/there-are-no-bad-teams/index.mdx
@@ -2,7 +2,7 @@
 title: "There are no bad teams" 
 description: "it’s the leader, not the team" 
 published: 2022-06-03
-categories: "Mindset"
+categories: "Senior Mindset"
 content_upgrade: SeniorMindset
 hero: ./img/BE68AC8C-1FDF-4972-A7B7-6134AB288C3E.png
 ---

--- a/pages/blog/these-3-alerts-catch-the-most-issues/index.mdx
+++ b/pages/blog/these-3-alerts-catch-the-most-issues/index.mdx
@@ -2,7 +2,7 @@
 title: "These 3 alerts catch the most issues"
 description: "Here's a few alerts I've found unreasonably effective over time"
 published: 2025-07-26
-categories: "Software Engineering, Observability"
+categories: "Software Engineering, Observability, Backend"
 ---
 
 Good observability is like a safety net. You get to move fast, [write fewer tests](https://swizec.com/blog/why-you-need-observability-more-than-tests/), and know that if production blows up you'll find out quick.

--- a/pages/blog/time-is-funny-in-ruby/index.mdx
+++ b/pages/blog/time-is-funny-in-ruby/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2017-03-29
 redirect_from:
   - /blog/time-funny-ruby/swizec/7525
-categories: "Rails, Technical"
+categories: "Rails, Technical, Backend"
 ---
 
 https://www.youtube.com/watch?v=2uj_2G_KaGw

--- a/pages/blog/today-was-the-worst-day-ive-ever-had/index.mdx
+++ b/pages/blog/today-was-the-worst-day-ive-ever-had/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-06-21
 redirect_from:
   - /blog/today-was-the-worst-day-ive-ever-had/swizec/1370
-categories: "Business, Personal, London"
+categories: "Business, Personal, London, Travel + Events"
 ---
 
 - [![Vending Machine for Books](https://swizec.com/wp-content/uploads/2010/06/639800453_8b1b6f3c26_m.jpg "Vending Machine for Books")](http://www.flickr.com/photos/95239135@N00/639800453)

--- a/pages/blog/trust-your-wings-not-the-market/index.mdx
+++ b/pages/blog/trust-your-wings-not-the-market/index.mdx
@@ -2,7 +2,7 @@
 title: "Trust your wings, not the market"
 description: "Success in your career doesn't come from relying on the market or job stability. It comes from trusting your own wings - having a clear vision, treating work as a value exchange, leveraging your skills, and owning your path"
 published: 2023-09-13
-categories: "Career, Mindset"
+categories: "Career, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/try-to-work-for-a-brand/index.mdx
+++ b/pages/blog/try-to-work-for-a-brand/index.mdx
@@ -2,7 +2,7 @@
 title: "Try to work for a brand"
 description: "Brand helps your career in subtle ways."
 published: 2022-01-14
-categories: "Opinion, Mindset"
+categories: "Opinion, Senior Mindset"
 ---
 
 Here's a career tip many engineers don't think of:

--- a/pages/blog/two-business-things-slovenia-needs-to-change/index.mdx
+++ b/pages/blog/two-business-things-slovenia-needs-to-change/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-02-15
 redirect_from:
   - /blog/two-business-things-slovenia-needs-to-change/swizec/3668
-categories: "Business, Education, Slovenia, Student"
+categories: "Business, Education, Slovenia, Student, Travel + Events"
 ---
 
 This post is aimed at my local readers, the rest can look at it as a curiosity from an awesome small country that is fumbling all over itself trying to be even awesomer.

--- a/pages/blog/unit-testing-is-antiproductive/index.mdx
+++ b/pages/blog/unit-testing-is-antiproductive/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2009-06-23
 redirect_from:
   - /blog/unit-testing-is-anti-productive/swizec/610
-categories: "food for thought, Programming, Testing, Twitulater"
+categories: "food for thought, Programming, Testing, Twitulater, Software Engineering"
 hero: ./img/3121-3652816293_3853125da9_m.jpg
 ---
 

--- a/pages/blog/unit-testing-is-for-lazy-people/index.mdx
+++ b/pages/blog/unit-testing-is-for-lazy-people/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-02-27
 redirect_from:
   - /blog/unit-testing-is-for-lazy-people/swizec/3752
-categories: "Testing, Programming"
+categories: "Testing, Programming, Software Engineering"
 ---
 
 The other day I was talking to a guy about a possible freelancing gig and he said how wonderful it was that I should bring up the topic of unit/[automated testing](http://en.wikipedia.org/wiki/Test_automation "Test automation")without being asked. Said that most (many?) developers don't have the level of rigor to use automated testing.

--- a/pages/blog/usecallback-is-a-code-smell/index.mdx
+++ b/pages/blog/usecallback-is-a-code-smell/index.mdx
@@ -3,7 +3,7 @@ title: "useCallback is a code smell"
 description: "One of my favorite ways to simplify and de-gotcha React code is to rip out all the useCallback and useMemo drama. 90% of the time you don't need it."
 published: 2022-09-16
 content_upgrade: ReactCU
-categories: "Technical, React, Frontend, Programming Lessons"
+categories: "Technical, React, Frontend, Programming Lessons, Software Engineering"
 ---
 
 One of my favorite ways to simplify and de-gotcha React code is to rip out all the `useCallback` and `useMemo` drama. 90% of the time you don't need it.

--- a/pages/blog/users-buy-your-service-not-your-code/index.mdx
+++ b/pages/blog/users-buy-your-service-not-your-code/index.mdx
@@ -2,7 +2,7 @@
 title: "Users buy your service, not your code"
 description: "You might enjoy this podcast episode. Sylvain and I talked about owning production in a world where AI writes the code."
 published: 2026-02-18
-categories: "AI, Software Engineering, Podcast, Mindset"
+categories: "AI, Software Engineering, Podcast, Senior Mindset"
 ---
 
 You might enjoy this podcast episode. [Sylvain and I talked about owning production in a world where AI writes the code](https://rootly.com/humans-of-reliability/swizec-teller).

--- a/pages/blog/using-dynamodb-streams-with-the-serverless-framework/index.mdx
+++ b/pages/blog/using-dynamodb-streams-with-the-serverless-framework/index.mdx
@@ -2,7 +2,7 @@
 title: "Using DynamoDB Streams with the Serverless Framework"
 description: "DynamoDB Streams are a convenient way to react to changes in your database. And surprisingly easy to use 🥳"
 published: 2022-01-04
-categories: "Serverless, AWS, Slack, TypeScript, DevOps"
+categories: "Serverless, AWS, Slack, TypeScript, DevOps, Backend"
 content_upgrade: Serverless
 hero: ./img/Architecture-diagram-of-using-a-DynamoDB-Stream0cbe7f.png
 ---

--- a/pages/blog/watch-people-work/index.mdx
+++ b/pages/blog/watch-people-work/index.mdx
@@ -3,7 +3,7 @@ title: "Watch people work"
 description: "We talk a lot about outcomes over outputs and how engineers are supposed to get us over the water, not blindly build a bridge because someone asked for a bridge. But how do you do that in practice?"
 published: 2026-04-14
 content_upgrade: ScalingFast
-categories: "Mindset, Software Engineering, Product Management, Productivity, Leadership"
+categories: "Senior Mindset, Software Engineering, Product Management, Productivity, Leadership"
 ---
 
 [name|Friend], we talk a lot about outcomes over outputs and how engineers are supposed to get us over the water, not blindly build a bridge because someone asked for a bridge. But how do you do that in practice?

--- a/pages/blog/we-are-not-generation-sell/index.mdx
+++ b/pages/blog/we-are-not-generation-sell/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-11-15
 redirect_from:
   - /blog/we-are-not-generation-sell/swizec/2926
-categories: "Employment, Slovenia, Steve Jobs, United States"
+categories: "Employment, Slovenia, Steve Jobs, United States, Travel + Events"
 ---
 
 [William Deresiewicz](http://en.wikipedia.org/wiki/William_Deresiewicz "William Deresiewicz") wrote yesterday in the new york times that the current generation is [generation sell](http://www.nytimes.com/2011/11/13/opinion/sunday/the-entrepreneurial-generation.html?_r=2&ref=opinion&pagewanted=all)- that they care about nothing more than selling themselves, their product or both. There was a clear hint that this is particularly bad and that a society of agreeable twenty somethings who would never do anything against the status quo or anyone in particular lest it damage their reputations and hurt their brand is simply bad.

--- a/pages/blog/weather-the-best-thing-about-silicon-valley/index.mdx
+++ b/pages/blog/weather-the-best-thing-about-silicon-valley/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-07-03
 redirect_from:
   - /blog/weather-the-best-thing-about-silicon-valley/swizec/4771
-categories: "Ljubljana, London, New York City, Silicon Valley, Startup"
+categories: "Ljubljana, London, New York City, Silicon Valley, Startup, Travel + Events"
 hero: ./img/6118-6227811644_bcd1328eae_b.jpg
 ---
 

--- a/pages/blog/webcamplj-was-bitchin/index.mdx
+++ b/pages/blog/webcamplj-was-bitchin/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2011-10-23
 redirect_from:
   - /blog/webcamplj-was-bitchin/swizec/2696
-categories: "Ljubljana, Online Communities, Slovenia, Social Network, Twitter"
+categories: "Ljubljana, Online Communities, Slovenia, Social Network, Twitter, Travel + Events"
 ---
 
 Yesterday was Webcamp time again and the creme de la creme of the [Slovenia](<http://maps.google.com/maps?ll=46.05,14.5&spn=10.0,10.0&q=46.05,14.5 (Slovenia)&t=h> "Slovenia") web scene gathered to bang chests and feel awesome.

--- a/pages/blog/what-coding-tutorials-and-teachers-get-wrong/index.mdx
+++ b/pages/blog/what-coding-tutorials-and-teachers-get-wrong/index.mdx
@@ -3,7 +3,7 @@ title: "What coding tutorials and teachers get wrong"
 description: "Chatting about teaching and learning complex technical skills with an engineer I'm mentoring. She's a former chef. We shared the same frustration with online resources."
 published: 2022-08-12
 content_upgrade: SeniorMindset
-categories: "Learning, Mentoring, Mindset, Leadership"
+categories: "Learning, Mentoring, Senior Mindset, Leadership"
 ---
 
 Yesterday we were chatting about teaching and learning complex technical skills with an engineer I'm mentoring. She's a former chef.

--- a/pages/blog/what-does-solve-problems-even-mean/index.mdx
+++ b/pages/blog/what-does-solve-problems-even-mean/index.mdx
@@ -2,7 +2,7 @@
 title: 'What does "solve problems" even mean'
 description: "Focus on solving problems, not just doing work or writing code. Think creatively, question existing processes, and prioritize effective outcomes"
 published: 2023-06-13
-categories: "Software Engineering, Mindset"
+categories: "Software Engineering, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/what-i-learned-from-team-topologies/index.mdx
+++ b/pages/blog/what-i-learned-from-team-topologies/index.mdx
@@ -2,7 +2,7 @@
 title: "What I learned from Team Topologies"
 description: "You can't escape Conway's Law. Might as well use it for good."
 published: 2023-07-21
-categories: "Software Architecture, Leadership, Teamwork, Books, Management"
+categories: "Software Architecture, Leadership, Teamwork, Books, Management, Software Engineering"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/what-i-learned-of-php-by-ignoring-it-for-three-months/index.mdx
+++ b/pages/blog/what-i-learned-of-php-by-ignoring-it-for-three-months/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2009-10-23
 redirect_from:
   - /blog/what-i-learned-of-php-by-ignoring-it-for-three-months/swizec/782
-categories: "food for thought, PHP, Programming"
+categories: "food for thought, PHP, Programming, Backend"
 ---
 
 When I took a break from php three months ago I'd been up to my shoulders in the technology for about five years - I remember my first interactions with the language were figuring out whether I need to use .php3 or .php4 or just .php file extensions. But that's not very interesting.

--- a/pages/blog/what-interviewers-look-for-in-senior-engineers/index.mdx
+++ b/pages/blog/what-interviewers-look-for-in-senior-engineers/index.mdx
@@ -3,7 +3,7 @@ title: "What interviewers look for in senior engineers"
 description: "People are starting to cheat in interviews using ChatGPT. It's obvious, doesn't work, and wouldn't even be cheating if you did it right!"
 published: 2024-02-01
 content_upgrade: SeniorMindset
-categories: "Interviewing, Mindset"
+categories: "Interviewing, Senior Mindset"
 ---
 
 Did you know people are starting to cheat in interviews using ChatGPT? It's obvious, doesn't work, and wouldn't even be cheating if you did it right!

--- a/pages/blog/what-is-the-goal-of-engineering/index.mdx
+++ b/pages/blog/what-is-the-goal-of-engineering/index.mdx
@@ -2,7 +2,7 @@
 title: "What is the goal of engineering?"
 description: "How can you know you're succeeding if you don't know where you're going?"
 published: 2022-01-20
-categories: "Mindset, Business"
+categories: "Senior Mindset, Business"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/what-makes-a-great-software-engineer/index.mdx
+++ b/pages/blog/what-makes-a-great-software-engineer/index.mdx
@@ -3,7 +3,7 @@ title: "What makes a great software engineer?"
 description: 'In 2015 a group of researchers asked 59 experienced engineers at Microsoft "What makes a great software engineer?". Here''s what they found.'
 published: 2022-07-11
 content_upgrade: SeniorMindset
-categories: "Mindset, Papers, Software Engineering"
+categories: "Senior Mindset, Papers, Software Engineering"
 hero: ./img/Research-paper-with-my-notes-and-scribblesfcjbai.png
 ---
 

--- a/pages/blog/what-makes-a-senior-engineer/index.mdx
+++ b/pages/blog/what-makes-a-senior-engineer/index.mdx
@@ -2,7 +2,7 @@
 title: "What makes a senior engineer"
 description: "The base expectation for engineers is that you don't just build whatever you're asked."
 published: 2025-07-22
-categories: "Mindset, Talks, Career, Leadership"
+categories: "Senior Mindset, Talks, Career, Leadership"
 ---
 
 The base expectation for engineers is that you don't just build whatever you're asked.

--- a/pages/blog/what-microservices-are-for/index.mdx
+++ b/pages/blog/what-microservices-are-for/index.mdx
@@ -3,7 +3,7 @@ title: "What microservices are for"
 description: "Microservices are a pain in the ass. They turn every system into a byzantine mess of complexity. But this week ... they saved my butt."
 published: 2022-05-13
 content_upgrade: Serverless
-categories: "Software Architecture, Backend"
+categories: "Software Architecture, Backend, Software Engineering"
 ---
 
 Microservices are a pain in the ass. They turn every system into a byzantine mess of complexity. But this week ... they saved my butt.

--- a/pages/blog/what-refactoring-is-and-what-it-isnt/index.mdx
+++ b/pages/blog/what-refactoring-is-and-what-it-isnt/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-04-11
 redirect_from:
   - /blog/what-refactoring-is-and-what-it-isnt/swizec/4148
-categories: "Language, Programmer, Programming, Refactoring"
+categories: "Language, Programmer, Programming, Refactoring, Software Engineering"
 ---
 
 _This post is my first test of zemanta's Blogspire, please tell me if you find this style of reblogging useful and I should do more in the future, or maybe I \_should\_ reblog, but differently. Thanks :)_

--- a/pages/blog/what-to-expect-in-senior-level-interviews/index.mdx
+++ b/pages/blog/what-to-expect-in-senior-level-interviews/index.mdx
@@ -2,7 +2,7 @@
 title: "What to expect in senior level interviews"
 description: "Interviews are terrible. Stressful, time-intensive, loosely correlated with on the job performance. They're the least terrible way we have to hire."
 published: 2021-11-25
-categories: "Mindset, Interviewing"
+categories: "Senior Mindset, Interviewing"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/what-to-work-on-next/index.mdx
+++ b/pages/blog/what-to-work-on-next/index.mdx
@@ -2,7 +2,7 @@
 title: "What to work on next?"
 description: "Younger engineers keep asking how I prioritize in a chaotic environment. Here's my approach."
 content_upgrade: SeniorMindset
-categories: "Mindset, Teamwork, Software Engineering, Leadership"
+categories: "Senior Mindset, Teamwork, Software Engineering, Leadership"
 published: 2025-04-14
 ---
 

--- a/pages/blog/whats-your-next-mountain/index.mdx
+++ b/pages/blog/whats-your-next-mountain/index.mdx
@@ -2,7 +2,7 @@
 title: "What's your next mountain?"
 description: "Life is a hill-climbing algorithm"
 published: 2024-12-21
-categories: "Opinion, Personal, Mindset"
+categories: "Opinion, Personal, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/when-to-join-and-leave-a-company-project-or-trend/index.mdx
+++ b/pages/blog/when-to-join-and-leave-a-company-project-or-trend/index.mdx
@@ -2,7 +2,7 @@
 title: "When to join and leave a company, project, or trend"
 description: "Timing changes everything. Who do you think has better engineers? The team that built Google from 9 million daily searches in 2000 to 1 billion in 2009, or the team that launched Google's 10th chat app last year?"
 published: 2022-04-07
-categories: "Career, Mindset"
+categories: "Career, Senior Mindset"
 content_upgrade: SeniorMindset
 hero: ./img/Using-S-curves-to-your-advantagef324j4.png
 ---

--- a/pages/blog/when-to-stay-at-a-company/index.mdx
+++ b/pages/blog/when-to-stay-at-a-company/index.mdx
@@ -3,7 +3,7 @@ title: "When to stay at a company"
 description: "Cap your down-side and think like an investor. Look for key metrics that can shape your career growth."
 published: 2024-01-23
 content_upgrade: SeniorMindset
-categories: "Mindset, Career, Reader Question"
+categories: "Senior Mindset, Career, Reader Question"
 ---
 
 A question that comes up a lot is _"How do you know when to stay at a company?"_. Someone asks this any time I bust out the [S-curves](https://swizec.com/blog/i-m-a-different-engineer-than-i-was-3-years-ago/) and talk about why [joining right before big growth is best](https://swizec.com/blog/when-to-join-and-leave-a-company-project-or-trend/).

--- a/pages/blog/why-a-coding-ai-like-github-copilot-wont-take-your-job/index.mdx
+++ b/pages/blog/why-a-coding-ai-like-github-copilot-wont-take-your-job/index.mdx
@@ -2,7 +2,7 @@
 title: "Why a coding AI like Github Copilot won't take your job"
 description: 'It might. What''s your job? If you''re in the *"write code to exact specifications"* business ... now''s a good time to start leveling up. The AI''s not ready yet.'
 published: 2021-07-07
-categories: "Opinion, AI, Mindset"
+categories: "Opinion, AI, Senior Mindset"
 ---
 
 It might. What's your job Friend?

--- a/pages/blog/why-a-tech-meltdown-is-the-best-time-to-invest-in-your-career/index.mdx
+++ b/pages/blog/why-a-tech-meltdown-is-the-best-time-to-invest-in-your-career/index.mdx
@@ -3,7 +3,7 @@ title: "Why a tech meltdown is the best time to invest in your career"
 description: "Invest in your career growth. Seize the moment to develop new skills and prepare for a brighter future"
 published: 2023-05-23
 content_upgrade: SeniorMindset
-categories: "Career, Mindset"
+categories: "Career, Senior Mindset"
 ---
 
 Tech has been going through a rough patch. Hiring freezes, promotion freezes, layoffs ... what's a regular schmuck like us to do? Attack!

--- a/pages/blog/why-experts-charge-more/index.mdx
+++ b/pages/blog/why-experts-charge-more/index.mdx
@@ -2,7 +2,7 @@
 title: "Why experts charge more"
 description: "Ever noticed how an expert's job isn't that different from an apprentice's? Yet they can charge way more 🤔"
 published: 2022-03-07
-categories: "Mindset, Compensation, Salary"
+categories: "Senior Mindset, Compensation, Salary"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/why-i-switched-to-making-products/index.mdx
+++ b/pages/blog/why-i-switched-to-making-products/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2016-06-03
 redirect_from:
   - /blog/switch-to-products/swizec/6812
-categories: "Business, Programming, Learning, Side Project, Slovenia"
+categories: "Business, Programming, Learning, Side Project, Slovenia, Travel + Events"
 ---
 
 Four weeks ago, I made $3,000 while stuffing my face with my grandma’s cake.

--- a/pages/blog/why-i-will-always-suck-at-programming-grega-stritar/index.mdx
+++ b/pages/blog/why-i-will-always-suck-at-programming-grega-stritar/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2012-07-19
 redirect_from:
   - /blog/why-i-will-always-suck-at-programming-grega-stritar/swizec/4873
-categories: "Facebook, JavaScript, Ljubljana"
+categories: "Facebook, JavaScript, Ljubljana, Travel + Events"
 ---
 
 I've been actively **coding for 15 years now**, ever since I've discovered the Interwebs. If you count in the lectures I took for [ZX Spectrum 48](http://en.wikipedia.org/wiki/ZX_Spectrum "ZX Spectrum - Wikipedia") during my elementary school, this range stretches to more than 20 years, but that was more fun than business. In this time, I've developed more than **50 different pieces of software**, mostly [business-oriented information systems](http://neolab.si/ "Neolab, software development"), majority of them successfully implemented. But I still **don't know shit about programming**, about different environments and technologies, methodologies and other technical fetishes. And I've accepted the fact this situation won't change any time soon, if ever.

--- a/pages/blog/why-null-checks-are-bad/index.mdx
+++ b/pages/blog/why-null-checks-are-bad/index.mdx
@@ -2,7 +2,7 @@
 title: "Why null checks are bad"
 description: "Every null or undefined check doubles the number of tests you need 😱"
 published: 2021-12-10
-categories: "TypeScript, JavaScript, Lesson, State machines, Software Architecture"
+categories: "TypeScript, JavaScript, Lesson, State machines, Software Architecture, Software Engineering"
 content_upgrade: ScalingFast
 ---
 

--- a/pages/blog/why-serverless-fits-side-projects-perfectly/index.mdx
+++ b/pages/blog/why-serverless-fits-side-projects-perfectly/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Why serverless fits side-projects perfectly"
 description: "How do you provision servers for no load most days THEN ALL THE LOAD THIS MINUTE? That's how side-projects work and it's hard"
-categories: "Serverless, Technical, Indie Hacking"
+categories: "Serverless, Technical, Indie Hacking, Backend"
 content_upgrade: ServerlessHandbook
 published: 2021-03-10
 ---

--- a/pages/blog/why-software-projects-fail/index.mdx
+++ b/pages/blog/why-software-projects-fail/index.mdx
@@ -2,7 +2,7 @@
 title: "Why software projects fail"
 description: "5 common themes"
 published: 2024-09-03
-categories: "Books, Mindset, Software Engineering, Software Architecture, Scaling Fast Book"
+categories: "Books, Senior Mindset, Software Engineering, Software Architecture, Scaling Fast Book"
 ---
 
 In [How Big Things Get Done](https://www.penguinrandomhouse.com/books/672118/how-big-things-get-done-by-bent-flyvbjerg-and-dan-gardner/) authors Flyvbjerg and Gardner talk about why large projects fail.

--- a/pages/blog/why-sprints/index.mdx
+++ b/pages/blog/why-sprints/index.mdx
@@ -2,7 +2,7 @@
 title: "Why sprints"
 description: "For the past few months I've been introducing sprints into a chaotic startup that's been growing so fast everyone's got whiplash. Since August, 5 engineers turned into 12. I think it's starting to work."
 published: 2025-03-25
-categories: "Teamwork, Productivity, Mindset, Scaling Fast Book, Leadership"
+categories: "Teamwork, Productivity, Senior Mindset, Scaling Fast Book, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/why-sql-is-forever-followup/index.mdx
+++ b/pages/blog/why-sql-is-forever-followup/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Why SQL is Forever followup"
 description: "Yes SQL is super flexible. That is its strenght and its weakness"
-categories: "Reader Question, Software Engineering, Database"
+categories: "Reader Question, Software Engineering, Database, Backend"
 published: 2024-08-01
 ---
 

--- a/pages/blog/why-sql-is-forever/index.mdx
+++ b/pages/blog/why-sql-is-forever/index.mdx
@@ -2,7 +2,7 @@
 title: "Why SQL is Forever"
 description: "Never underestimate the power of good marketing for bad products. NoSQL was fun but SQL is here to stay."
 published: 2024-07-31
-categories: "Software Engineering, Software Architecture, Database, Papers"
+categories: "Software Engineering, Software Architecture, Database, Papers, Backend"
 ---
 
 Never underestimate the power of good marketing for bad products. That's my favorite line from [What Goes Around Comes around ... And Around ...](https://swizec.com/pdfs/whatgoesaround-sigmodrec2024.pdf), a paper going into detail about why SQL and relational databases continue to be the best tool for transactional data even now.

--- a/pages/blog/why-system-design-is-my-favorite-interview/index.mdx
+++ b/pages/blog/why-system-design-is-my-favorite-interview/index.mdx
@@ -2,7 +2,7 @@
 title: "Why system design is my favorite interview"
 description: "Without reading their resume, you'll see if a candidate is fresh or has been doing this a while. And you'll know their blind spots and their strengths"
 published: 2024-12-18
-categories: "Career, Mindset, Interviewing"
+categories: "Career, Senior Mindset, Interviewing"
 ---
 
 System design is in my opinion the highest signal hour you can spend with a candidate. If you had to do just one interview to evaluate engineers, this would be it.

--- a/pages/blog/why-trunk-based-development-is-best/index.mdx
+++ b/pages/blog/why-trunk-based-development-is-best/index.mdx
@@ -3,7 +3,7 @@ title: "Why trunk-based development is best"
 description: "Merging finished work straight to main and deploying to production right away, scales to teams of thousands. This approach is counterintuitive to many engineers who may be used to working on their own"
 published: 2023-01-24
 content_upgrade: SeniorMindset
-categories: "Teamwork, Productivity, Mindset, Velocity, Leadership"
+categories: "Teamwork, Productivity, Mindset, Velocity, Leadership, Software Engineering"
 ---
 
 How do you avoid having too many cooks in the kitchen when a bunch of developers try to work together?

--- a/pages/blog/why-trunk-based-development-is-best/index.mdx
+++ b/pages/blog/why-trunk-based-development-is-best/index.mdx
@@ -3,7 +3,7 @@ title: "Why trunk-based development is best"
 description: "Merging finished work straight to main and deploying to production right away, scales to teams of thousands. This approach is counterintuitive to many engineers who may be used to working on their own"
 published: 2023-01-24
 content_upgrade: SeniorMindset
-categories: "Teamwork, Productivity, Mindset, Velocity, Leadership, Software Engineering"
+categories: "Teamwork, Productivity, Senior Mindset, Velocity, Leadership, Software Engineering"
 ---
 
 How do you avoid having too many cooks in the kitchen when a bunch of developers try to work together?

--- a/pages/blog/why-understanding-beats-knowledge/index.mdx
+++ b/pages/blog/why-understanding-beats-knowledge/index.mdx
@@ -2,7 +2,7 @@
 title: "Why Understanding beats Knowledge"
 description: "Understanding beats knowledge every day. To have a strong career, learn to understand, not just to know."
 published: 2020-08-28
-categories: "Opinion, Learning, Mindset"
+categories: "Opinion, Learning, Senior Mindset"
 ---
 
 In one of his best anecdotes, Richard Feynman shares a secret insight into understanding vs. knowledge.

--- a/pages/blog/why-you-need-a-regular-retro/index.mdx
+++ b/pages/blog/why-you-need-a-regular-retro/index.mdx
@@ -2,7 +2,7 @@
 title: "Why you need a regular retro"
 description: "Agile is something you are, not something you do."
 published: 2024-02-24
-categories: "Mindset, Agile, Teamwork, Reader Question, Scaling Fast Book, Leadership"
+categories: "Senior Mindset, Agile, Teamwork, Reader Question, Scaling Fast Book, Leadership"
 ---
 
 A good team just fixes things with no need for a meeting right? Nyes, sort of.

--- a/pages/blog/why-you-need-observability-more-than-tests/index.mdx
+++ b/pages/blog/why-you-need-observability-more-than-tests/index.mdx
@@ -2,7 +2,7 @@
 title: "Why you need observability more than tests"
 description: "Here's a short and sweet story about a Friday deploy. I love Friday deploys."
 published: 2024-11-16
-categories: "Software Engineering, Scaling Fast Book, Observability"
+categories: "Software Engineering, Scaling Fast Book, Observability, Backend"
 ---
 
 Here's a short and sweet story about a Friday deploy. I love Friday deploys.

--- a/pages/blog/why-you-shouldnt-use-ai-to-write-your-tests/index.mdx
+++ b/pages/blog/why-you-shouldnt-use-ai-to-write-your-tests/index.mdx
@@ -2,7 +2,7 @@
 title: "Why you shouldn't use AI to write your tests"
 description: "If you derive tests from your implementation, you can't apply the Beyonce rule. What if the code is wrong and that wasn't the programmer's intent? We'll never know. The bug now exists in both places."
 published: 2024-05-25
-categories: "AI, Testing"
+categories: "AI, Testing, Software Engineering"
 ---
 
 People are starting to use AI to write their tests. This is great! Also very bad.

--- a/pages/blog/with-90k-i-could-become-a-fulltime-author/index.mdx
+++ b/pages/blog/with-90k-i-could-become-a-fulltime-author/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2014-07-18
 redirect_from:
   - /blog/with-90k-i-could-become-a-full-time-author/swizec/6589
-categories: "Books, Data Visualization, Packt, San Francisco, Slovenia"
+categories: "Books, Data Visualization, Packt, San Francisco, Slovenia, Travel + Events"
 hero: ./img/images-17899.png
 ---
 

--- a/pages/blog/wow-api-gateway-v2-is-fast/index.mdx
+++ b/pages/blog/wow-api-gateway-v2-is-fast/index.mdx
@@ -2,7 +2,7 @@
 title: "Wow API Gateway v2 is fast"
 description: "A story of how my performance hunch was totally wrong and the answer that sped up an AWS Lambda 33%"
 published: 2022-01-17
-categories: "Serverless, AWS, GraphQL, DevOps"
+categories: "Serverless, AWS, GraphQL, DevOps, Backend"
 content_upgrade: Serverless
 ---
 

--- a/pages/blog/write-abstractions-not-just-code/index.mdx
+++ b/pages/blog/write-abstractions-not-just-code/index.mdx
@@ -2,7 +2,7 @@
 title: "Write abstractions, not just code"
 description: "Wherein I use a silly example to show why you need more than small reusable single purpose functions to write good software."
 published: 2022-07-08
-categories: "Mindset, Lesson, Architectural Complexity, Software Engineering"
+categories: "Senior Mindset, Lesson, Architectural Complexity, Software Engineering"
 ---
 
 Have you heard the idea that functions should be small, reusable, single purpose, and well tested?

--- a/pages/blog/write-abstractions-not-just-code/index.mdx
+++ b/pages/blog/write-abstractions-not-just-code/index.mdx
@@ -2,7 +2,7 @@
 title: "Write abstractions, not just code"
 description: "Wherein I use a silly example to show why you need more than small reusable single purpose functions to write good software."
 published: 2022-07-08
-categories: "Mindset, Lesson, Architectural Complexity"
+categories: "Mindset, Lesson, Architectural Complexity, Software Engineering"
 ---
 
 Have you heard the idea that functions should be small, reusable, single purpose, and well tested?

--- a/pages/blog/writing-software-is-like-kicking-a-can/index.mdx
+++ b/pages/blog/writing-software-is-like-kicking-a-can/index.mdx
@@ -2,7 +2,7 @@
 title: "Writing software is like kicking a can"
 description: "Writing software is a playful process of exploration and discovery. Like a game of kick the can on a Sunday walk."
 published: 2022-05-25
-categories: "Mindset, Software Engineering, Lesson, Scaling Fast Book"
+categories: "Senior Mindset, Software Engineering, Lesson, Scaling Fast Book"
 content_upgrade: ScalingFast
 hero: ./img/The-path-of-a-game-of-kick-the-canhcigbf.png
 ---

--- a/pages/blog/wtf-is-xframeoptions/index.mdx
+++ b/pages/blog/wtf-is-xframeoptions/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2016-10-13
 redirect_from:
   - /blog/x-frame-options/swizec/7115
-categories: "Programming, Testing, Technical"
+categories: "Programming, Testing, Technical, Software Engineering"
 ---
 
 Here’s a fun way to waste an afternoon:

--- a/pages/blog/yay-my-blog-is-up-and-running-again-d/index.mdx
+++ b/pages/blog/yay-my-blog-is-up-and-running-again-d/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2010-03-29
 redirect_from:
   - /blog/yay-my-blog-is-up-and-running-again-d/swizec/1266
-categories: "Personal, PHP, Server"
+categories: "Personal, PHP, Server, Backend"
 ---
 
 - [![Carlton Banks](https://swizec.com/wp-content/uploads/2010/03/2583922605_d074c280da_m.jpg "Carlton Banks")](http://www.flickr.com/photos/22641075@N03/2583922605)

--- a/pages/blog/yes-ai-will-take-your-job-no-you-wont-mind/index.mdx
+++ b/pages/blog/yes-ai-will-take-your-job-no-you-wont-mind/index.mdx
@@ -2,7 +2,7 @@
 title: 'Yes, AI will "take" your job. No, you won''t mind'
 description: "Is the job to get things done or to memorize trivia and solve cute coding puzzles?"
 published: 2024-10-17
-categories: "AI, Mindset, Career, Reader Question"
+categories: "AI, Senior Mindset, Career, Reader Question"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/yes-caviar-is-great-heres-a-ham-sandwich/index.mdx
+++ b/pages/blog/yes-caviar-is-great-heres-a-ham-sandwich/index.mdx
@@ -2,7 +2,7 @@
 title: '"Yes caviar is great, here''s a ham sandwich"'
 description: "Why do some projects ship and others seem to drag on forever? You need 3 people to get this right."
 published: 2024-10-22
-categories: "Mindset, Teamwork, Product development, Scaling Fast Book, Leadership"
+categories: "Senior Mindset, Teamwork, Product development, Scaling Fast Book, Leadership"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/you-dont-have-to-build-it-sloppy-to-go-fast/index.mdx
+++ b/pages/blog/you-dont-have-to-build-it-sloppy-to-go-fast/index.mdx
@@ -2,7 +2,7 @@
 title: "You don't *have to* build it sloppy to go fast"
 description: "My favorite mistake to make when I'm in a hurry is to think that I _have to_ build new features the sloppiest way possible. Find the quick fix and move on. But that's not true."
 published: 2022-07-19
-categories: "Refactoring, Mindset, Software Engineering"
+categories: "Refactoring, Senior Mindset, Software Engineering"
 ---
 
 My favorite mistake to make when I'm in a hurry is to think that I _have to_ build new features the sloppiest way possible. Find the quick fix and move on.

--- a/pages/blog/you-dont-need-a-big-team-to-automate-your-work/index.mdx
+++ b/pages/blog/you-dont-need-a-big-team-to-automate-your-work/index.mdx
@@ -2,7 +2,7 @@
 title: "You don't need a big team to automate your work"
 description: "The opposite of folks who follow every FAANG trend and over-engineer their companies to death, are the folks who *never* take advice from the big boys."
 published: 2021-07-27
-categories: "Technical, Learning, NodeJS"
+categories: "Technical, Learning, NodeJS, Backend"
 hero: ./img/hero.png
 ---
 

--- a/pages/blog/you-dont-need-tests/index.mdx
+++ b/pages/blog/you-dont-need-tests/index.mdx
@@ -4,7 +4,7 @@ description: ""
 published: 2016-10-06
 redirect_from:
   - /blog/dont-need-tests/swizec/7095
-categories: "Opinion, Personal, Testing"
+categories: "Opinion, Personal, Testing, Software Engineering"
 ---
 
 ![photo-1461632830798-3adb3034e4c8](https://swizec.com/wp-content/uploads/2016/10/photo-1461632830798-3adb3034e4c8-1024x684.jpeg)

--- a/pages/blog/you-re-a-business/index.mdx
+++ b/pages/blog/you-re-a-business/index.mdx
@@ -2,7 +2,7 @@
 title: "You're a business"
 description: "Quick thought from a conversation with friends"
 published: 2025-05-30
-categories: "Career, Mindset"
+categories: "Career, Senior Mindset"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/your-career-needs-a-vision/index.mdx
+++ b/pages/blog/your-career-needs-a-vision/index.mdx
@@ -2,7 +2,7 @@
 title: "Your career needs a vision"
 description: "In his book, The Art of Science and Engineering, Richard Hamming says the key to a great career is vision. What does that really look like?"
 published: 2021-07-14
-categories: "Opinion, Learning, Mindset, Books"
+categories: "Opinion, Learning, Senior Mindset, Books"
 content_upgrade: SeniorMindset
 hero: ./img/hero.png
 ---

--- a/pages/blog/your-code-doesnt-matter/index.mdx
+++ b/pages/blog/your-code-doesnt-matter/index.mdx
@@ -2,7 +2,7 @@
 title: "Your code doesn't matter"
 description: '"Your code doesn''t matter" is something experienced programmers say, between the lines, when they sound like complete lunatics. But what do they mean? Why does everyone say it?'
 published: 2022-08-16
-categories: "Programming Lessons, Code, Philosophy, Technical"
+categories: "Programming Lessons, Code, Philosophy, Technical, Software Engineering"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/your-interview-is-a-sales-call/index.mdx
+++ b/pages/blog/your-interview-is-a-sales-call/index.mdx
@@ -3,7 +3,7 @@ title: "Your interview is a sales call"
 description: "I've been doing hiring manager screens lately. Here's a few tips."
 published: 2025-05-03
 content_upgrade: SeniorMindset
-categories: "Interviewing, Mindset"
+categories: "Interviewing, Senior Mindset"
 ---
 
 I've been doing hiring manager screens lately. Here's a few tips.

--- a/pages/blog/your-job-as-an-engineer-is-to-make-yourself-unnecessary/index.mdx
+++ b/pages/blog/your-job-as-an-engineer-is-to-make-yourself-unnecessary/index.mdx
@@ -2,7 +2,7 @@
 title: "Your job as an engineer is to make yourself unnecessary"
 description: ""
 published: 2021-11-09
-categories: "Mindset, Opinion, Podcast"
+categories: "Senior Mindset, Opinion, Podcast"
 content_upgrade: SeniorMindset
 hero: ./img/iG7qoL0.png
 ---

--- a/pages/blog/your-luck-and-opportunity-surface-area/index.mdx
+++ b/pages/blog/your-luck-and-opportunity-surface-area/index.mdx
@@ -2,7 +2,7 @@
 title: "Your luck & opportunity surface area"
 description: "Here's a comment that resonated yesterday and you might like. It's about how to maximize the opportunity in your work."
 published: 2021-03-26
-categories: "Lesson, Mindset, Senior Mindset"
+categories: "Lesson, Senior Mindset"
 content_upgrade: SeniorMindset
 hero: ./img/Luck-surface-areab637ca.png
 ---

--- a/pages/blog/your-next-mountain-pt2/index.mdx
+++ b/pages/blog/your-next-mountain-pt2/index.mdx
@@ -2,7 +2,7 @@
 title: "Your next mountain, pt2"
 description: "3+1 quick book recommendations to help you think about next year"
 published: 2024-12-24
-categories: "Productivity, Books, Mindset"
+categories: "Productivity, Books, Senior Mindset"
 content_upgrade: SeniorMindset
 hero: ./img/IMG_2445.png
 ---

--- a/pages/blog/your-resume-has-a-job/index.mdx
+++ b/pages/blog/your-resume-has-a-job/index.mdx
@@ -2,7 +2,7 @@
 title: "Your resumé has a job"
 description: "Is your resume a tech bingo card? Not great."
 published: 2024-02-21
-categories: "Mindset, Career"
+categories: "Senior Mindset, Career"
 content_upgrade: SeniorMindset
 ---
 

--- a/pages/blog/your-serverless-questions-answered/index.mdx
+++ b/pages/blog/your-serverless-questions-answered/index.mdx
@@ -2,7 +2,7 @@
 title: "Your serverless questions, answered"
 description: "When talk comes to serverless, engineers have lots of questions. Here are some answers 😊"
 published: 2021-03-29
-categories: "Serverless, Technical"
+categories: "Serverless, Technical, Backend"
 content_upgrade: ServerlessHandbook
 ---
 

--- a/pages/blog/youre-not-asking-for-a-job-youre-selling-a-service/index.mdx
+++ b/pages/blog/youre-not-asking-for-a-job-youre-selling-a-service/index.mdx
@@ -2,7 +2,7 @@
 title: "You're not asking for a job, you're selling a service"
 description: 'You''re not asking for a job, you''re selling a service. The true question behind every interview is "How can you help us?"'
 content_upgrade: SeniorMindset
-categories: "Interviewing, Mindset, Career"
+categories: "Interviewing, Senior Mindset, Career"
 published: 2020-11-20
 ---
 

--- a/vercel.json
+++ b/vercel.json
@@ -211,6 +211,11 @@
       "permanent": true
     },
     {
+      "source": "/categories/mindset",
+      "destination": "/categories/senior-mindset",
+      "permanent": true
+    },
+    {
       "source": "/categories/neural-networks",
       "destination": "/categories/neural-network",
       "permanent": true


### PR DESCRIPTION
Stacked on #158. Finishes the parent-category work from the IA analysis:

- **Backend** becomes the server-side parent, mirroring how Frontend already works: co-tagged onto every post carrying Serverless, Database, API, AWS, DevOps, Django, Rails, NodeJS, PHP, GraphQL, Heroku, Firebase, Observability, REST, or Server. **29 → 104 posts.** Cross-cutting practice tags (Testing, Git, Tools, Software Architecture) deliberately excluded.
- **Travel + Events** co-tagged onto the city/country/event posts that lacked it (Ljubljana, Slovenia, San Francisco, London, Silicon Valley, Croatia, Events…). **82 → 131 posts.**

124 posts changed, no tags removed — purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)