### PR TITLE
Archive pages: title, description, and og-image reflect the date filter

### DIFF
--- a/app/[...slug]/opengraph-image.tsx
+++ b/app/[...slug]/opengraph-image.tsx
@@ -1,6 +1,8 @@
 import { ImageResponse } from 'takumi-js/response';
 import { allPages } from 'content-collections';
 import { getSegmentParams } from '@timber-js/app/server';
+import { archiveParams } from '../../lib/archive-params';
+import { archiveTimeLabel } from '../../lib/archive-metadata';
 import { OgCard } from '../../components/og-card';
 import { ogImageOptions } from '../../components/og-image';
 
@@ -21,8 +23,18 @@ export default async function OGImage() {
         return new Response(null, { status: 404 });
     }
 
+    // Listing pages carry the active ?year/?month filter in the card title so
+    // shared archive links unfurl distinctly. Regular pages ignore the params.
+    const { year, month } = archiveParams.get();
+    const label = page.archive ? archiveTimeLabel(year, month) : undefined;
+    const title = label ? `${page.title} — ${label}` : page.title;
+
     return new ImageResponse(
-        <OgCard title={page.title} description={page.description} seed={page._meta.path} />,
+        <OgCard
+            title={title}
+            description={page.description}
+            seed={label ? `${page._meta.path}/${label}` : page._meta.path}
+        />,
         ogImageOptions,
     );
 }

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -23,6 +23,7 @@ import { SmartLink } from "../../components/link"
 import { SparkJoy } from "../../components/sparkjoy"
 import { OldPostNote } from "../../components/old-post-note"
 import { parseArchiveFrontmatter } from "../../lib/article-archive"
+import { withArchiveTime } from "../../lib/archive-metadata"
 
 // Vite glob: all MDX in pages/, compiled as ES modules via @mdx-js/rollup (RSC-compatible)
 const mdxModules = import.meta.glob("/pages/**/*.{mdx,md}")
