### PR TITLE
Fix unstyled code blocks for fences without a language

### DIFF
--- a/timber.config.ts
+++ b/timber.config.ts
@@ -33,7 +33,18 @@ export default {
     rehypePlugins: [
       rehypeSlug,
       [rehypeAutolinkHeadings, { behavior: 'wrap', test: (el) => !containsLink(el) }],
-      [rehypeShiki, { themes: { light: 'github-light', dark: 'github-dark' }, inline: 'tailing-curly-colon' }],
+      [
+        rehypeShiki,
+        {
+          themes: { light: 'github-light', dark: 'github-dark' },
+          inline: 'tailing-curly-colon',
+          // Fences with no language (and unknown languages) still get the
+          // pre.shiki treatment — styles.css only styles pre.shiki, so
+          // unhighlighted blocks would otherwise render as bare <pre>.
+          defaultLanguage: 'text',
+          fallbackLanguage: 'text',
+        },
+      ],
     ],
   },
   pageExtensions: ['tsx', 'ts', 'jsx', 'js', 'mdx'],


### PR DESCRIPTION
## Problem

Code fences without a declared language (like the prompt blocks in the big-bang-migrations article) rendered as bare unstyled `<pre><code>` — no dark background, no titlebar chrome, no shadow.

Root cause: `@shikijs/rehype` skips fences with no language, and `styles.css` only styles `pre.shiki`.

## Fix

Two options added to the Shiki plugin config in `timber.config.ts`:

- `defaultLanguage: 'text'` — language-less fences now go through Shiki as plain text, so they get the same `pre.shiki` markup and styling as every other block, just without token colors
- `fallbackLanguage: 'text'` — a fence with an unrecognized language degrades to plain text instead of failing the build

## Verified

Checked on the dev server against the latest article: all code blocks (including the previously-broken language-less ones) now render with the dark github theme background, mac titlebar, and hard shadow. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)