### PR TITLE
Fix index-articles re-checking every article on every run

### DIFF
--- a/bin/index-articles.ts
+++ b/bin/index-articles.ts
@@ -32,11 +32,47 @@ function findIndexMDXFiles(dir: string, fileList: string[] = []): string[] {
   return fileList
 }
 
+// NULL published_date rows sort first on DESC and would poison the cutoff
+// (new Date(null) is 1970, so nothing gets skipped)
 async function getLastIndexedDate() {
   const { rows } =
-    await sql`select published_date from article_embeddings order by published_date desc limit 1`
+    await sql`select published_date from article_embeddings where published_date is not null order by published_date desc limit 1`
 
   return new Date(rows[0].published_date)
+}
+
+async function getIndexedUrls() {
+  const { rows } = await sql`select url from article_embeddings`
+
+  return new Set(rows.map((row) => row.url))
+}
+
+// articles over ada-002's 8192-token limit get embedded from their head
+// instead of failing — a swallowed error here means the article is never
+// indexed once its date falls behind the cutoff
+async function embed(content: string) {
+  let input = content
+
+  for (;;) {
+    try {
+      const res = await openai.embeddings.create({
+        input,
+        model: "text-embedding-ada-002",
+      })
+
+      return res.data[0].embedding
+    } catch (e) {
+      const tooLong =
+        e instanceof OpenAI.BadRequestError &&
+        /maximum context length/.test(e.message)
+
+      if (tooLong && input.length > 1000) {
+        input = input.slice(0, Math.floor(input.length * 0.8))
+      } else {
+        throw e
+      }
+    }
+  }
 }
 
 /**
@@ -45,36 +81,42 @@ async function getLastIndexedDate() {
  *
  * @param path path to article
  * @param lastIndexed date of latest indexed article
+ * @param indexedUrls urls already in the table
  */
-async function indexArticle(path: string, lastIndexed: Date) {
-  console.log(`Processing ${path}`)
-
+async function indexArticle(
+  path: string,
+  lastIndexed: Date,
+  indexedUrls: Set<string>
+) {
   const file = Bun.file(path)
   const { data: frontmatter, content } = matter(await file.text())
   const url = "/" + path.split("/pages/")[1].replace("index.mdx", "")
 
-  if (new Date(frontmatter.published) < lastIndexed) {
+  const published = new Date(frontmatter.published)
+
+  // a draft without a valid published date must not be inserted — a NULL
+  // published_date row breaks getLastIndexedDate on every future run
+  if (isNaN(published.getTime())) {
+    console.warn(`Skipping ${url} — no valid published date in frontmatter`)
     return
   }
 
-  const { rowCount } =
-    await sql`SELECT url FROM article_embeddings WHERE url=${url} LIMIT 1`
-
-  if (rowCount > 0) {
+  if (published < lastIndexed) {
     return
   }
+
+  if (indexedUrls.has(url)) {
+    return
+  }
+
+  console.log(`Indexing ${url}`)
 
   try {
-    const res = await openai.embeddings.create({
-      input: content,
-      model: "text-embedding-ada-002",
-    })
-
-    const embedding = res.data[0].embedding
+    const embedding = await embed(content)
     await sql`INSERT INTO article_embeddings VALUES (
-            ${url}, 
-            ${frontmatter.title}, 
-            ${frontmatter.published}, 
+            ${url},
+            ${frontmatter.title},
+            ${frontmatter.published},
             ${JSON.stringify(embedding)}
         )`
   } catch (e) {
@@ -87,7 +129,8 @@ async function indexArticle(path: string, lastIndexed: Date) {
 const articles = findIndexMDXFiles(`${import.meta.dir}/../pages/blog`)
 
 const lastIndexed = await getLastIndexedDate()
+const indexedUrls = await getIndexedUrls()
 
 for (const article of articles) {
-  await indexArticle(article, lastIndexed)
+  await indexArticle(article, lastIndexed, indexedUrls)
 }


### PR DESCRIPTION
## What changed

`pnpm article`'s index-articles step was taking minutes because it made a Postgres round-trip for every one of the ~1970 articles on every run, instead of only touching new ones.

Root cause: one row in `article_embeddings` had a NULL `published_date` (indexed while that article was still a draft). Postgres sorts NULLs first on `ORDER BY ... DESC`, so `getLastIndexedDate()` returned `new Date(null)` = Jan 1 1970 — nothing was ever skipped by the date cutoff, and every article fell through to a sequential per-URL existence query.

Changes in `bin/index-articles.ts`:

- `getLastIndexedDate()` ignores NULL `published_date` rows
- drafts without a valid `published` date are skipped with a warning instead of being inserted with NULLs (prevents the poison from recurring)
- indexed URLs are fetched once into a `Set` instead of one query per article, so even a degraded cutoff costs one round-trip, not ~2000
- articles over ada-002's 8192-token limit are truncated and retried instead of the error being swallowed (one 2019 article had been silently missing from the index for this reason)
- logs only when actually indexing, instead of a "Processing" line per article

## Reviewer notes

- The poisoned DB row and the missing 2019 article were repaired directly in Postgres alongside this PR (backfilled `title`/`published_date`; embedded the long article from its first ~18k chars). The code changes are the recurrence prevention.
- Verified: full run now completes in ~2.7s with a complete index (1971/1971 articles), vs minutes before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)