@@ -54,7 +55,9 @@ export async function metadata(): Promise<Metadata> {
   const path = resolvedPath()
   const page = findPage(path)
   if (!page) return {}
-  return metadataFromFrontmatter(page, `/${path}`)
+  const meta = metadataFromFrontmatter(page, `/${path}`)
+  // Listing pages: title/og-image reflect the active ?year/?month filter.
+  return page.archive ? withArchiveTime(meta) : meta
 }
 
 export default async function Page() {

--- a/app/blog/opengraph-image.tsx
+++ b/app/blog/opengraph-image.tsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from 'takumi-js/response';
+import { archiveParams } from '../../lib/archive-params';
+import { archiveTimeLabel } from '../../lib/archive-metadata';
+import { filterByTime, queryArchive } from '../../lib/article-archive';
+import { OgCard } from '../../components/og-card';
+import { ogImageOptions } from '../../components/og-image';
+
+// The /blog listing card, date-aware: ?year/?month render the filtered
+// period's title and article count so shared archive links unfurl distinctly.
+export default async function OGImage() {
+    const { year, month } = archiveParams.get();
+    const label = archiveTimeLabel(year, month);
+
+    let title = 'Latest articles';
+    let description =
+        'Software engineering lessons from production — almost 20 years of articles.';
+    if (label) {
+        title = `Articles from ${label}`;
+        const count = filterByTime(await queryArchive({}), year, month).length;
+        description = `${count} article${count === 1 ? '' : 's'} · Software engineering lessons from production.`;
+    }
+
+    return new ImageResponse(
+        <OgCard title={title} description={description} seed={`blog/${label ?? 'all'}`} />,
+        ogImageOptions,
+    );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,13 +1,46 @@
 import type { Metadata } from '@timber-js/app/server';
+import { archiveParams } from '../../lib/archive-params';
+import { archiveOgQuery, archiveTimeLabel } from '../../lib/archive-metadata';
+import { SITE_URL } from '../../lib/structured-data';
+import { requestOrigin } from '../mdx-metadata';
 import { ArticleArchive } from '../../components/article-archive';
 import { ArchiveSidebar } from '../../components/archive-sidebar';
 import { SmartLink } from '../../components/link';
 
-export const metadata: Metadata = {
-    title: 'Latest articles',
-    description:
-        'Software engineering lessons from production — almost 20 years of articles by Swizec Teller',
-};
+// Title, description, and og-image all reflect the active ?year/?month filter
+// (and deep page number) — a link to the 2019 archive shouldn't unfurl the
+// same as a link to 2026, and crawlers shouldn't see hundreds of identical
+// titles.
+export function metadata(): Metadata {
+    const { year, month: rawMonth, page } = archiveParams.get();
+    // A month without a year doesn't filter anything — keep it out of the
+    // title and canonical.
+    const month = year ? rawMonth : undefined;
+    const label = archiveTimeLabel(year, month);
+    const baseTitle = label ? `Articles from ${label}` : 'Latest articles';
+    const title = page > 1 ? `${baseTitle} · page ${page}` : baseTitle;
+    const description = label
+        ? `Software engineering lessons from production — articles from ${label} by Swizec Teller`
+        : 'Software engineering lessons from production — almost 20 years of articles by Swizec Teller';
+    const ogImage = `${requestOrigin()}/blog/opengraph-image.png${archiveOgQuery(year, month)}`;
+    const query = archiveParams.serialize({ year, month, page });
+
+    return {
+        title,
+        description,
+        alternates: { canonical: `${SITE_URL}/blog${query ? `?${query}` : ''}` },
+        openGraph: {
+            title,
+            description,
+            images: { url: ogImage, alt: title },
+        },
+        twitter: {
+            card: 'summary_large_image',
+            site: '@swizec',
+            images: { url: ogImage, alt: title },
+        },
+    };
+}
 
 export default function BlogIndex() {
     return (

--- a/app/categories/[categorySlug]/opengraph-image.tsx
+++ b/app/categories/[categorySlug]/opengraph-image.tsx
@@ -1,6 +1,9 @@
 import { ImageResponse } from 'takumi-js/response';
 import { getSegmentParams } from '@timber-js/app/server';
 import { getCategory } from '../../../lib/categories';
+import { archiveParams } from '../../../lib/archive-params';
+import { archiveTimeLabel } from '../../../lib/archive-metadata';
+import { filterByTime } from '../../../lib/article-archive';
 import { CATEGORY_INTROS } from '../../../components/category-intros';
 import { OgCard } from '../../../components/og-card';
 import { ogImageOptions } from '../../../components/og-image';
@@ -18,12 +21,27 @@ export default async function OGImage() {
         return new Response(null, { status: 404 });
     }
 
-    const description =
+    // ?year/?month render the filtered period's title and count so shared
+    // archive links unfurl distinctly.
+    const { year, month } = archiveParams.get();
+    const label = archiveTimeLabel(year, month);
+
+    let title = category.name;
+    let description =
         CATEGORY_INTROS[slug]?.blurb ??
         `${category.articles.length} articles about ${category.name} by Swizec Teller`;
+    if (label) {
+        title = `${category.name} — ${label}`;
+        const count = filterByTime(category.articles, year, month).length;
+        description = `${count} article${count === 1 ? '' : 's'} about ${category.name} from ${label} by Swizec Teller`;
+    }
 
     return new ImageResponse(
-        <OgCard title={category.name} description={description} seed={`categories/${slug}`} />,
+        <OgCard
+            title={title}
+            description={description}
+            seed={label ? `categories/${slug}/${label}` : `categories/${slug}`}
+        />,
         ogImageOptions,
     );
 }

--- a/app/categories/[categorySlug]/page.tsx
+++ b/app/categories/[categorySlug]/page.tsx
@@ -1,6 +1,8 @@
 import { deny, getSegmentParams } from '@timber-js/app/server';
 import type { Metadata } from '@timber-js/app/server';
 import { getCategory } from '../../../lib/categories';
+import { archiveParams } from '../../../lib/archive-params';
+import { archiveOgQuery, archiveTimeLabel } from '../../../lib/archive-metadata';
 import { requestOrigin } from '../../mdx-metadata';
 import { ArticleArchive } from '../../../components/article-archive';
 import { ArchiveSidebar } from '../../../components/archive-sidebar';
@@ -19,12 +21,24 @@ export async function metadata(): Promise<Metadata> {
     const slug = resolvedSlug();
     const category = await getCategory(slug);
     if (!category) return {};
-    const title = category.name;
-    const description = `Articles about ${category.name} by Swizec Teller`;
-    const ogImage = `${requestOrigin()}/categories/${slug}/opengraph-image.png`;
+    // Title, description, and og-image reflect the active ?year/?month filter
+    // (and deep page number) so filtered views don't all share one title.
+    const { year, month: rawMonth, page } = archiveParams.get();
+    // A month without a year doesn't filter anything — keep it out of the
+    // title and canonical.
+    const month = year ? rawMonth : undefined;
+    const label = archiveTimeLabel(year, month);
+    const baseTitle = label ? `${category.name} — ${label}` : category.name;
+    const title = page > 1 ? `${baseTitle} · page ${page}` : baseTitle;
+    const description = label
+        ? `Articles about ${category.name} from ${label} by Swizec Teller`
+        : `Articles about ${category.name} by Swizec Teller`;
+    const ogImage = `${requestOrigin()}/categories/${slug}/opengraph-image.png${archiveOgQuery(year, month)}`;
+    const query = archiveParams.serialize({ year, month, page });
     return {
         title,
         description,
+        alternates: { canonical: `${SITE_URL}/categories/${slug}${query ? `?${query}` : ''}` },
         openGraph: {
             title,
             description,

--- a/lib/archive-metadata.ts
+++ b/lib/archive-metadata.ts
@@ -1,0 +1,70 @@
+import type { Metadata } from '@timber-js/app/server';
+import { archiveParams } from './archive-params';
+import { MONTH_NAMES } from './article-archive';
+
+// "May 2025", "2025", or undefined when the view isn't time-filtered.
+export function archiveTimeLabel(year?: number, month?: number): string | undefined {
+    if (!year) return undefined;
+    return month ? `${MONTH_NAMES[month - 1]} ${year}` : String(year);
+}
+
+// Query string ("?year=2025&month=5") that carries the active time filter to a
+// generated og-image route, so the card can render the date. Empty when
+// unfiltered.
+export function archiveOgQuery(year?: number, month?: number): string {
+    if (!year) return '';
+    return `?${archiveParams.serialize({ year, month })}`;
+}
+
+function suffixImages<
+    T extends Metadata['openGraph'] | Metadata['twitter'],
+>(section: T, ogQuery: string, title: string): T {
+    if (!section) return section;
+    const images = (section as { images?: unknown }).images;
+    if (!images || typeof images !== 'object' || Array.isArray(images)) return section;
+    const image = images as { url: string; alt?: string };
+    if (!image.url.endsWith('/opengraph-image.png')) return section;
+    return {
+        ...section,
+        title,
+        images: { ...image, url: `${image.url}${ogQuery}`, alt: title },
+    };
+}
+
+// Suffix a listing page's metadata with the active ?year/?month filter and deep
+// page number, so filtered and paginated views don't all share one title and
+// unfurl card — distinct for crawlers, oriented-in-time for humans. Also points
+// the generated og-image at the same filter and makes the canonical
+// self-referential. No-op on the unfiltered first page.
+export function withArchiveTime(meta: Metadata): Metadata {
+    const { year, month: rawMonth, page } = archiveParams.get();
+    // A month without a year doesn't filter anything — don't let it leak into
+    // titles or canonicals.
+    const month = year ? rawMonth : undefined;
+    const label = archiveTimeLabel(year, month);
+    if (!label && page === 1) return meta;
+    if (typeof meta.title !== 'string') return meta;
+
+    const suffix = [label, page > 1 ? `page ${page}` : undefined].filter(Boolean).join(' · ');
+    const title = `${meta.title} — ${suffix}`;
+    const description =
+        label && meta.description
+            ? `${meta.description} Showing articles from ${label}.`
+            : meta.description;
+    const ogQuery = archiveOgQuery(year, month);
+    const canonical = (meta.alternates as { canonical?: string } | undefined)?.canonical;
+
+    return {
+        ...meta,
+        title,
+        description,
+        ...(canonical && {
+            alternates: {
+                ...meta.alternates,
+                canonical: `${canonical}?${archiveParams.serialize({ year, month, page })}`,
+            },
+        }),
+        openGraph: suffixImages(meta.openGraph, ogQuery, title),
+        twitter: suffixImages(meta.twitter, ogQuery, title),
+    };
+}


### PR DESCRIPTION
## Problem

Every filtered archive view — `/blog?year=2025&month=5`, `/categories/react?year=2018`, paginated pages — shared one title, description, and unfurl card. Linking someone to the 2025 archive looked identical to linking the 2026 one, and Google saw hundreds of pages with the same title.

## Changes

- **New `lib/archive-metadata.ts`** — `archiveTimeLabel()` ("May 2025" / "2025"), `archiveOgQuery()` (carries the filter to og-image URLs), and `withArchiveTime()` (decorates any listing page's metadata; the MDX catch-all uses it so collections and interviews get this for free).
- **`/blog`** — date-aware `metadata()` plus its own og-image route (it previously had **no og:image at all**). The card renders the period and its real article count.
- **Category pages** — same treatment; the og card shows "N articles about X from \<period\>".
- **MDX listing pages** — titles get "— \<period\>" suffixed via `withArchiveTime()`, og-images carry the filter.
- **Canonicals** — filtered and paginated views are self-referential (`…/blog?year=2025&month=5`) so crawlers index them as distinct pages. Deep pages get "· page N" in the title.
- **Edge case** — `?month=5` without `?year` filters nothing, so it stays out of titles and canonicals.

## Example unfurls

| URL | Title |
|---|---|
| `/blog?year=2025&month=5` | Articles from May 2025 |
| `/blog?page=3` | Latest articles · page 3 |
| `/categories/react?year=2018` | React — 2018 |
| `/career-growth?year=2023` | Grow your engineering career — 2023 |

## Verified

On the dev server: head tags for filtered/unfiltered/paginated views on all three page types, plus visual inspection of rendered OG PNGs. Card counts match the page listing (React 2019 genuinely has 0 articles — the sidebar skips 2019 too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)