### PR TITLE
Fix newsletter form fields overflowing on Mobile Safari

### DIFF
--- a/app/styles.css
+++ b/app/styles.css
@@ -681,6 +681,11 @@ a.button:hover {
   gap: 0.75rem;
 }
 
+/* min-width: 0 is load bearing. Flex items default to min-width: auto, and
+   WebKit's min-content width for a text input comes from the `size` attribute
+   (20 characters), so on Mobile Safari the fields refuse to shrink below ~20ch
+   and burst out of the pink box. Chromium shrinks them, which is why this only
+   showed up on iOS. max-width keeps the box-sizing honest at any text scale. */
 .newsletter-signup input[type='text'],
 .newsletter-signup input[type='email'] {
   background: var(--color-background-card);
@@ -689,6 +694,8 @@ a.button:hover {
   flex: 1 1 180px;
   font-family: var(--font-family-body);
   font-size: 1rem;
+  max-width: 100%;
+  min-width: 0;
   padding: 0.6rem 0.8rem;
 }
 
@@ -701,6 +708,7 @@ a.button:hover {
   font-family: var(--font-family-body);
   font-size: 1rem;
   font-weight: 600;
+  max-width: 100%;
   padding: 0.6rem 1.2rem;
   transition: translate 0.1s ease, box-shadow 0.1s ease;
 }


### PR DESCRIPTION
On Mobile Safari the newsletter signup's input fields burst out of the pink box and drag horizontal scroll onto the page.

## Cause

The fields are flex items, and flex items default to `min-width: auto`. WebKit derives a text input's min-content width from the `size` attribute (default 20 characters), so that becomes a hard floor the fields refuse to shrink below. It scales with font size. Chromium has no such floor, which is why desktop testing never caught it.

## Fix

`min-width: 0` on the two inputs removes the floor. `max-width: 100%` on the inputs and button guards the boxes at any text scale.

## Verification

Measured in the iOS Simulator (Safari 17.4) with a probe replicating the newsletter box's exact metrics:

| case | input width | box inner width | overflows? |
|---|---|---|---|
| 320pt phone layout, `min-width: auto` | 225px | 204px | **yes** |
| same, `min-width: 0` | 204px | 204px | no |
| 375pt layout at 24px text, `min-width: auto` | 324px | 259px | **yes** |
| same, `min-width: 0` | 259px | 259px | no |

WebKit's min-content width for a bare text input measured 221px at 16px text. The large-text case reproduces the reported screenshot exactly.

Also re-checked in Chromium at 375px and with root font-size forced to 32px: computed `min-width` is `0px`, fields sit inside the box's padding, and `documentElement.scrollWidth === innerWidth`.

## Noted separately, not addressed here

On iOS 17.4 and older the whole site renders with no theme colors — layout intact, colors gone. `@astryxdesign/theme-y2k` defines every token with `light-dark()`, which shipped in Safari 17.5, so every `var(--color-*)` is invalid there. Would need a fallback layer in the theme package or a local override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
